### PR TITLE
chore: sync badge order with goFF/go-spocp

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,15 +2,13 @@
 
 <div align="center">
 
+[![CI](https://github.com/sirosfoundation/go-trust/actions/workflows/go.yml/badge.svg)](https://github.com/sirosfoundation/go-trust/actions/workflows/go.yml)
 [![Go Reference](https://pkg.go.dev/badge/github.com/sirosfoundation/go-trust.svg)](https://pkg.go.dev/github.com/sirosfoundation/go-trust)
 [![Go Report Card](https://goreportcard.com/badge/github.com/sirosfoundation/go-trust)](https://goreportcard.com/report/github.com/sirosfoundation/go-trust)
 [![Coverage](https://raw.githubusercontent.com/sirosfoundation/go-trust/badges/.badges/main/coverage.svg)](https://github.com/sirosfoundation/go-trust/actions/workflows/go.yml)
-[![Build Status](https://img.shields.io/github/actions/workflow/status/sirosfoundation/go-trust/go.yml?branch=main)](https://github.com/sirosfoundation/go-trust/actions)
-[![License](https://img.shields.io/badge/License-BSD_2--Clause-orange.svg)](https://opensource.org/licenses/BSD-2-Clause)
-[![Latest Release](https://img.shields.io/github/v/release/sirosfoundation/go-trust?include_prereleases)](https://github.com/sirosfoundation/go-trust/releases)
 [![Go Version](https://img.shields.io/github/go-mod/go-version/sirosfoundation/go-trust)](https://go.dev/)
 [![Issues](https://img.shields.io/github/issues/sirosfoundation/go-trust)](https://github.com/sirosfoundation/go-trust/issues)
-[![CodeQL](https://github.com/sirosfoundation/go-trust/actions/workflows/codeql.yml/badge.svg)](https://github.com/sirosfoundation/go-trust/actions/workflows/codeql.yml)
+[![License](https://img.shields.io/badge/License-BSD_2--Clause-orange.svg)](LICENSE)
 
 </div>
 


### PR DESCRIPTION
Sync README badges with goFF and go-spocp for consistency across sirosfoundation projects.

## Changes

- Add CI badge at start for consistency
- Remove Latest Release badge (no releases yet)
- Remove redundant Build Status badge (CI badge covers this)  
- Remove CodeQL badge (less important)
- Standardize badge order: CI, Go Reference, Go Report Card, Coverage, Go Version, Issues, License
- Fix License link to point to LICENSE file

## Badge Order (consistent with goFF/go-spocp)

```
CI → Go Reference → Go Report Card → Coverage → Go Version → Issues → License
```