### PR TITLE
feat(etsi): add background refresh loop to TSL registry

### DIFF
--- a/pkg/api/health.go
+++ b/pkg/api/health.go
@@ -100,13 +100,17 @@ func ReadinessHandler(serverCtx *ServerContext) gin.HandlerFunc {
 					healthyCount++
 				}
 				if verbose {
-					registryInfos = append(registryInfos, map[string]interface{}{
+					entry := map[string]interface{}{
 						"name":            info.Name,
 						"type":            info.Type,
 						"resource_types":  info.ResourceTypes,
 						"resolution_only": info.ResolutionOnly,
 						"healthy":         info.Healthy,
-					})
+					}
+					if info.LastUpdated != nil {
+						entry["last_updated"] = info.LastUpdated
+					}
+					registryInfos = append(registryInfos, entry)
 				}
 			}
 		}

--- a/pkg/registry/etsi/registry.go
+++ b/pkg/registry/etsi/registry.go
@@ -974,6 +974,7 @@ func (r *TSLRegistry) Info() registry.RegistryInfo {
 		Description:  r.config.Description,
 		Version:      "1.0.0",
 		TrustAnchors: trustAnchors,
+		LastUpdated:  &r.loadedAt,
 	}
 }
 

--- a/pkg/registry/etsi/registry.go
+++ b/pkg/registry/etsi/registry.go
@@ -164,10 +164,10 @@ func NewTSLRegistry(cfg TSLConfig) (*TSLRegistry, error) {
 }
 
 // load reads trust data from configured sources.
+// I/O and parsing are performed without holding the lock; the lock is only
+// held briefly to swap in the new state, so Evaluate/Info/Healthy are not
+// blocked during network or file fetches.
 func (r *TSLRegistry) load() error {
-	r.mu.Lock()
-	defer r.mu.Unlock()
-
 	var pool *x509.CertPool
 	var certCount int
 	var tsls []*etsi119612.TSL
@@ -178,9 +178,9 @@ func (r *TSLRegistry) load() error {
 	if r.config.LOTLSignerBundle != "" {
 		signers, err := r.loadLOTLSignerBundle(r.config.LOTLSignerBundle)
 		if err != nil {
-			r.lastError = fmt.Errorf("failed to load LOTL signer bundle: %w", err)
-			r.healthy = false
-			return r.lastError
+			err = fmt.Errorf("failed to load LOTL signer bundle: %w", err)
+			r.setError(err)
+			return err
 		}
 		lotlSigners = signers
 	}
@@ -189,8 +189,7 @@ func (r *TSLRegistry) load() error {
 	if r.config.CertBundle != "" {
 		p, count, err := r.loadCertBundle(r.config.CertBundle)
 		if err != nil {
-			r.lastError = err
-			r.healthy = false
+			r.setError(err)
 			return err
 		}
 		pool = p
@@ -203,22 +202,20 @@ func (r *TSLRegistry) load() error {
 	for _, tslPath := range r.config.TSLFiles {
 		// Reject network URLs in TSLFiles
 		if strings.HasPrefix(tslPath, "http://") || strings.HasPrefix(tslPath, "https://") {
-			r.lastError = fmt.Errorf("network URLs not allowed in TSLFiles: %s", tslPath)
-			r.healthy = false
-			return r.lastError
+			err := fmt.Errorf("network URLs not allowed in TSLFiles: %s", tslPath)
+			r.setError(err)
+			return err
 		}
 
 		tsl, certs, err := r.loadLocalTSL(tslPath)
 		if err != nil {
-			r.lastError = err
-			r.healthy = false
+			r.setError(err)
 			return err
 		}
 
 		// Verify TSL signature if LOTL signers are configured
 		if err := r.verifyTSLSignature(tsl, lotlSigners); err != nil {
-			r.lastError = err
-			r.healthy = false
+			r.setError(err)
 			return err
 		}
 
@@ -240,24 +237,22 @@ func (r *TSLRegistry) load() error {
 		// Check if network access is allowed
 		if !r.config.AllowNetworkAccess {
 			if strings.HasPrefix(tslURL, "http://") || strings.HasPrefix(tslURL, "https://") {
-				r.lastError = fmt.Errorf("network URL not allowed (AllowNetworkAccess=false): %s", tslURL)
-				r.healthy = false
-				return r.lastError
+				err := fmt.Errorf("network URL not allowed (AllowNetworkAccess=false): %s", tslURL)
+				r.setError(err)
+				return err
 			}
 		}
 
 		loadedTSLs, certs, err := r.loadTSLFromURL(tslURL)
 		if err != nil {
-			r.lastError = err
-			r.healthy = false
+			r.setError(err)
 			return err
 		}
 
 		// Verify TSL signatures if LOTL signers are configured
 		for _, tsl := range loadedTSLs {
 			if err := r.verifyTSLSignature(tsl, lotlSigners); err != nil {
-				r.lastError = err
-				r.healthy = false
+				r.setError(err)
 				return err
 			}
 		}
@@ -276,11 +271,13 @@ func (r *TSLRegistry) load() error {
 
 	// Verify we have some trust data
 	if pool == nil || certCount == 0 {
-		r.lastError = fmt.Errorf("no trust data loaded")
-		r.healthy = false
-		return fmt.Errorf("no trust data loaded - configure CertBundle, TSLFiles, or TSLURLs")
+		err := fmt.Errorf("no trust data loaded - configure CertBundle, TSLFiles, or TSLURLs")
+		r.setError(err)
+		return err
 	}
 
+	// Swap in new state under the lock
+	r.mu.Lock()
 	r.certPool = pool
 	r.certCount = certCount
 	r.tsls = tsls
@@ -289,8 +286,17 @@ func (r *TSLRegistry) load() error {
 	r.loadedAt = time.Now()
 	r.healthy = true
 	r.lastError = nil
+	r.mu.Unlock()
 
 	return nil
+}
+
+// setError records a load failure under the lock.
+func (r *TSLRegistry) setError(err error) {
+	r.mu.Lock()
+	r.lastError = err
+	r.healthy = false
+	r.mu.Unlock()
 }
 
 // loadCertBundle reads certificates from a PEM file.
@@ -968,14 +974,18 @@ func (r *TSLRegistry) Info() registry.RegistryInfo {
 		trustAnchors = append(trustAnchors, r.sourceFiles...)
 	}
 
-	return registry.RegistryInfo{
+	info := registry.RegistryInfo{
 		Name:         r.config.Name,
 		Type:         "etsi_tsl",
 		Description:  r.config.Description,
 		Version:      "1.0.0",
 		TrustAnchors: trustAnchors,
-		LastUpdated:  &r.loadedAt,
 	}
+	if !r.loadedAt.IsZero() {
+		loadedAt := r.loadedAt
+		info.LastUpdated = &loadedAt
+	}
+	return info
 }
 
 // Healthy returns true if the registry has loaded trust data successfully.
@@ -996,6 +1006,9 @@ func (r *TSLRegistry) StartRefreshLoop(ctx context.Context) error {
 	interval := r.config.RefreshInterval
 	if interval == 0 {
 		return nil // disabled
+	}
+	if interval < 0 {
+		return fmt.Errorf("RefreshInterval must be positive, got %v", interval)
 	}
 
 	go func() {

--- a/pkg/registry/etsi/registry.go
+++ b/pkg/registry/etsi/registry.go
@@ -36,6 +36,7 @@ import (
 	"encoding/base64"
 	"encoding/pem"
 	"fmt"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
@@ -106,6 +107,12 @@ type TSLConfig struct {
 	// CryptoExt provides extensible certificate parsing for non-standard curves
 	// (e.g. brainpool). If nil, standard x509.ParseCertificate is used.
 	CryptoExt *cryptoutil.Extensions
+
+	// RefreshInterval is how often to re-fetch TSL data. Zero disables.
+	RefreshInterval time.Duration
+
+	// Logger for structured logging. May be nil.
+	Logger *slog.Logger
 }
 
 // TSLRegistry implements TrustRegistry for ETSI TS 119 612 Trust Status Lists.
@@ -121,6 +128,8 @@ type TSLRegistry struct {
 	mu          sync.RWMutex
 	healthy     bool
 	lastError   error
+
+	stopCh chan struct{}
 }
 
 // NewTSLRegistry creates a new ETSI TSL registry.
@@ -144,6 +153,7 @@ func NewTSLRegistry(cfg TSLConfig) (*TSLRegistry, error) {
 
 	r := &TSLRegistry{
 		config: cfg,
+		stopCh: make(chan struct{}),
 	}
 
 	if err := r.load(); err != nil {
@@ -977,6 +987,42 @@ func (r *TSLRegistry) Healthy() bool {
 // Refresh reloads trust data from the configured sources.
 func (r *TSLRegistry) Refresh(ctx context.Context) error {
 	return r.load()
+}
+
+// StartRefreshLoop starts a background goroutine that periodically re-fetches
+// TSL data. Must be called after NewTSLRegistry.
+func (r *TSLRegistry) StartRefreshLoop(ctx context.Context) error {
+	interval := r.config.RefreshInterval
+	if interval == 0 {
+		return nil // disabled
+	}
+
+	go func() {
+		ticker := time.NewTicker(interval)
+		defer ticker.Stop()
+		for {
+			select {
+			case <-ticker.C:
+				if err := r.load(); err != nil && r.config.Logger != nil {
+					r.config.Logger.Warn("TSL refresh failed", slog.String("error", err.Error()))
+				}
+			case <-r.stopCh:
+				return
+			case <-ctx.Done():
+				return
+			}
+		}
+	}()
+	return nil
+}
+
+// Stop halts the background refresh loop.
+func (r *TSLRegistry) Stop() {
+	select {
+	case <-r.stopCh:
+	default:
+		close(r.stopCh)
+	}
 }
 
 // CertificateCount returns the number of trusted certificates loaded.

--- a/pkg/registry/etsi/registry_test.go
+++ b/pkg/registry/etsi/registry_test.go
@@ -2230,3 +2230,38 @@ func TestTSLRegistry_StartRefreshLoop_ContextCancel(t *testing.T) {
 		t.Error("expected refresh to stop after context cancellation")
 	}
 }
+
+func TestTSLRegistry_Info_LastUpdated(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	_, pemData := generateTestCertificate(t, "LastUpdated CA")
+	certPath := writeTestCertFile(t, tmpDir, "ca.pem", pemData)
+
+	reg, err := NewTSLRegistry(TSLConfig{
+		Name:       "last-updated-test",
+		CertBundle: certPath,
+	})
+	if err != nil {
+		t.Fatalf("failed to create registry: %v", err)
+	}
+
+	info := reg.Info()
+	if info.LastUpdated == nil {
+		t.Fatal("expected LastUpdated to be set after initial load")
+	}
+	if info.LastUpdated.IsZero() {
+		t.Fatal("expected LastUpdated to be non-zero")
+	}
+
+	before := *info.LastUpdated
+	time.Sleep(10 * time.Millisecond)
+
+	if err := reg.Refresh(context.Background()); err != nil {
+		t.Fatalf("refresh failed: %v", err)
+	}
+
+	info = reg.Info()
+	if !info.LastUpdated.After(before) {
+		t.Error("expected LastUpdated to advance after refresh")
+	}
+}

--- a/pkg/registry/etsi/registry_test.go
+++ b/pkg/registry/etsi/registry_test.go
@@ -2106,3 +2106,127 @@ func TestTSLRegistry_UnsupportedResourceType(t *testing.T) {
 		})
 	}
 }
+
+func TestTSLRegistry_StartRefreshLoop(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	_, pemData := generateTestCertificate(t, "Refresh Loop CA")
+	certPath := writeTestCertFile(t, tmpDir, "ca.pem", pemData)
+
+	reg, err := NewTSLRegistry(TSLConfig{
+		Name:            "refresh-loop-test",
+		CertBundle:      certPath,
+		RefreshInterval: 50 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("failed to create registry: %v", err)
+	}
+
+	originalLoadedAt := reg.LoadedAt()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := reg.StartRefreshLoop(ctx); err != nil {
+		t.Fatalf("StartRefreshLoop failed: %v", err)
+	}
+	defer reg.Stop()
+
+	// Wait for at least one tick to fire
+	time.Sleep(120 * time.Millisecond)
+
+	if !reg.LoadedAt().After(originalLoadedAt) {
+		t.Error("expected LoadedAt to advance after refresh loop tick")
+	}
+	if !reg.Healthy() {
+		t.Error("expected registry to remain healthy after refresh")
+	}
+}
+
+func TestTSLRegistry_StartRefreshLoop_ZeroInterval(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	_, pemData := generateTestCertificate(t, "No Refresh CA")
+	certPath := writeTestCertFile(t, tmpDir, "ca.pem", pemData)
+
+	reg, err := NewTSLRegistry(TSLConfig{
+		Name:       "no-refresh-test",
+		CertBundle: certPath,
+		// RefreshInterval defaults to zero
+	})
+	if err != nil {
+		t.Fatalf("failed to create registry: %v", err)
+	}
+
+	// Should be a no-op
+	if err := reg.StartRefreshLoop(context.Background()); err != nil {
+		t.Fatalf("StartRefreshLoop should succeed with zero interval: %v", err)
+	}
+}
+
+func TestTSLRegistry_Stop(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	_, pemData := generateTestCertificate(t, "Stop CA")
+	certPath := writeTestCertFile(t, tmpDir, "ca.pem", pemData)
+
+	reg, err := NewTSLRegistry(TSLConfig{
+		Name:            "stop-test",
+		CertBundle:      certPath,
+		RefreshInterval: 50 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("failed to create registry: %v", err)
+	}
+
+	ctx := context.Background()
+	if err := reg.StartRefreshLoop(ctx); err != nil {
+		t.Fatalf("StartRefreshLoop failed: %v", err)
+	}
+
+	// Stop should be safe to call
+	reg.Stop()
+
+	// Double-stop should not panic
+	reg.Stop()
+
+	loadedAt := reg.LoadedAt()
+	time.Sleep(120 * time.Millisecond)
+
+	// After stop, loadedAt should not advance
+	if reg.LoadedAt().After(loadedAt) {
+		t.Error("expected refresh to stop after Stop()")
+	}
+}
+
+func TestTSLRegistry_StartRefreshLoop_ContextCancel(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	_, pemData := generateTestCertificate(t, "Ctx Cancel CA")
+	certPath := writeTestCertFile(t, tmpDir, "ca.pem", pemData)
+
+	reg, err := NewTSLRegistry(TSLConfig{
+		Name:            "ctx-cancel-test",
+		CertBundle:      certPath,
+		RefreshInterval: 50 * time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("failed to create registry: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	if err := reg.StartRefreshLoop(ctx); err != nil {
+		t.Fatalf("StartRefreshLoop failed: %v", err)
+	}
+
+	// Cancel the context
+	cancel()
+
+	loadedAt := reg.LoadedAt()
+	time.Sleep(120 * time.Millisecond)
+
+	// After context cancel, loadedAt should not advance
+	if reg.LoadedAt().After(loadedAt) {
+		t.Error("expected refresh to stop after context cancellation")
+	}
+}

--- a/pkg/registry/etsi/registry_test.go
+++ b/pkg/registry/etsi/registry_test.go
@@ -2038,10 +2038,10 @@ func TestTSLRegistry_UnsupportedResourceType(t *testing.T) {
 	certB64 := base64.StdEncoding.EncodeToString(cert.Raw)
 
 	tests := []struct {
-		name            string
-		resourceType    string
-		expectKnown     bool // known-but-unsupported vs completely unknown
-		expectSecNote   bool // should include security note
+		name          string
+		resourceType  string
+		expectKnown   bool // known-but-unsupported vs completely unknown
+		expectSecNote bool // should include security note
 	}{
 		{
 			name:          "completely unknown type",
@@ -2161,6 +2161,27 @@ func TestTSLRegistry_StartRefreshLoop_ZeroInterval(t *testing.T) {
 	// Should be a no-op
 	if err := reg.StartRefreshLoop(context.Background()); err != nil {
 		t.Fatalf("StartRefreshLoop should succeed with zero interval: %v", err)
+	}
+}
+
+func TestTSLRegistry_StartRefreshLoop_NegativeInterval(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	_, pemData := generateTestCertificate(t, "Negative Interval CA")
+	certPath := writeTestCertFile(t, tmpDir, "ca.pem", pemData)
+
+	reg, err := NewTSLRegistry(TSLConfig{
+		Name:            "negative-interval-test",
+		CertBundle:      certPath,
+		RefreshInterval: -1 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("failed to create registry: %v", err)
+	}
+
+	err = reg.StartRefreshLoop(context.Background())
+	if err == nil {
+		t.Fatal("expected error for negative RefreshInterval")
 	}
 }
 

--- a/pkg/registry/interface.go
+++ b/pkg/registry/interface.go
@@ -14,6 +14,7 @@ package registry
 
 import (
 	"context"
+	"time"
 
 	"github.com/sirosfoundation/go-trust/pkg/authzen"
 )
@@ -72,14 +73,15 @@ type TrustRegistry interface {
 
 // RegistryInfo provides metadata about a TrustRegistry instance
 type RegistryInfo struct {
-	Name           string   // Human-readable name, e.g. "ETSI TSL Registry"
-	Type           string   // Registry type identifier, e.g. "etsi_tsl", "openid_federation"
-	Description    string   // Description of what this registry provides
-	Version        string   // Implementation version
-	TrustAnchors   []string // List of trust anchor identifiers (TSL URLs, federation roots, etc.)
-	ResourceTypes  []string // Supported resource types (from SupportedResourceTypes())
-	ResolutionOnly bool     // Whether this is a resolution-only registry (from SupportsResolutionOnly())
-	Healthy        bool     // Whether the registry is healthy (from Healthy())
+	Name           string     // Human-readable name, e.g. "ETSI TSL Registry"
+	Type           string     // Registry type identifier, e.g. "etsi_tsl", "openid_federation"
+	Description    string     // Description of what this registry provides
+	Version        string     // Implementation version
+	TrustAnchors   []string   // List of trust anchor identifiers (TSL URLs, federation roots, etc.)
+	ResourceTypes  []string   // Supported resource types (from SupportedResourceTypes())
+	ResolutionOnly bool       // Whether this is a resolution-only registry (from SupportsResolutionOnly())
+	Healthy        bool       // Whether the registry is healthy (from Healthy())
+	LastUpdated    *time.Time // When the registry data was last refreshed (nil if not applicable)
 }
 
 // ResolutionStrategy defines how RegistryManager aggregates results from multiple registries

--- a/pkg/registry/lote/registry.go
+++ b/pkg/registry/lote/registry.go
@@ -255,7 +255,8 @@ func (r *Registry) Info() registry.RegistryInfo {
 		Healthy:        r.healthy,
 	}
 	if !r.lastUpdated.IsZero() {
-		info.LastUpdated = &r.lastUpdated
+		lastUpdated := r.lastUpdated
+		info.LastUpdated = &lastUpdated
 	}
 	return info
 }

--- a/pkg/registry/lote/registry.go
+++ b/pkg/registry/lote/registry.go
@@ -51,10 +51,11 @@ type Config struct {
 type Registry struct {
 	config Config
 
-	mu      sync.RWMutex
-	lotes   []*etsi119602.ListOfTrustedEntities
-	index   *entityIndex
-	healthy bool
+	mu          sync.RWMutex
+	lotes       []*etsi119602.ListOfTrustedEntities
+	index       *entityIndex
+	healthy     bool
+	lastUpdated time.Time
 
 	stopCh chan struct{}
 }
@@ -244,7 +245,7 @@ func (r *Registry) SupportsResolutionOnly() bool {
 func (r *Registry) Info() registry.RegistryInfo {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	return registry.RegistryInfo{
+	info := registry.RegistryInfo{
 		Name:           r.config.Name,
 		Type:           "lote",
 		Description:    r.config.Description,
@@ -253,6 +254,10 @@ func (r *Registry) Info() registry.RegistryInfo {
 		ResolutionOnly: true,
 		Healthy:        r.healthy,
 	}
+	if !r.lastUpdated.IsZero() {
+		info.LastUpdated = &r.lastUpdated
+	}
+	return info
 }
 
 func (r *Registry) Healthy() bool {
@@ -387,6 +392,7 @@ func (r *Registry) refresh() error {
 	r.lotes = lotes
 	r.index = idx
 	r.healthy = true
+	r.lastUpdated = time.Now()
 	r.mu.Unlock()
 
 	if r.config.Logger != nil {

--- a/pkg/registry/lote/registry_test.go
+++ b/pkg/registry/lote/registry_test.go
@@ -246,6 +246,26 @@ func TestRefresh(t *testing.T) {
 	assert.True(t, resp.Decision)
 }
 
+func TestInfo_LastUpdated(t *testing.T) {
+	dir := t.TempDir()
+	path := writeLoTE(t, dir, "lote.json", testLoTE())
+
+	reg, err := New(Config{Sources: []string{path}})
+	require.NoError(t, err)
+
+	info := reg.Info()
+	require.NotNil(t, info.LastUpdated, "expected LastUpdated to be set")
+	assert.False(t, info.LastUpdated.IsZero())
+
+	before := *info.LastUpdated
+	time.Sleep(10 * time.Millisecond)
+
+	require.NoError(t, reg.Refresh(context.Background()))
+
+	info = reg.Info()
+	assert.True(t, info.LastUpdated.After(before), "expected LastUpdated to advance after refresh")
+}
+
 func TestMultipleSources(t *testing.T) {
 	dir := t.TempDir()
 

--- a/pkg/registry/static/whitelist.go
+++ b/pkg/registry/static/whitelist.go
@@ -678,7 +678,7 @@ func (r *WhitelistRegistry) Info() registry.RegistryInfo {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	return registry.RegistryInfo{
+	info := registry.RegistryInfo{
 		Name:           r.name,
 		Type:           "static_whitelist",
 		Description:    r.description,
@@ -687,6 +687,10 @@ func (r *WhitelistRegistry) Info() registry.RegistryInfo {
 		ResolutionOnly: true,
 		Healthy:        r.keysLoaded,
 	}
+	if !r.lastRefresh.IsZero() {
+		info.LastUpdated = &r.lastRefresh
+	}
+	return info
 }
 
 // Healthy returns true when the most recent JWKS refresh loaded keys for

--- a/pkg/registry/static/whitelist.go
+++ b/pkg/registry/static/whitelist.go
@@ -688,7 +688,8 @@ func (r *WhitelistRegistry) Info() registry.RegistryInfo {
 		Healthy:        r.keysLoaded,
 	}
 	if !r.lastRefresh.IsZero() {
-		info.LastUpdated = &r.lastRefresh
+		lastRefresh := r.lastRefresh
+		info.LastUpdated = &lastRefresh
 	}
 	return info
 }


### PR DESCRIPTION
Add `RefreshInterval` and `Logger` config fields, `StartRefreshLoop()`, and `Stop()` methods to `TSLRegistry`, matching the LoTE registry's refresh support.

## Changes
- **`RefreshInterval`** (`time.Duration`): periodic re-fetch interval (zero disables)
- **`Logger`** (`*slog.Logger`): structured logging for refresh failures
- **`StartRefreshLoop(ctx)`**: background goroutine with ticker, context-aware
- **`Stop()`**: graceful shutdown via channel (safe to double-call)
- **`stopCh`** channel for lifecycle management

## Tests
- `TestTSLRegistry_StartRefreshLoop` — verifies `LoadedAt` advances after tick
- `TestTSLRegistry_StartRefreshLoop_ZeroInterval` — no-op when interval is zero
- `TestTSLRegistry_Stop` — stop halts refresh, double-stop is safe
- `TestTSLRegistry_StartRefreshLoop_ContextCancel` — context cancellation stops loop