### PR TITLE
refactor(api): rename /tsls endpoint to /registries

### DIFF
--- a/DEVELOPER.md
+++ b/DEVELOPER.md
@@ -211,7 +211,7 @@ Integration tests cover:
 - **Health endpoints**: `/healthz` and `/readyz` for liveness/readiness probes
 - **Metrics endpoint**: `/metrics` for Prometheus metrics
 - **AuthZEN discovery**: `/.well-known/authzen-configuration`
-- **TSL information**: `/tsls` endpoint
+- **Registry information**: `/registries` endpoint
 - **Evaluation endpoint**: `/evaluation` with various scenarios:
   - Valid requests with mock registries
   - Trusted certificates (generated test CA)

--- a/README.md
+++ b/README.md
@@ -105,7 +105,7 @@ Environment variable: `GO_TRUST_EXTERNAL_URL` for external URL.
 | `GET /readyz` | Kubernetes readiness probe (503 until TSLs loaded) |
 | `GET /readyz?verbose=true` | Readiness with detailed TSL info |
 | `GET /metrics` | Prometheus metrics |
-| `GET /tsls` | List loaded Trust Status Lists |
+| `GET /registries` | List configured trust registries |
 
 ### AuthZEN Evaluation Request
 

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -107,14 +107,14 @@
         },
         "/info": {
             "get": {
-                "description": "Returns detailed summaries of all loaded Trust Status Lists\n\nDEPRECATED: This endpoint is deprecated. Use GET /tsls instead.\n\nThis endpoint provides comprehensive information about each TSL including:\n- Territory code\n- Sequence number\n- Issue date\n- Next update date\n- Number of services",
+                "description": "Returns detailed summaries of all loaded Trust Status Lists\n\nDEPRECATED: This endpoint is deprecated. Use GET /registries instead.\n\nThis endpoint provides comprehensive information about each TSL including:\n- Territory code\n- Sequence number\n- Issue date\n- Next update date\n- Number of services",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "Status"
                 ],
-                "summary": "Get TSL information (DEPRECATED - use GET /tsls)",
+                "summary": "Get TSL information (DEPRECATED - use GET /registries)",
                 "deprecated": true,
                 "responses": {
                     "200": {
@@ -183,7 +183,7 @@
                 }
             }
         },
-        "/tsls": {
+        "/registries": {
             "get": {
                 "description": "Returns comprehensive information about all configured trust registries\n\nThis is the primary endpoint for retrieving registry metadata including:\n- Registry names and types\n- Supported resource types\n- Health status\n- Last processing timestamp",
                 "produces": [
@@ -195,7 +195,29 @@
                 "summary": "List Trust Registries",
                 "responses": {
                     "200": {
-                        "description": "count, last_updated, registries",
+                        "description": "count, registries",
+                        "schema": {
+                            "type": "object",
+                            "additionalProperties": true
+                        }
+                    }
+                }
+            }
+        },
+        "/tsls": {
+            "get": {
+                "description": "DEPRECATED: Use GET /registries instead.\n\nReturns comprehensive information about all configured trust registries. This endpoint is kept for backward compatibility and will be removed in v2.0.0.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "Registries"
+                ],
+                "summary": "List Trust Registries (DEPRECATED - use GET /registries)",
+                "deprecated": true,
+                "responses": {
+                    "200": {
+                        "description": "count, registries",
                         "schema": {
                             "type": "object",
                             "additionalProperties": true
@@ -220,14 +242,17 @@
         "api.ReadinessResponse": {
             "type": "object",
             "properties": {
-                "last_processed": {
-                    "type": "string"
-                },
                 "message": {
                     "type": "string"
                 },
                 "ready": {
                     "type": "boolean"
+                },
+                "registry_count": {
+                    "type": "integer"
+                },
+                "healthy_count": {
+                    "type": "integer"
                 },
                 "status": {
                     "type": "string"
@@ -235,10 +260,7 @@
                 "timestamp": {
                     "type": "string"
                 },
-                "tsl_count": {
-                    "type": "integer"
-                },
-                "tsls": {
+                "registries": {
                     "description": "Only included with ?verbose=true",
                     "type": "array",
                     "items": {
@@ -382,7 +404,7 @@
             }
         },
         "authzen.Resource": {
-            "description": "Resource (public key) in an AuthZEN trust evaluation request",
+            "description": "Resource (public key) in an AuthZEN trust evaluation request.\\n\\nFor full trust evaluation: type and key are REQUIRED.\\nFor resolution-only requests: omit type and key to resolve the subject without key validation. Registries supporting resolution (did:web, did:key, OpenID Federation) will return the resolved document in context.trust_metadata.",
             "type": "object",
             "properties": {
                 "id": {

--- a/docs/swagger/swagger.json
+++ b/docs/swagger/swagger.json
@@ -107,18 +107,18 @@
         },
         "/info": {
             "get": {
-                "description": "Returns detailed summaries of all loaded Trust Status Lists\n\nDEPRECATED: This endpoint is deprecated. Use GET /registries instead.\n\nThis endpoint provides comprehensive information about each TSL including:\n- Territory code\n- Sequence number\n- Issue date\n- Next update date\n- Number of services",
+                "description": "Returns the same registry metadata as GET /registries.\n\nDEPRECATED: This endpoint is deprecated. Use GET /registries instead.\nResponse includes deprecation headers.",
                 "produces": [
                     "application/json"
                 ],
                 "tags": [
                     "Status"
                 ],
-                "summary": "Get TSL information (DEPRECATED - use GET /registries)",
+                "summary": "Get registry information (DEPRECATED - use GET /registries)",
                 "deprecated": true,
                 "responses": {
                     "200": {
-                        "description": "tsl_summaries",
+                        "description": "registries",
                         "schema": {
                             "type": "object",
                             "additionalProperties": true
@@ -185,7 +185,7 @@
         },
         "/registries": {
             "get": {
-                "description": "Returns comprehensive information about all configured trust registries\n\nThis is the primary endpoint for retrieving registry metadata including:\n- Registry names and types\n- Supported resource types\n- Health status\n- Last processing timestamp",
+                "description": "Returns comprehensive information about all configured trust registries\n\nThis is the primary endpoint for retrieving registry metadata including:\n- Registry names and types\n- Supported resource types\n- Health status",
                 "produces": [
                     "application/json"
                 ],

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -267,25 +267,19 @@ paths:
     get:
       deprecated: true
       description: |-
-        Returns detailed summaries of all loaded Trust Status Lists
+        Returns the same registry metadata as GET /registries.
 
         DEPRECATED: This endpoint is deprecated. Use GET /registries instead.
-
-        This endpoint provides comprehensive information about each TSL including:
-        - Territory code
-        - Sequence number
-        - Issue date
-        - Next update date
-        - Number of services
+        Response includes deprecation headers.
       produces:
       - application/json
       responses:
         "200":
-          description: tsl_summaries
+          description: registries
           schema:
             additionalProperties: true
             type: object
-      summary: Get TSL information (DEPRECATED - use GET /registries)
+      summary: Get registry information (DEPRECATED - use GET /registries)
       tags:
       - Status
   /readyz:
@@ -341,7 +335,6 @@ paths:
         - Registry names and types
         - Supported resource types
         - Health status
-        - Last processing timestamp
       produces:
       - application/json
       responses:

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -9,19 +9,19 @@ definitions:
     type: object
   api.ReadinessResponse:
     properties:
-      last_processed:
-        type: string
       message:
         type: string
       ready:
         type: boolean
+      registry_count:
+        type: integer
+      healthy_count:
+        type: integer
       status:
         type: string
       timestamp:
         type: string
-      tsl_count:
-        type: integer
-      tsls:
+      registries:
         description: Only included with ?verbose=true
         items:
           additionalProperties: true
@@ -131,7 +131,13 @@ definitions:
         type: string
     type: object
   authzen.Resource:
-    description: Resource (public key) in an AuthZEN trust evaluation request
+    description: |-
+      Resource (public key) in an AuthZEN trust evaluation request.
+
+      For full trust evaluation: type and key are REQUIRED.
+      For resolution-only requests: omit type and key to resolve the subject
+      without key validation. Registries supporting resolution (did:web, did:key,
+      OpenID Federation) will return the resolved document in context.trust_metadata.
     properties:
       id:
         description: MUST match subject.id
@@ -263,7 +269,7 @@ paths:
       description: |-
         Returns detailed summaries of all loaded Trust Status Lists
 
-        DEPRECATED: This endpoint is deprecated. Use GET /tsls instead.
+        DEPRECATED: This endpoint is deprecated. Use GET /registries instead.
 
         This endpoint provides comprehensive information about each TSL including:
         - Territory code
@@ -279,7 +285,7 @@ paths:
           schema:
             additionalProperties: true
             type: object
-      summary: Get TSL information (DEPRECATED - use GET /tsls)
+      summary: Get TSL information (DEPRECATED - use GET /registries)
       tags:
       - Status
   /readyz:
@@ -326,7 +332,7 @@ paths:
       summary: Get server status (DEPRECATED - use GET /readyz)
       tags:
       - Status
-  /tsls:
+  /registries:
     get:
       description: |-
         Returns comprehensive information about all configured trust registries
@@ -340,11 +346,30 @@ paths:
       - application/json
       responses:
         "200":
-          description: count, last_updated, registries
+          description: count, registries
           schema:
             additionalProperties: true
             type: object
       summary: List Trust Registries
+      tags:
+      - Registries
+  /tsls:
+    get:
+      deprecated: true
+      description: |-
+        DEPRECATED: Use GET /registries instead.
+
+        Returns comprehensive information about all configured trust registries.
+        This endpoint is kept for backward compatibility and will be removed in v2.0.0.
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: count, registries
+          schema:
+            additionalProperties: true
+            type: object
+      summary: List Trust Registries (DEPRECATED - use GET /registries)
       tags:
       - Registries
 schemes:

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -160,15 +160,17 @@ func NewServerContext(logger logging.Logger) *ServerContext {
 //	validating that a public key (in resource.key) is correctly bound to a name (in subject.id)
 //	according to the trusted certificates in the pipeline context.
 //
-// TSL Information:
+// Registry Information:
 //
-// GET /tsls - Returns detailed information about all loaded Trust Status Lists
+// GET /registries - Returns information about all configured trust registries
 //
 // Deprecated Endpoints (will be removed in v2.0.0):
 //
+// GET /tsls - DEPRECATED: Use GET /registries instead
+//
 // GET /status - DEPRECATED: Use GET /readyz instead
 //
-// GET /info - DEPRECATED: Use GET /tsls instead
+// GET /info - DEPRECATED: Use GET /registries instead
 //
 // If a RateLimiter is configured in the ServerContext, it will be applied to all routes.
 func RegisterAPIRoutes(r *gin.Engine, serverCtx *ServerContext) {
@@ -189,10 +191,11 @@ func RegisterAPIRoutes(r *gin.Engine, serverCtx *ServerContext) {
 	// AuthZEN evaluation endpoint
 	r.POST("/evaluation", AuthZENDecisionHandler(serverCtx))
 
-	// TSL information endpoint
-	r.GET("/tsls", TSLsHandler(serverCtx))
+	// Registry information endpoint
+	r.GET("/registries", RegistriesHandler(serverCtx))
 
 	// Deprecated endpoints (kept for backward compatibility)
+	r.GET("/tsls", RegistriesHandler(serverCtx)) // DEPRECATED: use /registries
 	r.GET("/status", StatusHandler(serverCtx))
 	r.GET("/info", InfoHandler(serverCtx))
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -195,7 +195,7 @@ func RegisterAPIRoutes(r *gin.Engine, serverCtx *ServerContext) {
 	r.GET("/registries", RegistriesHandler(serverCtx))
 
 	// Deprecated endpoints (kept for backward compatibility)
-	r.GET("/tsls", RegistriesHandler(serverCtx)) // DEPRECATED: use /registries
+	r.GET("/tsls", DeprecatedTSLsHandler(serverCtx))
 	r.GET("/status", StatusHandler(serverCtx))
 	r.GET("/info", InfoHandler(serverCtx))
 

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -772,8 +772,8 @@ func TestNilRegistryManager(t *testing.T) {
 	assert.Contains(t, w.Body.String(), "no registry manager")
 }
 
-// TestTSLsHandler_EmptyRegistryManager tests TSLsHandler when no ETSI registries exist
-func TestTSLsHandler_EmptyRegistryManager(t *testing.T) {
+// TestRegistriesHandler_EmptyRegistryManager tests RegistriesHandler when no ETSI registries exist
+func TestRegistriesHandler_EmptyRegistryManager(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	logger := logging.NewLogger(logging.InfoLevel)
@@ -788,7 +788,7 @@ func TestTSLsHandler_EmptyRegistryManager(t *testing.T) {
 	router := gin.New()
 	RegisterAPIRoutes(router, serverCtx)
 
-	req := httptest.NewRequest("GET", "/tsls", nil)
+	req := httptest.NewRequest("GET", "/registries", nil)
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 
@@ -797,8 +797,28 @@ func TestTSLsHandler_EmptyRegistryManager(t *testing.T) {
 	assert.Contains(t, w.Body.String(), "registries")
 }
 
-// TestTSLsHandler_NilRegistryManager tests TSLsHandler when RegistryManager is nil
-func TestTSLsHandler_NilRegistryManager(t *testing.T) {
+// TestRegistriesHandler_NilRegistryManager tests RegistriesHandler when RegistryManager is nil
+func TestRegistriesHandler_NilRegistryManager(t *testing.T) {
+	gin.SetMode(gin.TestMode)
+
+	logger := logging.NewLogger(logging.InfoLevel)
+	serverCtx := NewServerContext(logger)
+	serverCtx.RegistryManager = nil
+
+	router := gin.New()
+	RegisterAPIRoutes(router, serverCtx)
+
+	req := httptest.NewRequest("GET", "/registries", nil)
+	w := httptest.NewRecorder()
+	router.ServeHTTP(w, req)
+
+	// When RegistryManager is nil, it returns 200 with empty registries
+	assert.Equal(t, 200, w.Code)
+	assert.Contains(t, w.Body.String(), "count")
+}
+
+// TestDeprecatedTSLsEndpoint tests that the legacy /tsls path still works
+func TestDeprecatedTSLsEndpoint(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
 	logger := logging.NewLogger(logging.InfoLevel)
@@ -812,7 +832,6 @@ func TestTSLsHandler_NilRegistryManager(t *testing.T) {
 	w := httptest.NewRecorder()
 	router.ServeHTTP(w, req)
 
-	// When RegistryManager is nil, it returns 200 with empty registries
 	assert.Equal(t, 200, w.Code)
 	assert.Contains(t, w.Body.String(), "count")
 }

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -817,7 +817,7 @@ func TestRegistriesHandler_NilRegistryManager(t *testing.T) {
 	assert.Contains(t, w.Body.String(), "count")
 }
 
-// TestDeprecatedTSLsEndpoint tests that the legacy /tsls path still works
+// TestDeprecatedTSLsEndpoint tests that the legacy /tsls path still works and emits deprecation headers
 func TestDeprecatedTSLsEndpoint(t *testing.T) {
 	gin.SetMode(gin.TestMode)
 
@@ -834,4 +834,9 @@ func TestDeprecatedTSLsEndpoint(t *testing.T) {
 
 	assert.Equal(t, 200, w.Code)
 	assert.Contains(t, w.Body.String(), "count")
+
+	// Verify deprecation signaling
+	assert.Equal(t, "true", w.Header().Get("Deprecation"))
+	assert.Contains(t, w.Header().Get("Link"), "/registries")
+	assert.Contains(t, w.Header().Get("X-API-Warn"), "/registries")
 }

--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -178,21 +178,15 @@ func AuthZENDecisionHandler(serverCtx *ServerContext) gin.HandlerFunc {
 }
 
 // InfoHandler godoc
-// @Summary Get TSL information (DEPRECATED - use GET /registries)
-// @Description Returns detailed summaries of all loaded Trust Status Lists
+// @Summary Get registry information (DEPRECATED - use GET /registries)
+// @Description Returns the same registry metadata as GET /registries.
 // @Description
 // @Description DEPRECATED: This endpoint is deprecated. Use GET /registries instead.
-// @Description
-// @Description This endpoint provides comprehensive information about each TSL including:
-// @Description - Territory code
-// @Description - Sequence number
-// @Description - Issue date
-// @Description - Next update date
-// @Description - Number of services
+// @Description Response includes deprecation headers.
 // @Tags Status
 // @Deprecated true
 // @Produce json
-// @Success 200 {object} map[string]interface{} "tsl_summaries"
+// @Success 200 {object} map[string]interface{} "registries"
 // @Router /info [get]
 func InfoHandler(serverCtx *ServerContext) gin.HandlerFunc {
 	return func(c *gin.Context) {
@@ -242,7 +236,6 @@ func InfoHandler(serverCtx *ServerContext) gin.HandlerFunc {
 // @Description - Registry names and types
 // @Description - Supported resource types
 // @Description - Health status
-// @Description - Last processing timestamp
 // @Tags Registries
 // @Produce json
 // @Success 200 {object} map[string]interface{} "count, registries"
@@ -278,6 +271,19 @@ func RegistriesHandler(serverCtx *ServerContext) gin.HandlerFunc {
 			"count":      registryCount,
 			"registries": registryInfos,
 		})
+	}
+}
+
+// DeprecatedTSLsHandler wraps RegistriesHandler with deprecation headers.
+// This preserves backward compatibility for clients still using GET /tsls
+// while signaling they should migrate to GET /registries.
+func DeprecatedTSLsHandler(serverCtx *ServerContext) gin.HandlerFunc {
+	handler := RegistriesHandler(serverCtx)
+	return func(c *gin.Context) {
+		c.Header("Deprecation", "true")
+		c.Header("Link", "</registries>; rel=\"alternate\"")
+		c.Header("X-API-Warn", "This endpoint is deprecated. Please use GET /registries instead.")
+		handler(c)
 	}
 }
 

--- a/pkg/api/handlers.go
+++ b/pkg/api/handlers.go
@@ -178,10 +178,10 @@ func AuthZENDecisionHandler(serverCtx *ServerContext) gin.HandlerFunc {
 }
 
 // InfoHandler godoc
-// @Summary Get TSL information (DEPRECATED - use GET /tsls)
+// @Summary Get TSL information (DEPRECATED - use GET /registries)
 // @Description Returns detailed summaries of all loaded Trust Status Lists
 // @Description
-// @Description DEPRECATED: This endpoint is deprecated. Use GET /tsls instead.
+// @Description DEPRECATED: This endpoint is deprecated. Use GET /registries instead.
 // @Description
 // @Description This endpoint provides comprehensive information about each TSL including:
 // @Description - Territory code
@@ -198,8 +198,8 @@ func InfoHandler(serverCtx *ServerContext) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		// Add deprecation headers
 		c.Header("Deprecation", "true")
-		c.Header("Link", "</tsls>; rel=\"alternate\"")
-		c.Header("X-API-Warn", "This endpoint is deprecated. Please use GET /tsls instead.")
+		c.Header("Link", "</registries>; rel=\"alternate\"")
+		c.Header("X-API-Warn", "This endpoint is deprecated. Please use GET /registries instead.")
 
 		serverCtx.RLock()
 		defer serverCtx.RUnlock()
@@ -226,7 +226,7 @@ func InfoHandler(serverCtx *ServerContext) gin.HandlerFunc {
 		serverCtx.Logger.Debug("API info request (deprecated endpoint)",
 			logging.F("remote_ip", c.ClientIP()),
 			logging.F("registry_count", registryCount),
-			logging.F("replacement", "GET /tsls"))
+			logging.F("replacement", "GET /registries"))
 
 		c.JSON(200, gin.H{
 			"registries": registryInfos,
@@ -234,7 +234,7 @@ func InfoHandler(serverCtx *ServerContext) gin.HandlerFunc {
 	}
 }
 
-// TSLsHandler godoc
+// RegistriesHandler godoc
 // @Summary List Trust Registries
 // @Description Returns comprehensive information about all configured trust registries
 // @Description
@@ -245,9 +245,9 @@ func InfoHandler(serverCtx *ServerContext) gin.HandlerFunc {
 // @Description - Last processing timestamp
 // @Tags Registries
 // @Produce json
-// @Success 200 {object} map[string]interface{} "count, last_updated, registries"
-// @Router /tsls [get]
-func TSLsHandler(serverCtx *ServerContext) gin.HandlerFunc {
+// @Success 200 {object} map[string]interface{} "count, registries"
+// @Router /registries [get]
+func RegistriesHandler(serverCtx *ServerContext) gin.HandlerFunc {
 	return func(c *gin.Context) {
 		serverCtx.RLock()
 		defer serverCtx.RUnlock()
@@ -270,7 +270,7 @@ func TSLsHandler(serverCtx *ServerContext) gin.HandlerFunc {
 			registryCount = len(registryInfos)
 		}
 
-		serverCtx.Logger.Debug("API /tsls request",
+		serverCtx.Logger.Debug("API /registries request",
 			logging.F("remote_ip", c.ClientIP()),
 			logging.F("registry_count", registryCount))
 


### PR DESCRIPTION
## Summary

Renames the misleading `/tsls` endpoint to `/registries` since it returns metadata about **all** trust registries (ETSI TSL, DID, OIDF), not just TSLs.

## Changes

- **Route rename**: `/tsls` → `/registries` (primary), `/tsls` kept as deprecated alias
- **Handler rename**: `TSLsHandler` → `RegistriesHandler`
- **Swagger**: Updated paths, added deprecated `/tsls` entry, fixed stale field names in ReadinessResponse, added resolution-only mode docs to Resource schema
- **Deprecation notices**: `/info` now points to `/registries` instead of `/tsls`
- **Tests**: Renamed test functions, added `TestDeprecatedTSLsEndpoint` for backward compat
- **Docs**: Updated README.md and DEVELOPER.md

## Backward Compatibility

`GET /tsls` continues to work — it's now a deprecated alias that calls `RegistriesHandler`. No external consumers were found in the workspace.

## Note

The `docs/static/api/go-trust-swagger.yaml` in the docs repo needs a separate update to match.