### PR TITLE
test: integration test against published SIROS LoTE

### DIFF
--- a/pkg/registry/lote/published_lote_test.go
+++ b/pkg/registry/lote/published_lote_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -27,11 +28,15 @@ const (
 func skipIfOffline(t *testing.T) {
 	t.Helper()
 	if os.Getenv("GO_TRUST_INTEGRATION") == "" {
-		t.Skip("set GO_TRUST_INTEGRATION=1 to run live integration tests")
+		t.Skip("set GO_TRUST_INTEGRATION to a non-empty value to run live integration tests")
 	}
 	client := &http.Client{Timeout: 10 * time.Second}
 	resp, err := client.Head(loteURL)
-	if err != nil || resp.StatusCode != http.StatusOK {
+	if err != nil {
+		t.Skipf("cannot reach %s — skipping", loteURL)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
 		t.Skipf("cannot reach %s — skipping", loteURL)
 	}
 }
@@ -70,9 +75,16 @@ func TestPublishedLoTE_SchemeInformation(t *testing.T) {
 	assert.Equal(t, "SE", l.SchemeInformation.Territory)
 	assert.GreaterOrEqual(t, l.SchemeInformation.SequenceNumber, 1)
 
-	// Operator name should reference SIROS Foundation
+	// Operator name should reference SIROS Foundation (any language entry)
 	require.NotEmpty(t, l.SchemeInformation.SchemeOperator)
-	assert.Equal(t, "SIROS Foundation", l.SchemeInformation.SchemeOperator[0].Value)
+	foundOperator := false
+	for _, operator := range l.SchemeInformation.SchemeOperator {
+		if operator.Value == "SIROS Foundation" {
+			foundOperator = true
+			break
+		}
+	}
+	assert.True(t, foundOperator, "expected SchemeOperator to include SIROS Foundation")
 }
 
 // TestPublishedLoTE_ResolveGrantedEntity verifies that the known granted
@@ -134,8 +146,8 @@ func TestPublishedLoTE_JWSAvailable(t *testing.T) {
 	body, err := io.ReadAll(io.LimitReader(resp.Body, 1*1024*1024))
 	require.NoError(t, err)
 
-	compact := string(body)
-	parts := splitDot(compact)
+	compact := strings.TrimSpace(string(body))
+	parts := strings.Split(compact, ".")
 	assert.Equal(t, 3, len(parts), "JWS compact serialization must have 3 parts (header.payload.signature)")
 	for i, p := range parts {
 		assert.NotEmpty(t, p, "JWS part %d must not be empty", i)
@@ -179,16 +191,4 @@ func TestPublishedLoTE_WithTestServer(t *testing.T) {
 	assert.False(t, resp.Decision)
 }
 
-// splitDot splits a string on '.' without importing strings to keep deps minimal.
-func splitDot(s string) []string {
-	var parts []string
-	start := 0
-	for i := 0; i < len(s); i++ {
-		if s[i] == '.' {
-			parts = append(parts, s[start:i])
-			start = i + 1
-		}
-	}
-	parts = append(parts, s[start:])
-	return parts
-}
+

--- a/pkg/registry/lote/published_lote_test.go
+++ b/pkg/registry/lote/published_lote_test.go
@@ -1,0 +1,194 @@
+package lote_test
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sirosfoundation/g119612/pkg/etsi119602"
+	"github.com/sirosfoundation/go-trust/pkg/authzen"
+	"github.com/sirosfoundation/go-trust/pkg/authzenclient"
+	"github.com/sirosfoundation/go-trust/pkg/registry/lote"
+	"github.com/sirosfoundation/go-trust/pkg/testserver"
+)
+
+const (
+	// Published LoTE URLs from trust.siros.org (GitHub Pages).
+	loteURL    = "https://sirosfoundation.github.io/trust-lists/lote-SE.json"
+	loteJWSURL = "https://sirosfoundation.github.io/trust-lists/lote-SE.json.jws"
+)
+
+func skipIfOffline(t *testing.T) {
+	t.Helper()
+	if os.Getenv("GO_TRUST_INTEGRATION") == "" {
+		t.Skip("set GO_TRUST_INTEGRATION=1 to run live integration tests")
+	}
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Head(loteURL)
+	if err != nil || resp.StatusCode != http.StatusOK {
+		t.Skipf("cannot reach %s — skipping", loteURL)
+	}
+}
+
+// TestPublishedLoTE_Load verifies that the live LoTE can be loaded as a
+// registry source and that the registry reports healthy.
+func TestPublishedLoTE_Load(t *testing.T) {
+	skipIfOffline(t)
+
+	reg, err := lote.New(lote.Config{
+		Name:         "siros-trust-lists",
+		Description:  "SIROS Foundation published LoTE",
+		Sources:      []string{loteURL},
+		FetchTimeout: 15 * time.Second,
+	})
+	require.NoError(t, err)
+	assert.True(t, reg.Healthy())
+
+	info := reg.Info()
+	assert.Equal(t, "siros-trust-lists", info.Name)
+	assert.Equal(t, "lote", info.Type)
+	assert.True(t, info.Healthy)
+	assert.NotNil(t, info.LastUpdated)
+}
+
+// TestPublishedLoTE_SchemeInformation verifies the scheme metadata of the
+// published LoTE matches the SIROS Foundation trust list definition.
+func TestPublishedLoTE_SchemeInformation(t *testing.T) {
+	skipIfOffline(t)
+
+	l, err := etsi119602.FetchLoTE(loteURL, &etsi119602.FetchOptions{
+		Timeout: 15 * time.Second,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "SE", l.SchemeInformation.Territory)
+	assert.GreaterOrEqual(t, l.SchemeInformation.SequenceNumber, 1)
+
+	// Operator name should reference SIROS Foundation
+	require.NotEmpty(t, l.SchemeInformation.SchemeOperator)
+	assert.Equal(t, "SIROS Foundation", l.SchemeInformation.SchemeOperator[0].Value)
+}
+
+// TestPublishedLoTE_ResolveGrantedEntity verifies that the known granted
+// entity can be resolved via the LoTE registry (resolution-only mode,
+// no key material required).
+func TestPublishedLoTE_ResolveGrantedEntity(t *testing.T) {
+	skipIfOffline(t)
+
+	reg, err := lote.New(lote.Config{
+		Sources:      []string{loteURL},
+		FetchTimeout: 15 * time.Second,
+	})
+	require.NoError(t, err)
+
+	// Resolution-only evaluation (no resource type/key) — should succeed
+	// for any entity in the LoTE with status "granted".
+	resp, err := reg.Evaluate(context.Background(), &authzen.EvaluationRequest{
+		Subject:  authzen.Subject{Type: "key", ID: "https://issuer.siros.org"},
+		Resource: authzen.Resource{ID: "https://issuer.siros.org"},
+	})
+	require.NoError(t, err)
+	assert.True(t, resp.Decision, "granted entity should be resolvable")
+	assert.NotNil(t, resp.Context)
+	assert.NotNil(t, resp.Context.TrustMetadata, "resolution should include trust metadata")
+}
+
+// TestPublishedLoTE_UnknownEntity verifies that entities not in the LoTE
+// are correctly rejected.
+func TestPublishedLoTE_UnknownEntity(t *testing.T) {
+	skipIfOffline(t)
+
+	reg, err := lote.New(lote.Config{
+		Sources:      []string{loteURL},
+		FetchTimeout: 15 * time.Second,
+	})
+	require.NoError(t, err)
+
+	resp, err := reg.Evaluate(context.Background(), &authzen.EvaluationRequest{
+		Subject:  authzen.Subject{Type: "key", ID: "https://unknown.example.com"},
+		Resource: authzen.Resource{ID: "https://unknown.example.com"},
+	})
+	require.NoError(t, err)
+	assert.False(t, resp.Decision, "unknown entity should not be trusted")
+}
+
+// TestPublishedLoTE_JWSAvailable verifies that the JWS-signed version of the
+// LoTE is reachable and contains a valid compact serialization (three
+// dot-separated segments).
+func TestPublishedLoTE_JWSAvailable(t *testing.T) {
+	skipIfOffline(t)
+
+	client := &http.Client{Timeout: 15 * time.Second}
+	resp, err := client.Get(loteJWSURL)
+	require.NoError(t, err)
+	defer resp.Body.Close()
+
+	require.Equal(t, http.StatusOK, resp.StatusCode, "JWS file should be available")
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 1*1024*1024))
+	require.NoError(t, err)
+
+	compact := string(body)
+	parts := splitDot(compact)
+	assert.Equal(t, 3, len(parts), "JWS compact serialization must have 3 parts (header.payload.signature)")
+	for i, p := range parts {
+		assert.NotEmpty(t, p, "JWS part %d must not be empty", i)
+	}
+}
+
+// TestPublishedLoTE_WithTestServer verifies that the live LoTE can back a
+// full AuthZEN evaluation through the go-trust test server.
+func TestPublishedLoTE_WithTestServer(t *testing.T) {
+	skipIfOffline(t)
+
+	reg, err := lote.New(lote.Config{
+		Name:         "siros-published",
+		Sources:      []string{loteURL},
+		FetchTimeout: 15 * time.Second,
+	})
+	require.NoError(t, err)
+
+	// Use the testserver for a full round-trip through the HTTP API.
+	srv := testserver.New(testserver.WithRegistry(reg))
+	defer srv.Close()
+
+	client := authzenclient.New(srv.URL())
+
+	ctx := context.Background()
+
+	// Positive: known granted entity
+	resp, err := client.Evaluate(ctx, &authzen.EvaluationRequest{
+		Subject:  authzen.Subject{Type: "key", ID: "https://issuer.siros.org"},
+		Resource: authzen.Resource{ID: "https://issuer.siros.org"},
+	})
+	require.NoError(t, err)
+	assert.True(t, resp.Decision)
+
+	// Negative: unknown entity
+	resp, err = client.Evaluate(ctx, &authzen.EvaluationRequest{
+		Subject:  authzen.Subject{Type: "key", ID: "https://evil.example.com"},
+		Resource: authzen.Resource{ID: "https://evil.example.com"},
+	})
+	require.NoError(t, err)
+	assert.False(t, resp.Decision)
+}
+
+// splitDot splits a string on '.' without importing strings to keep deps minimal.
+func splitDot(s string) []string {
+	var parts []string
+	start := 0
+	for i := 0; i < len(s); i++ {
+		if s[i] == '.' {
+			parts = append(parts, s[start:i])
+			start = i + 1
+		}
+	}
+	parts = append(parts, s[start:])
+	return parts
+}


### PR DESCRIPTION
Adds integration tests that validate the live LoTE published at `sirosfoundation.github.io/trust-lists/`:

- **Load**: LoTE fetches from URL, registry reports healthy
- **SchemeInformation**: Territory=SE, operator=SIROS Foundation, sequence >= 1
- **ResolveGrantedEntity**: `https://issuer.siros.org` resolves with trust metadata
- **UnknownEntity**: Unknown entities are rejected
- **JWSAvailable**: JWS compact serialization has valid 3-part structure
- **WithTestServer**: Full AuthZEN round-trip through the testserver HTTP API

Gated by `GO_TRUST_INTEGRATION=1` — skipped in normal CI runs.