### PR TITLE
feat: implement ETSI TS 119 615 pivot processing for signer rollover

### DIFF
--- a/cmd/gt/main.go
+++ b/cmd/gt/main.go
@@ -350,6 +350,7 @@ func configureRegistriesFromConfig(cfg *config.Config, registryMgr *registry.Reg
 			TSLFiles:         etsiCfg.TSLFiles,
 			LOTLSignerBundle: etsiCfg.LOTLSignerBundle,
 			RequireSignature: etsiCfg.RequireSignature,
+			FollowPivots:     etsiCfg.FollowPivots,
 		}
 
 		if tslConfig.Name == "" {

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -112,6 +112,10 @@ registries:
     # Requires lotl_signer_bundle to be configured.
     require_signature: false
 
+    # When true, process ETSI TS 119 615 pivot LOTLs for signer certificate rollover.
+    # Requires allow_network_access to be true.
+    follow_pivots: false
+
   # ---------------------------------------------------------------------------
   # OpenID Federation Registry (entity trust chains)
   # ---------------------------------------------------------------------------

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -61,6 +61,9 @@ type ETSIRegistryConfig struct {
 	// RequireSignature controls whether TSLs must have valid signatures.
 	// When true, LOTLSignerBundle must also be configured.
 	RequireSignature bool `yaml:"require_signature"`
+	// FollowPivots enables ETSI TS 119 615 pivot LOTL processing for signer certificate rollover.
+	// When true, the registry will fetch pivot LOTLs to discover new signer certificates.
+	FollowPivots bool `yaml:"follow_pivots"`
 }
 
 // WhitelistRegistryConfig contains whitelist registry configuration.

--- a/pkg/registry/etsi/pivot.go
+++ b/pkg/registry/etsi/pivot.go
@@ -6,7 +6,6 @@ import (
 	"regexp"
 	"sort"
 	"strconv"
-	"strings"
 
 	"github.com/sirosfoundation/g119612/pkg/etsi119612"
 	"github.com/sirosfoundation/go-trust/pkg/registry"
@@ -93,7 +92,7 @@ func (r *TSLRegistry) extractSignerCertsFromPointers(tsl *etsi119612.TSL, lotlLo
 		}
 
 		// If lotlLocation is specified, only extract from matching pointers
-		if lotlLocation != "" && !strings.EqualFold(pointer.TSLLocation, lotlLocation) {
+		if lotlLocation != "" && pointer.TSLLocation != lotlLocation {
 			continue
 		}
 
@@ -145,7 +144,8 @@ func (r *TSLRegistry) resolvePivotChain(tsl *etsi119612.TSL, lotlSigners []*x509
 	// The LOTL location is the source URL of the TSL we're trying to verify
 	lotlLocation := tsl.Source
 
-	var pivotVerified bool
+	var pivotVerified bool  // at least one pivot was signature-verified
+	var newSignerFound bool // at least one new signer cert was discovered
 
 	// Process pivots oldest-to-newest so trust chains build incrementally
 	for _, pivotURL := range pivotURLs {
@@ -176,6 +176,8 @@ func (r *TSLRegistry) resolvePivotChain(tsl *etsi119612.TSL, lotlSigners []*x509
 			continue
 		}
 
+		pivotVerified = true
+
 		// Extract new signer certificates from the pivot's PointersToOtherTSL.
 		// Look for pointers to the same LOTL location (or all pointers if location is empty).
 		newSigners := r.extractSignerCertsFromPointers(pivotTSL, lotlLocation)
@@ -187,7 +189,7 @@ func (r *TSLRegistry) resolvePivotChain(tsl *etsi119612.TSL, lotlSigners []*x509
 		for _, newSigner := range newSigners {
 			if !containsCert(trustedSigners, newSigner) {
 				trustedSigners = append(trustedSigners, newSigner)
-				pivotVerified = true
+				newSignerFound = true
 				if r.config.Logger != nil {
 					r.config.Logger.Info("discovered new LOTL signer via pivot",
 						"pivot", pivotURL,
@@ -200,6 +202,9 @@ func (r *TSLRegistry) resolvePivotChain(tsl *etsi119612.TSL, lotlSigners []*x509
 
 	if !pivotVerified {
 		return lotlSigners, fmt.Errorf("no pivot LOTLs could be verified with the current trust set")
+	}
+	if !newSignerFound {
+		return trustedSigners, fmt.Errorf("pivot LOTLs were verified but no new signer certificates were discovered")
 	}
 
 	return trustedSigners, nil

--- a/pkg/registry/etsi/pivot.go
+++ b/pkg/registry/etsi/pivot.go
@@ -1,0 +1,241 @@
+package etsi
+
+import (
+	"crypto/x509"
+	"fmt"
+	"regexp"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/sirosfoundation/g119612/pkg/etsi119612"
+	"github.com/sirosfoundation/go-trust/pkg/registry"
+)
+
+// pivotURLPattern matches LOTL pivot URLs like "eu-lotl-pivot-341.xml".
+var pivotURLPattern = regexp.MustCompile(`-pivot-(\d+)\.xml$`)
+
+// pivotURL associates a pivot URL with its sequence number for sorting.
+type pivotURL struct {
+	URL      string
+	Sequence int
+}
+
+// extractPivotURLs extracts pivot LOTL URLs from a TSL's SchemeInformationURI.
+// Pivot URLs follow the pattern *-pivot-<sequence>.xml per ETSI TS 119 615.
+// Returns URLs sorted oldest-to-newest (ascending sequence number).
+func extractPivotURLs(tsl *etsi119612.TSL) []string {
+	if tsl == nil {
+		return nil
+	}
+
+	info := tsl.StatusList.TslSchemeInformation
+	if info == nil || info.TslSchemeInformationURI == nil {
+		return nil
+	}
+
+	var pivots []pivotURL
+	for _, uri := range info.TslSchemeInformationURI.URI {
+		if uri == nil {
+			continue
+		}
+		matches := pivotURLPattern.FindStringSubmatch(uri.Value)
+		if matches == nil {
+			continue
+		}
+		seq, err := strconv.Atoi(matches[1])
+		if err != nil {
+			continue
+		}
+		// Deduplicate: same URL may appear with different lang attributes
+		found := false
+		for _, p := range pivots {
+			if p.URL == uri.Value {
+				found = true
+				break
+			}
+		}
+		if !found {
+			pivots = append(pivots, pivotURL{URL: uri.Value, Sequence: seq})
+		}
+	}
+
+	// Sort oldest first (ascending sequence number)
+	sort.Slice(pivots, func(i, j int) bool {
+		return pivots[i].Sequence < pivots[j].Sequence
+	})
+
+	urls := make([]string, len(pivots))
+	for i, p := range pivots {
+		urls[i] = p.URL
+	}
+	return urls
+}
+
+// extractSignerCertsFromPointers extracts X.509 certificates from a TSL's
+// PointersToOtherTSL ServiceDigitalIdentities. If lotlLocation is non-empty,
+// only certificates from pointers whose TSLLocation matches are returned.
+// This is used to find the new signer certificate in a pivot LOTL.
+func (r *TSLRegistry) extractSignerCertsFromPointers(tsl *etsi119612.TSL, lotlLocation string) []*x509.Certificate {
+	if tsl == nil {
+		return nil
+	}
+
+	info := tsl.StatusList.TslSchemeInformation
+	if info == nil || info.TslPointersToOtherTSL == nil {
+		return nil
+	}
+
+	var certs []*x509.Certificate
+	for _, pointer := range info.TslPointersToOtherTSL.TslOtherTSLPointer {
+		if pointer == nil {
+			continue
+		}
+
+		// If lotlLocation is specified, only extract from matching pointers
+		if lotlLocation != "" && !strings.EqualFold(pointer.TSLLocation, lotlLocation) {
+			continue
+		}
+
+		if pointer.TslServiceDigitalIdentities == nil {
+			continue
+		}
+
+		for _, sdi := range pointer.TslServiceDigitalIdentities.TslServiceDigitalIdentity {
+			if sdi == nil {
+				continue
+			}
+			for _, digitalId := range sdi.DigitalId {
+				if digitalId == nil || digitalId.X509Certificate == "" {
+					continue
+				}
+				certBytes, err := base64Decode(digitalId.X509Certificate)
+				if err != nil {
+					continue
+				}
+				cert, err := registry.ParseCertificate(certBytes, r.config.CryptoExt)
+				if err != nil {
+					continue
+				}
+				certs = append(certs, cert)
+			}
+		}
+	}
+	return certs
+}
+
+// resolvePivotChain attempts to discover new trusted LOTL signer certificates
+// by processing the ETSI TS 119 615 pivot chain. It extracts pivot URLs from
+// the TSL's SchemeInformationURI, fetches each pivot (oldest first), verifies
+// its signature against the current trust set, and extracts new signer
+// certificates from verified pivots.
+//
+// Returns the accumulated set of trusted signer certificates (including the
+// original lotlSigners plus any discovered via pivots).
+func (r *TSLRegistry) resolvePivotChain(tsl *etsi119612.TSL, lotlSigners []*x509.Certificate) ([]*x509.Certificate, error) {
+	pivotURLs := extractPivotURLs(tsl)
+	if len(pivotURLs) == 0 {
+		return lotlSigners, fmt.Errorf("no pivot URLs found in SchemeInformationURI")
+	}
+
+	// Accumulate trusted signers as we walk the chain
+	trustedSigners := make([]*x509.Certificate, len(lotlSigners))
+	copy(trustedSigners, lotlSigners)
+
+	// The LOTL location is the source URL of the TSL we're trying to verify
+	lotlLocation := tsl.Source
+
+	var pivotVerified bool
+
+	// Process pivots oldest-to-newest so trust chains build incrementally
+	for _, pivotURL := range pivotURLs {
+		if r.config.Logger != nil {
+			r.config.Logger.Info("fetching pivot LOTL", "url", pivotURL)
+		}
+
+		opts := etsi119612.TSLFetchOptions{
+			UserAgent:           r.config.UserAgent,
+			Timeout:             r.config.FetchTimeout,
+			AcceptHeaders:       []string{"application/xml", "text/xml", "application/xhtml+xml", "*/*;q=0.8"},
+			MaxDereferenceDepth: 0, // Don't follow references in pivots
+		}
+
+		pivotTSL, err := etsi119612.FetchTSLWithOptions(pivotURL, opts)
+		if err != nil {
+			if r.config.Logger != nil {
+				r.config.Logger.Warn("failed to fetch pivot LOTL", "url", pivotURL, "error", err)
+			}
+			continue
+		}
+
+		// Verify the pivot's signature against current trusted signers
+		if err := r.verifyTSLSignatureStrict(pivotTSL, trustedSigners); err != nil {
+			if r.config.Logger != nil {
+				r.config.Logger.Debug("pivot LOTL not verifiable with current trust set", "url", pivotURL, "error", err)
+			}
+			continue
+		}
+
+		// Extract new signer certificates from the pivot's PointersToOtherTSL.
+		// Look for pointers to the same LOTL location (or all pointers if location is empty).
+		newSigners := r.extractSignerCertsFromPointers(pivotTSL, lotlLocation)
+		if len(newSigners) == 0 {
+			// Also try without location filter - the pivot may point to a different URL
+			newSigners = r.extractSignerCertsFromPointers(pivotTSL, "")
+		}
+
+		for _, newSigner := range newSigners {
+			if !containsCert(trustedSigners, newSigner) {
+				trustedSigners = append(trustedSigners, newSigner)
+				pivotVerified = true
+				if r.config.Logger != nil {
+					r.config.Logger.Info("discovered new LOTL signer via pivot",
+						"pivot", pivotURL,
+						"signer_cn", newSigner.Subject.CommonName,
+					)
+				}
+			}
+		}
+	}
+
+	if !pivotVerified {
+		return lotlSigners, fmt.Errorf("no pivot LOTLs could be verified with the current trust set")
+	}
+
+	return trustedSigners, nil
+}
+
+// verifyTSLSignatureStrict checks that a TSL's signature was created by one
+// of the provided trusted signers. Returns an error if verification fails.
+// Unlike verifyTSLSignature, this always enforces verification (no opportunistic mode).
+func (r *TSLRegistry) verifyTSLSignatureStrict(tsl *etsi119612.TSL, trustedSigners []*x509.Certificate) error {
+	if len(trustedSigners) == 0 {
+		return fmt.Errorf("no trusted signers provided")
+	}
+	if !tsl.Signed {
+		return fmt.Errorf("TSL from %s is not signed", tsl.Source)
+	}
+
+	signerCert := &tsl.Signer
+	if len(signerCert.Raw) == 0 {
+		return fmt.Errorf("TSL from %s has no signer certificate", tsl.Source)
+	}
+
+	for _, trusted := range trustedSigners {
+		if signerCert.Equal(trusted) {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("TSL from %s signed by untrusted certificate: %s", tsl.Source, signerCert.Subject.CommonName)
+}
+
+// containsCert checks if a certificate is already in the list (by raw bytes equality).
+func containsCert(certs []*x509.Certificate, cert *x509.Certificate) bool {
+	for _, c := range certs {
+		if c.Equal(cert) {
+			return true
+		}
+	}
+	return false
+}

--- a/pkg/registry/etsi/pivot_test.go
+++ b/pkg/registry/etsi/pivot_test.go
@@ -394,12 +394,8 @@ func TestResolvePivotChain_WithHTTPServer(t *testing.T) {
 
 func TestVerifyTSLSignature_ReturnsUpdatedSigners(t *testing.T) {
 	// When FollowPivots is false and signer is trusted, returns original signers
-	cert, pemData, _ := generateTestCertAndKey(t, "Signer")
+	cert, _, _ := generateTestCertAndKey(t, "Signer")
 	tsl := makeTSLWithSigner("https://example.com/tsl.xml", cert, nil)
-
-	tmpDir := t.TempDir()
-	certPath := filepath.Join(tmpDir, "trust.pem")
-	os.WriteFile(certPath, pemData, 0644)
 
 	reg := &TSLRegistry{config: TSLConfig{}}
 	signers := []*x509.Certificate{cert}
@@ -521,9 +517,11 @@ func TestResolvePivotChain_HTTPIntegration(t *testing.T) {
 	}))
 	defer server.Close()
 
-	// Create LOTL with pivot URLs pointing to our test server
+	// Create LOTL with pivot URLs pointing to our test server.
+	// The pivot filename must match the production pivot URL pattern
+	// (`-pivot-<seq>.xml`) so resolvePivotChain will actually attempt an HTTP fetch.
 	lotl := makeTSLWithSigner(server.URL+"/lotl.xml", signerA, []string{
-		server.URL + "/pivot-100.xml",
+		server.URL + "/eu-lotl-pivot-100.xml",
 	})
 
 	reg := &TSLRegistry{config: TSLConfig{

--- a/pkg/registry/etsi/pivot_test.go
+++ b/pkg/registry/etsi/pivot_test.go
@@ -1,0 +1,550 @@
+package etsi
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/sirosfoundation/g119612/pkg/etsi119612"
+)
+
+// generateTestCertAndKey creates a self-signed test certificate and returns
+// the parsed cert, PEM bytes, and private key.
+func generateTestCertAndKey(t *testing.T, cn string) (*x509.Certificate, []byte, *rsa.PrivateKey) {
+	t.Helper()
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("failed to generate RSA key: %v", err)
+	}
+
+	tmpl := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName:   cn,
+			Organization: []string{"Test"},
+		},
+		NotBefore:             time.Now().Add(-1 * time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+
+	certDER, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("failed to create certificate: %v", err)
+	}
+
+	cert, err := x509.ParseCertificate(certDER)
+	if err != nil {
+		t.Fatalf("failed to parse certificate: %v", err)
+	}
+
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certDER})
+	return cert, pemBytes, key
+}
+
+// makeTSLWithSigner creates a minimal TSL struct that reports as signed by the given cert.
+func makeTSLWithSigner(source string, signer *x509.Certificate, schemeInfoURIs []string) *etsi119612.TSL {
+	var uris []*etsi119612.NonEmptyMultiLangURIType
+	for _, u := range schemeInfoURIs {
+		uris = append(uris, &etsi119612.NonEmptyMultiLangURIType{Value: u})
+	}
+
+	tsl := &etsi119612.TSL{
+		Source: source,
+		Signed: signer != nil,
+		StatusList: etsi119612.TrustStatusListType{
+			TslSchemeInformation: &etsi119612.TSLSchemeInformationType{
+				TslSchemeInformationURI: &etsi119612.NonEmptyMultiLangURIListType{
+					URI: uris,
+				},
+			},
+		},
+	}
+	if signer != nil {
+		tsl.Signer = *signer
+	}
+	return tsl
+}
+
+// addPointerWithCerts adds a pointer to another TSL location with embedded signer certificates.
+func addPointerWithCerts(tsl *etsi119612.TSL, location string, certs []*x509.Certificate) {
+	info := tsl.StatusList.TslSchemeInformation
+	if info.TslPointersToOtherTSL == nil {
+		info.TslPointersToOtherTSL = &etsi119612.OtherTSLPointersType{}
+	}
+
+	var sdiList []*etsi119612.DigitalIdentityListType
+	for _, cert := range certs {
+		b64 := base64.StdEncoding.EncodeToString(cert.Raw)
+		sdiList = append(sdiList, &etsi119612.DigitalIdentityListType{
+			DigitalId: []*etsi119612.DigitalIdentityType{
+				{X509Certificate: b64},
+			},
+		})
+	}
+
+	pointer := &etsi119612.OtherTSLPointerType{
+		TSLLocation: location,
+		TslServiceDigitalIdentities: &etsi119612.ServiceDigitalIdentityListType{
+			TslServiceDigitalIdentity: sdiList,
+		},
+	}
+
+	info.TslPointersToOtherTSL.TslOtherTSLPointer = append(
+		info.TslPointersToOtherTSL.TslOtherTSLPointer, pointer)
+}
+
+// --- Tests for extractPivotURLs ---
+
+func TestExtractPivotURLs(t *testing.T) {
+	tsl := makeTSLWithSigner("https://example.com/lotl.xml", nil, []string{
+		"https://ec.europa.eu/tools/lotl/eu-lotl-pivot-341.xml",
+		"https://ec.europa.eu/tools/lotl/eu-lotl-pivot-335.xml",
+		"https://ec.europa.eu/tools/lotl/eu-lotl-pivot-300.xml",
+		"https://ec.europa.eu/tools/lotl/eu-lotl-pivot-282.xml",
+		"https://eur-lex.europa.eu/legal-content/EN/TXT/?uri=uriserv:OJ.C_.2019.276.01.0001.01.ENG",
+		"https://ec.europa.eu/tools/lotl/eu-lotl-legalnotice.html#en",
+	})
+
+	urls := extractPivotURLs(tsl)
+
+	if len(urls) != 4 {
+		t.Fatalf("expected 4 pivot URLs, got %d: %v", len(urls), urls)
+	}
+
+	// Should be sorted oldest first (ascending sequence number)
+	expected := []string{
+		"https://ec.europa.eu/tools/lotl/eu-lotl-pivot-282.xml",
+		"https://ec.europa.eu/tools/lotl/eu-lotl-pivot-300.xml",
+		"https://ec.europa.eu/tools/lotl/eu-lotl-pivot-335.xml",
+		"https://ec.europa.eu/tools/lotl/eu-lotl-pivot-341.xml",
+	}
+	for i, url := range urls {
+		if url != expected[i] {
+			t.Errorf("pivot[%d]: expected %s, got %s", i, expected[i], url)
+		}
+	}
+}
+
+func TestExtractPivotURLs_NoPivots(t *testing.T) {
+	tsl := makeTSLWithSigner("https://example.com/tsl.xml", nil, []string{
+		"https://example.com/info",
+		"https://example.com/legal",
+	})
+
+	urls := extractPivotURLs(tsl)
+	if len(urls) != 0 {
+		t.Errorf("expected no pivot URLs, got %d: %v", len(urls), urls)
+	}
+}
+
+func TestExtractPivotURLs_NilTSL(t *testing.T) {
+	urls := extractPivotURLs(nil)
+	if urls != nil {
+		t.Errorf("expected nil, got %v", urls)
+	}
+}
+
+func TestExtractPivotURLs_EmptySchemeInfo(t *testing.T) {
+	tsl := &etsi119612.TSL{}
+	urls := extractPivotURLs(tsl)
+	if urls != nil {
+		t.Errorf("expected nil, got %v", urls)
+	}
+}
+
+func TestExtractPivotURLs_Deduplication(t *testing.T) {
+	// Same pivot URL with different language tags
+	tsl := &etsi119612.TSL{
+		StatusList: etsi119612.TrustStatusListType{
+			TslSchemeInformation: &etsi119612.TSLSchemeInformationType{
+				TslSchemeInformationURI: &etsi119612.NonEmptyMultiLangURIListType{
+					URI: []*etsi119612.NonEmptyMultiLangURIType{
+						{Value: "https://example.com/lotl-pivot-100.xml"},
+						{Value: "https://example.com/lotl-pivot-100.xml"}, // duplicate
+						{Value: "https://example.com/lotl-pivot-200.xml"},
+					},
+				},
+			},
+		},
+	}
+
+	urls := extractPivotURLs(tsl)
+	if len(urls) != 2 {
+		t.Fatalf("expected 2 deduplicated pivot URLs, got %d: %v", len(urls), urls)
+	}
+}
+
+// --- Tests for extractSignerCertsFromPointers ---
+
+func TestExtractSignerCertsFromPointers(t *testing.T) {
+	cert1, _, _ := generateTestCertAndKey(t, "Signer A")
+	cert2, _, _ := generateTestCertAndKey(t, "Signer B")
+
+	tsl := makeTSLWithSigner("https://example.com/pivot.xml", nil, nil)
+	addPointerWithCerts(tsl, "https://example.com/lotl.xml", []*x509.Certificate{cert1, cert2})
+
+	reg := &TSLRegistry{config: TSLConfig{}}
+
+	// Extract with matching location
+	certs := reg.extractSignerCertsFromPointers(tsl, "https://example.com/lotl.xml")
+	if len(certs) != 2 {
+		t.Fatalf("expected 2 certs, got %d", len(certs))
+	}
+
+	// Extract with non-matching location
+	certs = reg.extractSignerCertsFromPointers(tsl, "https://other.com/lotl.xml")
+	if len(certs) != 0 {
+		t.Errorf("expected 0 certs for non-matching location, got %d", len(certs))
+	}
+
+	// Extract with empty location (all pointers)
+	certs = reg.extractSignerCertsFromPointers(tsl, "")
+	if len(certs) != 2 {
+		t.Fatalf("expected 2 certs with empty filter, got %d", len(certs))
+	}
+}
+
+func TestExtractSignerCertsFromPointers_MultiplePointers(t *testing.T) {
+	certA, _, _ := generateTestCertAndKey(t, "Signer A")
+	certB, _, _ := generateTestCertAndKey(t, "Signer B")
+
+	tsl := makeTSLWithSigner("https://example.com/pivot.xml", nil, nil)
+	addPointerWithCerts(tsl, "https://example.com/lotl.xml", []*x509.Certificate{certA})
+	addPointerWithCerts(tsl, "https://example.com/other.xml", []*x509.Certificate{certB})
+
+	reg := &TSLRegistry{config: TSLConfig{}}
+
+	// Only get certs from matching pointer
+	certs := reg.extractSignerCertsFromPointers(tsl, "https://example.com/lotl.xml")
+	if len(certs) != 1 {
+		t.Fatalf("expected 1 cert, got %d", len(certs))
+	}
+	if certs[0].Subject.CommonName != "Signer A" {
+		t.Errorf("expected Signer A, got %s", certs[0].Subject.CommonName)
+	}
+
+	// Get all certs with empty filter
+	certs = reg.extractSignerCertsFromPointers(tsl, "")
+	if len(certs) != 2 {
+		t.Errorf("expected 2 certs with empty filter, got %d", len(certs))
+	}
+}
+
+// --- Tests for verifyTSLSignatureStrict ---
+
+func TestVerifyTSLSignatureStrict_Trusted(t *testing.T) {
+	cert, _, _ := generateTestCertAndKey(t, "Signer")
+	tsl := makeTSLWithSigner("https://example.com/tsl.xml", cert, nil)
+
+	reg := &TSLRegistry{config: TSLConfig{}}
+	err := reg.verifyTSLSignatureStrict(tsl, []*x509.Certificate{cert})
+	if err != nil {
+		t.Errorf("expected nil error, got: %v", err)
+	}
+}
+
+func TestVerifyTSLSignatureStrict_Untrusted(t *testing.T) {
+	signer, _, _ := generateTestCertAndKey(t, "Signer")
+	otherCert, _, _ := generateTestCertAndKey(t, "Other")
+	tsl := makeTSLWithSigner("https://example.com/tsl.xml", signer, nil)
+
+	reg := &TSLRegistry{config: TSLConfig{}}
+	err := reg.verifyTSLSignatureStrict(tsl, []*x509.Certificate{otherCert})
+	if err == nil {
+		t.Error("expected error for untrusted signer")
+	}
+}
+
+func TestVerifyTSLSignatureStrict_Unsigned(t *testing.T) {
+	tsl := makeTSLWithSigner("https://example.com/tsl.xml", nil, nil)
+
+	reg := &TSLRegistry{config: TSLConfig{}}
+	err := reg.verifyTSLSignatureStrict(tsl, []*x509.Certificate{})
+	if err == nil {
+		t.Error("expected error for unsigned TSL")
+	}
+}
+
+// --- Tests for containsCert ---
+
+func TestContainsCert(t *testing.T) {
+	cert1, _, _ := generateTestCertAndKey(t, "Cert1")
+	cert2, _, _ := generateTestCertAndKey(t, "Cert2")
+
+	if !containsCert([]*x509.Certificate{cert1, cert2}, cert1) {
+		t.Error("expected cert1 to be found")
+	}
+
+	cert3, _, _ := generateTestCertAndKey(t, "Cert3")
+	if containsCert([]*x509.Certificate{cert1, cert2}, cert3) {
+		t.Error("expected cert3 not to be found")
+	}
+
+	if containsCert(nil, cert1) {
+		t.Error("expected empty list to return false")
+	}
+}
+
+// --- Tests for resolvePivotChain ---
+
+func TestResolvePivotChain_NoPivotURLs(t *testing.T) {
+	signer, _, _ := generateTestCertAndKey(t, "Signer")
+	tsl := makeTSLWithSigner("https://example.com/lotl.xml", signer, nil) // no pivot URLs
+
+	reg := &TSLRegistry{config: TSLConfig{}}
+	_, err := reg.resolvePivotChain(tsl, []*x509.Certificate{signer})
+	if err == nil {
+		t.Error("expected error when no pivot URLs found")
+	}
+}
+
+func TestResolvePivotChain_WithHTTPServer(t *testing.T) {
+	// Create three signers to simulate a two-hop rollover:
+	// Known signer: signerA
+	// Pivot 100 signed by signerA, contains signerB
+	// Pivot 200 signed by signerB, contains signerC
+	// Current LOTL signed by signerC
+	signerA, _, _ := generateTestCertAndKey(t, "Signer A")
+	signerB, _, _ := generateTestCertAndKey(t, "Signer B")
+	signerC, _, _ := generateTestCertAndKey(t, "Signer C")
+
+	// Create pivot TSLs as in-memory structs
+	pivot100 := makeTSLWithSigner("", signerA, nil)
+	addPointerWithCerts(pivot100, "https://example.com/lotl.xml", []*x509.Certificate{signerB})
+
+	pivot200 := makeTSLWithSigner("", signerB, nil)
+	addPointerWithCerts(pivot200, "https://example.com/lotl.xml", []*x509.Certificate{signerC})
+
+	// We can't easily serve signed XML via HTTP and have the TSL fetch parse it
+	// since FetchTSLWithOptions validates real XML signatures.
+	// Instead, test the helper functions directly.
+
+	// Test that extractSignerCertsFromPointers works for the pivot chain
+	reg := &TSLRegistry{config: TSLConfig{}}
+
+	// Pivot 100: signed by A, should extract B
+	certsFrom100 := reg.extractSignerCertsFromPointers(pivot100, "https://example.com/lotl.xml")
+	if len(certsFrom100) != 1 {
+		t.Fatalf("expected 1 cert from pivot 100, got %d", len(certsFrom100))
+	}
+	if !certsFrom100[0].Equal(signerB) {
+		t.Error("pivot 100 should contain signer B")
+	}
+
+	// Pivot 200: signed by B, should extract C
+	certsFrom200 := reg.extractSignerCertsFromPointers(pivot200, "https://example.com/lotl.xml")
+	if len(certsFrom200) != 1 {
+		t.Fatalf("expected 1 cert from pivot 200, got %d", len(certsFrom200))
+	}
+	if !certsFrom200[0].Equal(signerC) {
+		t.Error("pivot 200 should contain signer C")
+	}
+
+	// Simulate the chain-walking logic manually:
+	// Start with signerA, verify pivot 100 → get signerB → verify pivot 200 → get signerC
+	trustedSigners := []*x509.Certificate{signerA}
+
+	// Verify pivot 100 against current trust set
+	err := reg.verifyTSLSignatureStrict(pivot100, trustedSigners)
+	if err != nil {
+		t.Fatalf("pivot 100 should be verifiable with signerA: %v", err)
+	}
+	// Extract new signers
+	for _, c := range certsFrom100 {
+		if !containsCert(trustedSigners, c) {
+			trustedSigners = append(trustedSigners, c)
+		}
+	}
+
+	// Verify pivot 200 against updated trust set (now includes signerB)
+	err = reg.verifyTSLSignatureStrict(pivot200, trustedSigners)
+	if err != nil {
+		t.Fatalf("pivot 200 should be verifiable with signerB: %v", err)
+	}
+	for _, c := range certsFrom200 {
+		if !containsCert(trustedSigners, c) {
+			trustedSigners = append(trustedSigners, c)
+		}
+	}
+
+	// Now signerC should be in the trust set
+	if !containsCert(trustedSigners, signerC) {
+		t.Error("signerC should be in trust set after walking pivot chain")
+	}
+	if len(trustedSigners) != 3 {
+		t.Errorf("expected 3 signers (A, B, C), got %d", len(trustedSigners))
+	}
+}
+
+// --- Tests for verifyTSLSignature with pivot support ---
+
+func TestVerifyTSLSignature_ReturnsUpdatedSigners(t *testing.T) {
+	// When FollowPivots is false and signer is trusted, returns original signers
+	cert, pemData, _ := generateTestCertAndKey(t, "Signer")
+	tsl := makeTSLWithSigner("https://example.com/tsl.xml", cert, nil)
+
+	tmpDir := t.TempDir()
+	certPath := filepath.Join(tmpDir, "trust.pem")
+	os.WriteFile(certPath, pemData, 0644)
+
+	reg := &TSLRegistry{config: TSLConfig{}}
+	signers := []*x509.Certificate{cert}
+	updated, err := reg.verifyTSLSignature(tsl, signers)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(updated) != 1 {
+		t.Errorf("expected 1 signer, got %d", len(updated))
+	}
+}
+
+func TestVerifyTSLSignature_UntrustedWithRequireSignature(t *testing.T) {
+	signer, _, _ := generateTestCertAndKey(t, "Signer")
+	otherCert, _, _ := generateTestCertAndKey(t, "Other")
+	tsl := makeTSLWithSigner("https://example.com/tsl.xml", signer, nil)
+
+	reg := &TSLRegistry{config: TSLConfig{RequireSignature: true}}
+	_, err := reg.verifyTSLSignature(tsl, []*x509.Certificate{otherCert})
+	if err == nil {
+		t.Error("expected error for untrusted signer with RequireSignature")
+	}
+}
+
+func TestVerifyTSLSignature_OpportunisticUntrusted(t *testing.T) {
+	signer, _, _ := generateTestCertAndKey(t, "Signer")
+	otherCert, _, _ := generateTestCertAndKey(t, "Other")
+	tsl := makeTSLWithSigner("https://example.com/tsl.xml", signer, nil)
+
+	reg := &TSLRegistry{config: TSLConfig{RequireSignature: false}}
+	_, err := reg.verifyTSLSignature(tsl, []*x509.Certificate{otherCert})
+	if err != nil {
+		t.Errorf("opportunistic mode should not fail: %v", err)
+	}
+}
+
+func TestVerifyTSLSignature_NoSigners(t *testing.T) {
+	signer, _, _ := generateTestCertAndKey(t, "Signer")
+	tsl := makeTSLWithSigner("https://example.com/tsl.xml", signer, nil)
+
+	// With RequireSignature=false, should pass
+	reg := &TSLRegistry{config: TSLConfig{RequireSignature: false}}
+	_, err := reg.verifyTSLSignature(tsl, nil)
+	if err != nil {
+		t.Errorf("should pass with no signers and RequireSignature=false: %v", err)
+	}
+
+	// With RequireSignature=true, should fail
+	reg2 := &TSLRegistry{config: TSLConfig{RequireSignature: true}}
+	_, err = reg2.verifyTSLSignature(tsl, nil)
+	if err == nil {
+		t.Error("should fail with no signers and RequireSignature=true")
+	}
+}
+
+// --- Tests for extractPivotURLs with real test data ---
+
+func TestExtractPivotURLs_FromEULOTL(t *testing.T) {
+	tslPath := filepath.Join("testdata", "eu-lotl.xml")
+	if _, err := os.Stat(tslPath); os.IsNotExist(err) {
+		t.Skip("testdata/eu-lotl.xml not found")
+	}
+
+	tsl, err := etsi119612.FetchTSLWithOptions("file://"+mustAbs(t, tslPath), etsi119612.TSLFetchOptions{
+		MaxDereferenceDepth: 0,
+	})
+	if err != nil {
+		t.Fatalf("failed to load EU LOTL: %v", err)
+	}
+
+	urls := extractPivotURLs(tsl)
+	if len(urls) == 0 {
+		t.Fatal("expected pivot URLs from EU LOTL, got none")
+	}
+
+	// EU LOTL should have pivots 282, 300, 335, 341
+	t.Logf("found %d pivot URLs:", len(urls))
+	for _, u := range urls {
+		t.Logf("  %s", u)
+	}
+
+	// Verify sorted oldest-first
+	if len(urls) >= 2 {
+		// The first should be the oldest (lowest sequence number)
+		if urls[0] != "https://ec.europa.eu/tools/lotl/eu-lotl-pivot-282.xml" {
+			t.Errorf("first pivot should be oldest (282), got: %s", urls[0])
+		}
+	}
+}
+
+// --- Integration test: pivot resolution with HTTP test server ---
+
+func TestResolvePivotChain_HTTPIntegration(t *testing.T) {
+	// This test verifies that resolvePivotChain correctly fetches pivot LOTLs
+	// via HTTP. We serve minimal unsigned XML that will fail signature validation,
+	// which means the pivot won't be trusted - this tests error handling.
+
+	signerA, _, _ := generateTestCertAndKey(t, "Signer A")
+
+	// Create a test server serving a minimal TSL XML
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Serve a minimal unsigned TSL XML
+		w.Header().Set("Content-Type", "application/xml")
+		fmt.Fprintf(w, `<?xml version="1.0" encoding="UTF-8"?>
+<TrustServiceStatusList xmlns="http://uri.etsi.org/02231/v2#">
+  <SchemeInformation>
+    <TSLVersionIdentifier>5</TSLVersionIdentifier>
+    <TSLSequenceNumber>100</TSLSequenceNumber>
+    <TSLType>http://uri.etsi.org/TrstSvc/TrustedList/TSLType/EUlistofthelists</TSLType>
+    <SchemeOperatorName><Name xml:lang="en">Test</Name></SchemeOperatorName>
+    <SchemeName><Name xml:lang="en">Test</Name></SchemeName>
+    <SchemeInformationURI><URI xml:lang="en">http://test</URI></SchemeInformationURI>
+    <StatusDeterminationApproach>http://test</StatusDeterminationApproach>
+    <HistoricalInformationPeriod>0</HistoricalInformationPeriod>
+    <ListIssueDateTime>2024-01-01T00:00:00Z</ListIssueDateTime>
+    <NextUpdate><dateTime>2030-01-01T00:00:00Z</dateTime></NextUpdate>
+  </SchemeInformation>
+</TrustServiceStatusList>`)
+	}))
+	defer server.Close()
+
+	// Create LOTL with pivot URLs pointing to our test server
+	lotl := makeTSLWithSigner(server.URL+"/lotl.xml", signerA, []string{
+		server.URL + "/pivot-100.xml",
+	})
+
+	reg := &TSLRegistry{config: TSLConfig{
+		FollowPivots: true,
+		FetchTimeout: 5 * time.Second,
+	}}
+
+	// resolvePivotChain should attempt to fetch the pivot, but since the served
+	// TSL is unsigned, verification will fail and the chain resolution will fail
+	_, err := reg.resolvePivotChain(lotl, []*x509.Certificate{signerA})
+	if err == nil {
+		t.Error("expected error since pivot TSL is unsigned")
+	}
+	t.Logf("correctly got error: %v", err)
+}
+
+func mustAbs(t *testing.T, path string) string {
+	t.Helper()
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		t.Fatalf("failed to get absolute path: %v", err)
+	}
+	return abs
+}

--- a/pkg/registry/etsi/registry.go
+++ b/pkg/registry/etsi/registry.go
@@ -429,22 +429,30 @@ func (r *TSLRegistry) verifyTSLSignature(tsl *etsi119612.TSL, lotlSigners []*x50
 
 	// Signer not in trusted list - attempt pivot resolution if enabled
 	if r.config.FollowPivots {
-		updatedSigners, err := r.resolvePivotChain(tsl, lotlSigners)
-		if err == nil {
-			// Re-check with updated signers
-			for _, trustedSigner := range updatedSigners {
-				if signerCert.Equal(trustedSigner) {
-					if r.config.Logger != nil {
-						r.config.Logger.Info("TSL signature verified via pivot chain",
-							"source", tsl.Source,
-							"signer_cn", signerCert.Subject.CommonName,
-						)
-					}
-					return updatedSigners, nil
-				}
+		if !r.config.AllowNetworkAccess {
+			if r.config.Logger != nil {
+				r.config.Logger.Warn("pivot chain resolution skipped because network access is disabled",
+					"source", tsl.Source,
+				)
 			}
-		} else if r.config.Logger != nil {
-			r.config.Logger.Warn("pivot chain resolution failed", "source", tsl.Source, "error", err)
+		} else {
+			updatedSigners, err := r.resolvePivotChain(tsl, lotlSigners)
+			if err == nil {
+				// Re-check with updated signers
+				for _, trustedSigner := range updatedSigners {
+					if signerCert.Equal(trustedSigner) {
+						if r.config.Logger != nil {
+							r.config.Logger.Info("TSL signature verified via pivot chain",
+								"source", tsl.Source,
+								"signer_cn", signerCert.Subject.CommonName,
+							)
+						}
+						return updatedSigners, nil
+					}
+				}
+			} else if r.config.Logger != nil {
+				r.config.Logger.Warn("pivot chain resolution failed", "source", tsl.Source, "error", err)
+			}
 		}
 	}
 

--- a/pkg/registry/etsi/registry.go
+++ b/pkg/registry/etsi/registry.go
@@ -104,6 +104,14 @@ type TSLConfig struct {
 	// Default: false
 	RequireSignature bool
 
+	// FollowPivots controls whether to process ETSI TS 119 615 pivot LOTLs
+	// for signer certificate rollover. When true and signature verification fails
+	// because the signer is unknown, the registry will fetch pivot LOTLs from
+	// SchemeInformationURI to discover new trusted signers.
+	// Requires AllowNetworkAccess=true since pivots must be fetched remotely.
+	// Default: false
+	FollowPivots bool
+
 	// CryptoExt provides extensible certificate parsing for non-standard curves
 	// (e.g. brainpool). If nil, standard x509.ParseCertificate is used.
 	CryptoExt *cryptoutil.Extensions
@@ -214,10 +222,12 @@ func (r *TSLRegistry) load() error {
 		}
 
 		// Verify TSL signature if LOTL signers are configured
-		if err := r.verifyTSLSignature(tsl, lotlSigners); err != nil {
+		updatedSigners, err := r.verifyTSLSignature(tsl, lotlSigners)
+		if err != nil {
 			r.setError(err)
 			return err
 		}
+		lotlSigners = updatedSigners
 
 		tsls = append(tsls, tsl)
 		absPath, _ := filepath.Abs(tslPath)
@@ -251,10 +261,12 @@ func (r *TSLRegistry) load() error {
 
 		// Verify TSL signatures if LOTL signers are configured
 		for _, tsl := range loadedTSLs {
-			if err := r.verifyTSLSignature(tsl, lotlSigners); err != nil {
+			updatedSigners, err := r.verifyTSLSignature(tsl, lotlSigners)
+			if err != nil {
 				r.setError(err)
 				return err
 			}
+			lotlSigners = updatedSigners
 		}
 
 		tsls = append(tsls, loadedTSLs...)
@@ -378,47 +390,70 @@ func (r *TSLRegistry) loadLOTLSignerBundle(path string) ([]*x509.Certificate, er
 
 // verifyTSLSignature verifies that a TSL's signature was created by a trusted LOTL signer.
 // This implements ETSI TS 119 615 LOTL signature validation.
-// Returns nil if signature is valid or signature verification is not required.
-func (r *TSLRegistry) verifyTSLSignature(tsl *etsi119612.TSL, lotlSigners []*x509.Certificate) error {
+// When FollowPivots is enabled and the signer is unknown, it attempts to discover
+// new trusted signers via the pivot chain (ETSI TS 119 615 signer rollover).
+// Returns the (possibly updated) signer list and nil error if verification succeeds
+// or is not required.
+func (r *TSLRegistry) verifyTSLSignature(tsl *etsi119612.TSL, lotlSigners []*x509.Certificate) ([]*x509.Certificate, error) {
 	// If no LOTL signer certificates configured, skip verification
 	if len(lotlSigners) == 0 {
 		if r.config.RequireSignature {
-			return fmt.Errorf("signature verification required but no LOTL signer certificates configured")
+			return lotlSigners, fmt.Errorf("signature verification required but no LOTL signer certificates configured")
 		}
-		return nil
+		return lotlSigners, nil
 	}
 
 	// Check if TSL is signed
 	if !tsl.Signed {
 		if r.config.RequireSignature {
-			return fmt.Errorf("TSL from %s is not signed", tsl.Source)
+			return lotlSigners, fmt.Errorf("TSL from %s is not signed", tsl.Source)
 		}
-		return nil
+		return lotlSigners, nil
 	}
 
 	// Verify signer certificate is one of the trusted LOTL signers
 	signerCert := &tsl.Signer
 	if len(signerCert.Raw) == 0 {
 		if r.config.RequireSignature {
-			return fmt.Errorf("TSL from %s has no signer certificate", tsl.Source)
+			return lotlSigners, fmt.Errorf("TSL from %s has no signer certificate", tsl.Source)
 		}
-		return nil
+		return lotlSigners, nil
 	}
 
 	// Check if signer is in the trusted list
 	for _, trustedSigner := range lotlSigners {
 		if signerCert.Equal(trustedSigner) {
-			return nil // Signature verified - signer is trusted
+			return lotlSigners, nil // Signature verified - signer is trusted
 		}
 	}
 
-	// Signer not in trusted list
+	// Signer not in trusted list - attempt pivot resolution if enabled
+	if r.config.FollowPivots {
+		updatedSigners, err := r.resolvePivotChain(tsl, lotlSigners)
+		if err == nil {
+			// Re-check with updated signers
+			for _, trustedSigner := range updatedSigners {
+				if signerCert.Equal(trustedSigner) {
+					if r.config.Logger != nil {
+						r.config.Logger.Info("TSL signature verified via pivot chain",
+							"source", tsl.Source,
+							"signer_cn", signerCert.Subject.CommonName,
+						)
+					}
+					return updatedSigners, nil
+				}
+			}
+		} else if r.config.Logger != nil {
+			r.config.Logger.Warn("pivot chain resolution failed", "source", tsl.Source, "error", err)
+		}
+	}
+
 	if r.config.RequireSignature {
-		return fmt.Errorf("TSL from %s signed by untrusted certificate: %s", tsl.Source, signerCert.Subject.CommonName)
+		return lotlSigners, fmt.Errorf("TSL from %s signed by untrusted certificate: %s", tsl.Source, signerCert.Subject.CommonName)
 	}
 
 	// Opportunistic verification - log warning but don't fail
-	return nil
+	return lotlSigners, nil
 }
 
 // loadLocalTSL loads a TSL from a local file path.


### PR DESCRIPTION
Closes #12 (pivot processing portion)

## Summary

Implements ETSI TS 119 615 pivot LOTL processing for signer certificate rollover. When a LOTL is signed by an unknown certificate, the registry can now fetch pivot LOTLs from `SchemeInformationURI` to discover new trusted signer certificates, enabling automated handling of LOTL signer rotations.

## How it works

1. When `verifyTSLSignature` encounters an unknown signer and `FollowPivots=true`:
2. `extractPivotURLs()` parses pivot URLs from `SchemeInformationURI` (pattern `*-pivot-<seq>.xml`)
3. `resolvePivotChain()` fetches pivots oldest-first, verifies each against the current trust set
4. `extractSignerCertsFromPointers()` extracts new signer certs from each verified pivot's `PointersToOtherTSL`
5. New signers accumulate across the chain until the target LOTL's signer is trusted

## Changes

- **pivot.go** (new): Core pivot processing — `extractPivotURLs`, `extractSignerCertsFromPointers`, `resolvePivotChain`, `verifyTSLSignatureStrict`, `containsCert`
- **pivot_test.go** (new): 16 tests covering URL extraction, cert extraction, chain walking, HTTP integration, and real EU LOTL test data
- **registry.go**: Added `FollowPivots` config field; changed `verifyTSLSignature` to return updated signer list after pivot resolution; callers in `load()` propagate updated signers
- **config.go**: Added `follow_pivots` YAML field to `ETSIRegistryConfig`
- **main.go**: Passes `FollowPivots` through config mapping
- **config.yaml**: Documented `follow_pivots` option

## Configuration

```yaml
registries:
  etsi:
    lotl_signer_bundle: "/etc/go-trust/lotl-signers.pem"
    require_signature: true
    follow_pivots: true        # NEW: enables pivot chain resolution
    allow_network_access: true  # required for fetching pivots
```

## Remaining work for full ETSI TS 119 615 compliance

- [ ] Historical TSL validation during rollover periods (tracked separately)
- [ ] Signer cert caching to avoid re-fetching pivots on every refresh cycle