### PR TITLE
feat: add XML LoTE support and LoTL cascading resolution

### DIFF
--- a/cmd/gt/main.go
+++ b/cmd/gt/main.go
@@ -598,11 +598,13 @@ func configureRegistriesFromConfig(cfg *config.Config, registryMgr *registry.Reg
 		loteCfg := cfg.Registries.LoTE
 
 		loteConfig := lote.Config{
-			Name:        loteCfg.Name,
-			Description: loteCfg.Description,
-			Sources:     loteCfg.Sources,
-			VerifyJWS:   loteCfg.VerifyJWS,
-			Logger:      slog.Default(),
+			Name:                loteCfg.Name,
+			Description:         loteCfg.Description,
+			Sources:             loteCfg.Sources,
+			LoTLSources:         loteCfg.LoTLSources,
+			MaxDereferenceDepth: loteCfg.MaxDereferenceDepth,
+			VerifyJWS:           loteCfg.VerifyJWS,
+			Logger:              slog.Default(),
 		}
 
 		if loteCfg.FetchTimeout != "" {

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -202,6 +202,39 @@ registries:
     allow_http: false
 
   # ---------------------------------------------------------------------------
+  # LoTE Registry (ETSI TS 119 602 Lists of Trusted Entities)
+  # ---------------------------------------------------------------------------
+  # Validates entities against ETSI TS 119 602 LoTE documents.
+  # Best for: EU wallet ecosystem, PID/EAA provider trust lists
+  #
+  # Supported resource types: jwk, x5c
+  # Resolution-only: Yes (can resolve entity metadata)
+
+  # lote:
+  #   enabled: true
+  #   name: "LoTE"
+  #   description: "ETSI TS 119 602 List of Trusted Entities"
+  #
+  #   # Direct LoTE sources (JSON or XML, auto-detected)
+  #   sources:
+  #     - "https://registry.siros.org/lote/se-pid-providers.json"
+  #     - "/var/lib/lotes/se-pid-providers.xml"
+  #
+  #   # LoTL sources — follow pointers to discover LoTEs automatically
+  #   lotl_sources:
+  #     - "https://registry.siros.org/lotl/eu-lotl.json"
+  #
+  #   # Max depth for nested LoTL resolution (0 = unlimited)
+  #   max_dereference_depth: 3
+  #
+  #   # JWS signature verification for JSON LoTE documents
+  #   verify_jws: false
+  #
+  #   # Fetch settings
+  #   fetch_timeout: "30s"
+  #   refresh_interval: "1h"
+
+  # ---------------------------------------------------------------------------
   # mDOC IACA Registry (dynamic IACA validation)
   # ---------------------------------------------------------------------------
   # Validates mDOC/mDL X.509 certificate chains against IACA certificates

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/go-oidfed/lib v0.10.2
 	github.com/multiformats/go-multibase v0.3.0
 	github.com/prometheus/client_golang v1.23.2
-	github.com/sirosfoundation/g119612 v0.3.0
+	github.com/sirosfoundation/g119612 v0.3.3-0.20260424115313-28620f4a80ab
 	github.com/sirosfoundation/go-cryptoutil v0.5.0
 	github.com/stretchr/testify v1.11.1
 	github.com/swaggo/files v1.0.1

--- a/go.mod
+++ b/go.mod
@@ -13,7 +13,7 @@ require (
 	github.com/go-oidfed/lib v0.10.2
 	github.com/multiformats/go-multibase v0.3.0
 	github.com/prometheus/client_golang v1.23.2
-	github.com/sirosfoundation/g119612 v0.1.0
+	github.com/sirosfoundation/g119612 v0.3.0
 	github.com/sirosfoundation/go-cryptoutil v0.5.0
 	github.com/stretchr/testify v1.11.1
 	github.com/swaggo/files v1.0.1

--- a/go.sum
+++ b/go.sum
@@ -206,8 +206,8 @@ github.com/scylladb/go-set v1.0.3-0.20200225121959-cc7b2070d91e h1:7q6NSFZDeGfvv
 github.com/scylladb/go-set v1.0.3-0.20200225121959-cc7b2070d91e/go.mod h1:DkpGd78rljTxKAnTDPFqXSGxvETQnJyuSOQwsHycqfs=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
-github.com/sirosfoundation/g119612 v0.1.0 h1:+o8LlKIPNThJwdjcuJzvMqq4riHOmLLixntOEs8tT/o=
-github.com/sirosfoundation/g119612 v0.1.0/go.mod h1:k0kikCRCYjza9y4l4G6WItJ0YVr3vjYqXeRLOruOyPY=
+github.com/sirosfoundation/g119612 v0.3.0 h1:pEpxAutqVQfWvchHY9GB5o7Zq3t/2RIfzKc9wPsDD+4=
+github.com/sirosfoundation/g119612 v0.3.0/go.mod h1:ZRj0/9/OI/RnahL+TVMlN282rM96EnFW1qq6qX+hmcQ=
 github.com/sirosfoundation/go-cryptoutil v0.5.0 h1:ByKuNjHSdlvkOzGeElh0QAku36iuymqLVvBLMY4x5as=
 github.com/sirosfoundation/go-cryptoutil v0.5.0/go.mod h1:OZi673Xmf5o2LzF/QMceptIpiB2GKYAYBfEa75ocBss=
 github.com/sirosfoundation/signedxml v1.4.0-siros1 h1:+d+j6AQxu9CNylGkmPbUAUdEYny6gvXZxFnuvrPViHk=

--- a/go.sum
+++ b/go.sum
@@ -206,8 +206,8 @@ github.com/scylladb/go-set v1.0.3-0.20200225121959-cc7b2070d91e h1:7q6NSFZDeGfvv
 github.com/scylladb/go-set v1.0.3-0.20200225121959-cc7b2070d91e/go.mod h1:DkpGd78rljTxKAnTDPFqXSGxvETQnJyuSOQwsHycqfs=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
 github.com/segmentio/asm v1.2.1/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
-github.com/sirosfoundation/g119612 v0.3.0 h1:pEpxAutqVQfWvchHY9GB5o7Zq3t/2RIfzKc9wPsDD+4=
-github.com/sirosfoundation/g119612 v0.3.0/go.mod h1:ZRj0/9/OI/RnahL+TVMlN282rM96EnFW1qq6qX+hmcQ=
+github.com/sirosfoundation/g119612 v0.3.3-0.20260424115313-28620f4a80ab h1:fLaABRLlVbGgQ+pGkl7jBfp7BDDG0Smht179jgNaDoE=
+github.com/sirosfoundation/g119612 v0.3.3-0.20260424115313-28620f4a80ab/go.mod h1:ZRj0/9/OI/RnahL+TVMlN282rM96EnFW1qq6qX+hmcQ=
 github.com/sirosfoundation/go-cryptoutil v0.5.0 h1:ByKuNjHSdlvkOzGeElh0QAku36iuymqLVvBLMY4x5as=
 github.com/sirosfoundation/go-cryptoutil v0.5.0/go.mod h1:OZi673Xmf5o2LzF/QMceptIpiB2GKYAYBfEa75ocBss=
 github.com/sirosfoundation/signedxml v1.4.0-siros1 h1:+d+j6AQxu9CNylGkmPbUAUdEYny6gvXZxFnuvrPViHk=

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -153,13 +153,15 @@ type MDOCIACARegistryConfig struct {
 
 // LoTERegistryConfig contains ETSI TS 119 602 LoTE registry configuration.
 type LoTERegistryConfig struct {
-	Enabled         bool     `yaml:"enabled"`
-	Name            string   `yaml:"name,omitempty"`
-	Description     string   `yaml:"description,omitempty"`
-	Sources         []string `yaml:"sources"`
-	VerifyJWS       bool     `yaml:"verify_jws,omitempty"`
-	FetchTimeout    string   `yaml:"fetch_timeout,omitempty"`
-	RefreshInterval string   `yaml:"refresh_interval,omitempty"`
+	Enabled             bool     `yaml:"enabled"`
+	Name                string   `yaml:"name,omitempty"`
+	Description         string   `yaml:"description,omitempty"`
+	Sources             []string `yaml:"sources"`
+	LoTLSources         []string `yaml:"lotl_sources,omitempty"`
+	MaxDereferenceDepth int      `yaml:"max_dereference_depth,omitempty"`
+	VerifyJWS           bool     `yaml:"verify_jws,omitempty"`
+	FetchTimeout        string   `yaml:"fetch_timeout,omitempty"`
+	RefreshInterval     string   `yaml:"refresh_interval,omitempty"`
 }
 
 // =============================================================================

--- a/pkg/registry/lote/published_lote_test.go
+++ b/pkg/registry/lote/published_lote_test.go
@@ -72,13 +72,13 @@ func TestPublishedLoTE_SchemeInformation(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	assert.Equal(t, "SE", l.SchemeInformation.Territory)
-	assert.GreaterOrEqual(t, l.SchemeInformation.SequenceNumber, 1)
+	assert.Equal(t, "SE", l.ListAndSchemeInformation.SchemeTerritory)
+	assert.GreaterOrEqual(t, l.ListAndSchemeInformation.LoTESequenceNumber, 1)
 
 	// Operator name should reference SIROS Foundation (any language entry)
-	require.NotEmpty(t, l.SchemeInformation.SchemeOperator)
+	require.NotEmpty(t, l.ListAndSchemeInformation.SchemeOperatorName)
 	foundOperator := false
-	for _, operator := range l.SchemeInformation.SchemeOperator {
+	for _, operator := range l.ListAndSchemeInformation.SchemeOperatorName {
 		if operator.Value == "SIROS Foundation" {
 			foundOperator = true
 			break
@@ -190,5 +190,3 @@ func TestPublishedLoTE_WithTestServer(t *testing.T) {
 	require.NoError(t, err)
 	assert.False(t, resp.Decision)
 }
-
-

--- a/pkg/registry/lote/registry.go
+++ b/pkg/registry/lote/registry.go
@@ -82,6 +82,7 @@ type entityIndex struct {
 // indexedEntity holds a single entity and its precomputed key hashes.
 type indexedEntity struct {
 	entity    etsi119602.TrustedEntity
+	entityID  string
 	territory string
 	keyHashes map[string]bool // SHA-256 fingerprints of all digital identities
 	// certPool contains X.509 certificates from this entity's digital identities,
@@ -181,19 +182,8 @@ func (r *Registry) Evaluate(_ context.Context, req *authzen.EvaluationRequest) (
 		}, nil
 	}
 
-	// Check entity status.
-	if ent.entity.EntityStatus != "" && ent.entity.EntityStatus != etsi119602.StatusGranted {
-		reason := map[string]interface{}{
-			"admin": fmt.Sprintf("entity %q has status %q", subjectID, ent.entity.EntityStatus),
-		}
-		addCredentialTypesToReason(reason, credentialTypes)
-		return &authzen.EvaluationResponse{
-			Decision: false,
-			Context: &authzen.EvaluationResponseContext{
-				Reason: reason,
-			},
-		}, nil
-	}
+	// Per ETSI TS 119 602-1: presence in the list = trusted (no entity-level status).
+	// Withdrawn services are excluded during indexing.
 
 	// Resolution-only: no key check needed.
 	if req.IsResolutionOnlyRequest() {
@@ -354,7 +344,7 @@ func (r *Registry) validateX5CChain(req *authzen.EvaluationRequest, ent *indexed
 	}
 
 	if _, err := certs[0].Verify(opts); err == nil {
-		return r.buildSuccessResponse(ent.entity.EntityID, ent.territory, "x5c chain validates against trust anchor for entity", credentialTypes)
+		return r.buildSuccessResponse(ent.entityID, ent.territory, "x5c chain validates against trust anchor for entity", credentialTypes)
 	}
 	return nil
 }
@@ -435,29 +425,34 @@ func buildIndex(lotes []*etsi119602.ListOfTrustedEntities, ext *cryptoutil.Exten
 	}
 
 	for _, lote := range lotes {
-		territory := lote.SchemeInformation.Territory
-		for _, ent := range lote.TrustedEntities {
+		territory := lote.ListAndSchemeInformation.SchemeTerritory
+		for _, ent := range lote.TrustedEntitiesList {
+			id := entityID(ent)
 			ie := &indexedEntity{
 				entity:    ent,
+				entityID:  id,
 				territory: territory,
 				keyHashes: make(map[string]bool),
 			}
 
-			// Index digital identities and build cert pool for X.509 entries
-			for _, di := range ent.DigitalIdentities {
-				hashes := hashDigitalIdentity(di, ext)
+			// Index service digital identities; skip withdrawn services.
+			for _, svc := range ent.TrustedEntityServices {
+				if isWithdrawnStatus(svc.ServiceInformation.ServiceStatus) {
+					continue
+				}
+				sdi := svc.ServiceInformation.ServiceDigitalIdentity
+				hashes := hashServiceDigitalIdentity(sdi, ext)
 				for _, h := range hashes {
 					ie.keyHashes[h] = true
-
 					if idx.byKeyHash[h] == nil {
 						idx.byKeyHash[h] = make(map[string]bool)
 					}
-					idx.byKeyHash[h][ent.EntityID] = true
+					idx.byKeyHash[h][id] = true
 				}
 
-				// Add X.509 certs to the entity's cert pool for path validation
-				if di.Type == "x509" && di.X509Certificate != "" {
-					der, err := base64.StdEncoding.DecodeString(di.X509Certificate)
+				// Add X.509 certs to the entity's cert pool for path validation.
+				for _, cert509 := range sdi.X509Certificates {
+					der, err := base64.StdEncoding.DecodeString(cert509.Val)
 					if err == nil {
 						cert, err := registry.ParseCertificate(der, ext)
 						if err == nil {
@@ -470,54 +465,50 @@ func buildIndex(lotes []*etsi119602.ListOfTrustedEntities, ext *cryptoutil.Exten
 				}
 			}
 
-			idx.byID[ent.EntityID] = ie
+			idx.byID[id] = ie
 		}
 	}
 
 	return idx
 }
 
-// hashDigitalIdentity produces SHA-256 fingerprints for a LoTE digital identity.
-func hashDigitalIdentity(di etsi119602.DigitalIdentity, ext *cryptoutil.Extensions) []string {
+// hashServiceDigitalIdentity produces SHA-256 fingerprints for an ETSI TS 119 602-1
+// ServiceDigitalIdentity containing X.509 certificates, JWK public key values,
+// and/or X.509 subject names.
+func hashServiceDigitalIdentity(sdi etsi119602.ServiceDigitalIdentity, ext *cryptoutil.Extensions) []string {
 	var hashes []string
 
-	switch di.Type {
-	case "x509":
-		if di.X509Certificate != "" {
-			der, err := base64.StdEncoding.DecodeString(di.X509Certificate)
+	// X.509 certificates
+	for _, cert509 := range sdi.X509Certificates {
+		der, err := base64.StdEncoding.DecodeString(cert509.Val)
+		if err == nil {
+			cert, err := registry.ParseCertificate(der, ext)
 			if err == nil {
-				cert, err := registry.ParseCertificate(der, ext)
+				pubDER, err := x509.MarshalPKIXPublicKey(cert.PublicKey)
 				if err == nil {
-					// Hash the public key
-					pubDER, err := x509.MarshalPKIXPublicKey(cert.PublicKey)
-					if err == nil {
-						h := sha256.Sum256(pubDER)
-						hashes = append(hashes, fmt.Sprintf("%x", h))
-					}
+					h := sha256.Sum256(pubDER)
+					hashes = append(hashes, fmt.Sprintf("%x", h))
 				}
 			}
 		}
+	}
 
-	case "jwk":
-		if di.JWK != nil {
-			// Canonical JSON hash of the JWK
-			data, err := json.Marshal(di.JWK)
-			if err == nil {
-				h := sha256.Sum256(data)
-				hashes = append(hashes, fmt.Sprintf("%x", h))
-			}
-			// Also hash the public key material specifically for matching against
-			// request keys that may have different field ordering
-			if h := hashJWKPublicKey(di.JWK); h != "" {
-				hashes = append(hashes, h)
-			}
-		}
-
-	case "x509_subject_name":
-		if di.X509SubjectName != "" {
-			h := sha256.Sum256([]byte(di.X509SubjectName))
+	// JWK public key values
+	for _, jwk := range sdi.PublicKeyValues {
+		data, err := json.Marshal(jwk)
+		if err == nil {
+			h := sha256.Sum256(data)
 			hashes = append(hashes, fmt.Sprintf("%x", h))
 		}
+		if h := hashJWKPublicKey(jwk); h != "" {
+			hashes = append(hashes, h)
+		}
+	}
+
+	// X.509 subject names
+	for _, subj := range sdi.X509SubjectNames {
+		h := sha256.Sum256([]byte(subj))
+		hashes = append(hashes, fmt.Sprintf("%x", h))
 	}
 
 	return hashes
@@ -659,18 +650,18 @@ func (r *Registry) resolveLoTL(location string, opts *etsi119602.FetchOptions, d
 
 	var lotes []*etsi119602.ListOfTrustedEntities
 
-	for _, ptr := range lotl.PointersToOtherLoTEs {
-		if ptr.Location == "" {
+	for _, ptr := range lotl.ListAndSchemeInformation.PointersToOtherLoTE {
+		if ptr.LoTELocation == "" {
 			continue
 		}
 
-		if etsi119602.IsLoTLSchemeType(ptr.SchemeType) {
+		if etsi119602.IsLoTLSchemeType(pointerSchemeType(ptr)) {
 			// Nested LoTL — resolve recursively.
-			nested, err := r.resolveLoTL(ptr.Location, opts, depth+1, visited)
+			nested, err := r.resolveLoTL(ptr.LoTELocation, opts, depth+1, visited)
 			if err != nil {
 				if r.config.Logger != nil {
 					r.config.Logger.Warn("failed to resolve nested LoTL",
-						slog.String("location", ptr.Location),
+						slog.String("location", ptr.LoTELocation),
 						slog.String("error", err.Error()))
 				}
 				continue
@@ -678,11 +669,11 @@ func (r *Registry) resolveLoTL(location string, opts *etsi119602.FetchOptions, d
 			lotes = append(lotes, nested...)
 		} else {
 			// LoTE pointer — fetch the LoTE directly.
-			lote, err := etsi119602.FetchLoTE(ptr.Location, opts)
+			lote, err := etsi119602.FetchLoTE(ptr.LoTELocation, opts)
 			if err != nil {
 				if r.config.Logger != nil {
 					r.config.Logger.Warn("failed to fetch LoTE from LoTL pointer",
-						slog.String("location", ptr.Location),
+						slog.String("location", ptr.LoTELocation),
 						slog.String("error", err.Error()))
 				}
 				continue
@@ -698,4 +689,29 @@ func (r *Registry) resolveLoTL(location string, opts *etsi119602.FetchOptions, d
 	}
 
 	return lotes, nil
+}
+
+// entityID derives the entity identifier from a TrustedEntity.
+// Prefers TEInformationURI[0].URIValue, falls back to TEName[0].Value.
+func entityID(ent etsi119602.TrustedEntity) string {
+	if len(ent.TrustedEntityInformation.TEInformationURI) > 0 {
+		return ent.TrustedEntityInformation.TEInformationURI[0].URIValue
+	}
+	if len(ent.TrustedEntityInformation.TEName) > 0 {
+		return ent.TrustedEntityInformation.TEName[0].Value
+	}
+	return ""
+}
+
+// isWithdrawnStatus returns true if the service status URI indicates withdrawal.
+func isWithdrawnStatus(status string) bool {
+	return strings.Contains(strings.ToLower(status), "withdrawn")
+}
+
+// pointerSchemeType extracts the LoTE type from a LoTL pointer's qualifiers.
+func pointerSchemeType(ptr etsi119602.OtherLoTEPointer) string {
+	if len(ptr.LoTEQualifiers) > 0 {
+		return ptr.LoTEQualifiers[0].LoTEType
+	}
+	return ""
 }

--- a/pkg/registry/lote/registry.go
+++ b/pkg/registry/lote/registry.go
@@ -94,7 +94,7 @@ var _ registry.TrustRegistry = (*Registry)(nil)
 // New creates a new LoTE registry with the given config.
 func New(cfg Config) (*Registry, error) {
 	if len(cfg.Sources) == 0 && len(cfg.LoTLSources) == 0 {
-		return nil, fmt.Errorf("lote registry requires at least one source or lotl_source")
+		return nil, fmt.Errorf("lote registry requires at least one source or lotl_sources")
 	}
 	if cfg.Name == "" {
 		cfg.Name = "LoTE"
@@ -259,7 +259,7 @@ func (r *Registry) Info() registry.RegistryInfo {
 		Name:           r.config.Name,
 		Type:           "lote",
 		Description:    r.config.Description,
-		TrustAnchors:   append(r.config.Sources, r.config.LoTLSources...),
+		TrustAnchors:   append(append([]string{}, r.config.Sources...), r.config.LoTLSources...),
 		ResourceTypes:  r.SupportedResourceTypes(),
 		ResolutionOnly: true,
 		Healthy:        r.healthy,
@@ -399,8 +399,9 @@ func (r *Registry) refresh() error {
 	}
 
 	// Load LoTL sources and follow pointers to discover LoTEs.
+	visited := make(map[string]bool)
 	for _, src := range r.config.LoTLSources {
-		discovered, err := r.resolveLoTL(src, opts, 0)
+		discovered, err := r.resolveLoTL(src, opts, 0, visited)
 		if err != nil {
 			return fmt.Errorf("failed to resolve LoTL from %s: %w", src, err)
 		}
@@ -627,8 +628,8 @@ func hashResourceKey(req *authzen.EvaluationRequest, ext *cryptoutil.Extensions)
 
 // resolveLoTL fetches a LoTL document and follows its pointers to load LoTEs.
 // Nested LoTLs (pointers with LoTL scheme types) are resolved recursively up
-// to MaxDereferenceDepth.
-func (r *Registry) resolveLoTL(location string, opts *etsi119602.FetchOptions, depth int) ([]*etsi119602.ListOfTrustedEntities, error) {
+// to MaxDereferenceDepth. The visited set prevents cycles.
+func (r *Registry) resolveLoTL(location string, opts *etsi119602.FetchOptions, depth int, visited map[string]bool) ([]*etsi119602.ListOfTrustedEntities, error) {
 	if r.config.MaxDereferenceDepth > 0 && depth >= r.config.MaxDereferenceDepth {
 		if r.config.Logger != nil {
 			r.config.Logger.Warn("LoTL dereference depth limit reached",
@@ -637,6 +638,15 @@ func (r *Registry) resolveLoTL(location string, opts *etsi119602.FetchOptions, d
 		}
 		return nil, nil
 	}
+
+	if visited[location] {
+		if r.config.Logger != nil {
+			r.config.Logger.Warn("LoTL cycle detected, skipping",
+				slog.String("location", location))
+		}
+		return nil, nil
+	}
+	visited[location] = true
 
 	if r.config.Logger != nil {
 		r.config.Logger.Info("resolving LoTL", slog.String("location", location), slog.Int("depth", depth))
@@ -656,7 +666,7 @@ func (r *Registry) resolveLoTL(location string, opts *etsi119602.FetchOptions, d
 
 		if etsi119602.IsLoTLSchemeType(ptr.SchemeType) {
 			// Nested LoTL — resolve recursively.
-			nested, err := r.resolveLoTL(ptr.Location, opts, depth+1)
+			nested, err := r.resolveLoTL(ptr.Location, opts, depth+1, visited)
 			if err != nil {
 				if r.config.Logger != nil {
 					r.config.Logger.Warn("failed to resolve nested LoTL",

--- a/pkg/registry/lote/registry.go
+++ b/pkg/registry/lote/registry.go
@@ -1,7 +1,8 @@
 // Package lote provides a TrustRegistry backed by ETSI TS 119 602 Lists of
-// Trusted Entities (LoTE). It loads LoTE JSON documents from URLs or local
-// files, indexes entities by identifier and digital identity, and evaluates
-// AuthZEN trust requests against them.
+// Trusted Entities (LoTE). It loads LoTE documents (JSON or XML) from URLs or
+// local files, indexes entities by identifier and digital identity, and evaluates
+// AuthZEN trust requests against them. It also supports loading Lists of Trusted
+// Lists (LoTL) and following their pointers to discover individual LoTEs.
 package lote
 
 import (
@@ -27,8 +28,17 @@ type Config struct {
 	Name        string
 	Description string
 
-	// Sources are LoTE JSON document locations (URLs or file paths).
+	// Sources are LoTE document locations (URLs or file paths).
+	// Both JSON and XML formats are auto-detected.
 	Sources []string
+
+	// LoTLSources are LoTL document locations (URLs or file paths).
+	// Each LoTL's PointersToOtherLoTEs are followed to discover LoTEs.
+	// Both JSON and XML formats are auto-detected.
+	LoTLSources []string
+
+	// MaxDereferenceDepth limits nested LoTL resolution. Zero means no limit.
+	MaxDereferenceDepth int
 
 	// VerifyJWS controls whether JWS signatures on LoTE documents are verified.
 	VerifyJWS bool
@@ -83,8 +93,8 @@ var _ registry.TrustRegistry = (*Registry)(nil)
 
 // New creates a new LoTE registry with the given config.
 func New(cfg Config) (*Registry, error) {
-	if len(cfg.Sources) == 0 {
-		return nil, fmt.Errorf("lote registry requires at least one source")
+	if len(cfg.Sources) == 0 && len(cfg.LoTLSources) == 0 {
+		return nil, fmt.Errorf("lote registry requires at least one source or lotl_source")
 	}
 	if cfg.Name == "" {
 		cfg.Name = "LoTE"
@@ -249,7 +259,7 @@ func (r *Registry) Info() registry.RegistryInfo {
 		Name:           r.config.Name,
 		Type:           "lote",
 		Description:    r.config.Description,
-		TrustAnchors:   r.config.Sources,
+		TrustAnchors:   append(r.config.Sources, r.config.LoTLSources...),
 		ResourceTypes:  r.SupportedResourceTypes(),
 		ResolutionOnly: true,
 		Healthy:        r.healthy,
@@ -379,12 +389,22 @@ func (r *Registry) refresh() error {
 		Timeout: r.config.FetchTimeout,
 	}
 
+	// Load direct LoTE sources (JSON or XML, auto-detected).
 	for _, src := range r.config.Sources {
 		lote, err := etsi119602.FetchLoTE(src, opts)
 		if err != nil {
 			return fmt.Errorf("failed to fetch LoTE from %s: %w", src, err)
 		}
 		lotes = append(lotes, lote)
+	}
+
+	// Load LoTL sources and follow pointers to discover LoTEs.
+	for _, src := range r.config.LoTLSources {
+		discovered, err := r.resolveLoTL(src, opts, 0)
+		if err != nil {
+			return fmt.Errorf("failed to resolve LoTL from %s: %w", src, err)
+		}
+		lotes = append(lotes, discovered...)
 	}
 
 	idx := buildIndex(lotes, r.config.CryptoExt)
@@ -399,6 +419,8 @@ func (r *Registry) refresh() error {
 	if r.config.Logger != nil {
 		r.config.Logger.Info("LoTE registry refreshed",
 			slog.Int("sources", len(r.config.Sources)),
+			slog.Int("lotl_sources", len(r.config.LoTLSources)),
+			slog.Int("lotes_loaded", len(lotes)),
 			slog.Int("entities", len(idx.byID)))
 	}
 
@@ -601,4 +623,69 @@ func hashResourceKey(req *authzen.EvaluationRequest, ext *cryptoutil.Extensions)
 	default:
 		return "", fmt.Errorf("unsupported resource type: %s", req.Resource.Type)
 	}
+}
+
+// resolveLoTL fetches a LoTL document and follows its pointers to load LoTEs.
+// Nested LoTLs (pointers with LoTL scheme types) are resolved recursively up
+// to MaxDereferenceDepth.
+func (r *Registry) resolveLoTL(location string, opts *etsi119602.FetchOptions, depth int) ([]*etsi119602.ListOfTrustedEntities, error) {
+	if r.config.MaxDereferenceDepth > 0 && depth >= r.config.MaxDereferenceDepth {
+		if r.config.Logger != nil {
+			r.config.Logger.Warn("LoTL dereference depth limit reached",
+				slog.String("location", location),
+				slog.Int("depth", depth))
+		}
+		return nil, nil
+	}
+
+	if r.config.Logger != nil {
+		r.config.Logger.Info("resolving LoTL", slog.String("location", location), slog.Int("depth", depth))
+	}
+
+	lotl, err := etsi119602.FetchLoTL(location, opts)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch LoTL from %s: %w", location, err)
+	}
+
+	var lotes []*etsi119602.ListOfTrustedEntities
+
+	for _, ptr := range lotl.PointersToOtherLoTEs {
+		if ptr.Location == "" {
+			continue
+		}
+
+		if etsi119602.IsLoTLSchemeType(ptr.SchemeType) {
+			// Nested LoTL — resolve recursively.
+			nested, err := r.resolveLoTL(ptr.Location, opts, depth+1)
+			if err != nil {
+				if r.config.Logger != nil {
+					r.config.Logger.Warn("failed to resolve nested LoTL",
+						slog.String("location", ptr.Location),
+						slog.String("error", err.Error()))
+				}
+				continue
+			}
+			lotes = append(lotes, nested...)
+		} else {
+			// LoTE pointer — fetch the LoTE directly.
+			lote, err := etsi119602.FetchLoTE(ptr.Location, opts)
+			if err != nil {
+				if r.config.Logger != nil {
+					r.config.Logger.Warn("failed to fetch LoTE from LoTL pointer",
+						slog.String("location", ptr.Location),
+						slog.String("error", err.Error()))
+				}
+				continue
+			}
+			lotes = append(lotes, lote)
+		}
+	}
+
+	if r.config.Logger != nil {
+		r.config.Logger.Info("LoTL resolved",
+			slog.String("location", location),
+			slog.Int("lotes_discovered", len(lotes)))
+	}
+
+	return lotes, nil
 }

--- a/pkg/registry/lote/registry_test.go
+++ b/pkg/registry/lote/registry_test.go
@@ -86,7 +86,7 @@ func TestNew_Basic(t *testing.T) {
 func TestNew_NoSources(t *testing.T) {
 	_, err := New(Config{})
 	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "at least one source")
+	assert.Contains(t, err.Error(), "at least one source or lotl_sources")
 }
 
 func TestNew_BadSource(t *testing.T) {
@@ -735,7 +735,7 @@ func TestNew_LoTLSource(t *testing.T) {
 	lotl := &etsi119602.ListOfTrustedLists{
 		Version: "1.0",
 		SchemeInformation: etsi119602.SchemeInformation{
-			Territory: "EU",
+			Territory:  "EU",
 			SchemeType: etsi119602.LoTLTypeEU,
 		},
 		PointersToOtherLoTEs: []etsi119602.LoTEPointer{
@@ -908,7 +908,7 @@ func TestNew_LoTLWithEmptyPointer(t *testing.T) {
 		Version:           "1.0",
 		SchemeInformation: etsi119602.SchemeInformation{Territory: "EU", SchemeType: etsi119602.LoTLTypeEU},
 		PointersToOtherLoTEs: []etsi119602.LoTEPointer{
-			{Location: ""},   // empty location — should be skipped
+			{Location: ""},                  // empty location — should be skipped
 			{Location: "/nonexistent.json"}, // bad path — should warn and continue
 		},
 	}
@@ -918,12 +918,6 @@ func TestNew_LoTLWithEmptyPointer(t *testing.T) {
 	reg, err := New(Config{LoTLSources: []string{lotlPath}})
 	require.NoError(t, err)
 	assert.True(t, reg.Healthy())
-}
-
-func TestNew_NoSourcesOrLoTLSources(t *testing.T) {
-	_, err := New(Config{})
-	assert.Error(t, err)
-	assert.Contains(t, err.Error(), "at least one source or lotl_source")
 }
 
 func TestNew_LoTLOnlyNoDirectSources(t *testing.T) {
@@ -958,4 +952,56 @@ func TestNew_LoTLOnlyNoDirectSources(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.True(t, resp.Decision)
+}
+
+func TestNew_LoTLCycleDetection(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a LoTE that we'll actually discover
+	lote := &etsi119602.ListOfTrustedEntities{
+		Version:           "1.0",
+		SchemeInformation: etsi119602.SchemeInformation{Territory: "SE"},
+		TrustedEntities: []etsi119602.TrustedEntity{
+			{EntityID: "https://cycle.example.com", EntityStatus: etsi119602.StatusGranted},
+		},
+	}
+	lotePath := writeLoTE(t, dir, "lote.json", lote)
+
+	// Create two LoTLs that point to each other (cycle: A → B → A)
+	// Also have A point to the LoTE so we can verify resolution completes.
+	lotlAPath := filepath.Join(dir, "lotl-a.json")
+	lotlBPath := filepath.Join(dir, "lotl-b.json")
+
+	lotlA := &etsi119602.ListOfTrustedLists{
+		Version:           "1.0",
+		SchemeInformation: etsi119602.SchemeInformation{Territory: "EU", SchemeType: etsi119602.LoTLTypeEU},
+		PointersToOtherLoTEs: []etsi119602.LoTEPointer{
+			{Location: lotePath, SchemeType: etsi119602.LoTETypePIDProviders},
+			{Location: lotlBPath, SchemeType: etsi119602.LoTLTypeEU},
+		},
+	}
+	lotlB := &etsi119602.ListOfTrustedLists{
+		Version:           "1.0",
+		SchemeInformation: etsi119602.SchemeInformation{Territory: "EU", SchemeType: etsi119602.LoTLTypeEU},
+		PointersToOtherLoTEs: []etsi119602.LoTEPointer{
+			{Location: lotlAPath, SchemeType: etsi119602.LoTLTypeEU},
+		},
+	}
+
+	dataA, _ := json.Marshal(lotlA)
+	dataB, _ := json.Marshal(lotlB)
+	require.NoError(t, os.WriteFile(lotlAPath, dataA, 0644))
+	require.NoError(t, os.WriteFile(lotlBPath, dataB, 0644))
+
+	// Should complete without infinite recursion and find the LoTE
+	reg, err := New(Config{LoTLSources: []string{lotlAPath}})
+	require.NoError(t, err)
+	assert.True(t, reg.Healthy())
+
+	resp, err := reg.Evaluate(context.Background(), &authzen.EvaluationRequest{
+		Subject:  authzen.Subject{Type: "key", ID: "https://cycle.example.com"},
+		Resource: authzen.Resource{ID: "https://cycle.example.com"},
+	})
+	require.NoError(t, err)
+	assert.True(t, resp.Decision, "should find entity despite LoTL cycle")
 }

--- a/pkg/registry/lote/registry_test.go
+++ b/pkg/registry/lote/registry_test.go
@@ -612,3 +612,350 @@ func TestEvaluate_NoCredentialTypesInContext(t *testing.T) {
 	_, hasCredTypes := resp.Context.Reason["requested_credential_types"]
 	assert.False(t, hasCredTypes)
 }
+
+// --- XML LoTE format tests ---
+
+func writeLoTEXML(t *testing.T, dir, name string, lote *etsi119602.ListOfTrustedEntities) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	require.NoError(t, lote.EncodeXMLToFile(path))
+	return path
+}
+
+func TestNew_XMLSource(t *testing.T) {
+	dir := t.TempDir()
+	path := writeLoTEXML(t, dir, "lote.xml", testLoTE())
+
+	reg, err := New(Config{Sources: []string{path}})
+	require.NoError(t, err)
+	assert.True(t, reg.Healthy())
+
+	// Entity from the XML LoTE should be findable
+	resp, err := reg.Evaluate(context.Background(), &authzen.EvaluationRequest{
+		Subject:  authzen.Subject{Type: "key", ID: "https://issuer.example.com"},
+		Resource: authzen.Resource{ID: "https://issuer.example.com"},
+	})
+	require.NoError(t, err)
+	assert.True(t, resp.Decision)
+}
+
+func TestNew_XMLSource_JWKMatch(t *testing.T) {
+	dir := t.TempDir()
+	path := writeLoTEXML(t, dir, "lote.xml", testLoTE())
+
+	reg, err := New(Config{Sources: []string{path}})
+	require.NoError(t, err)
+
+	resp, err := reg.Evaluate(context.Background(), &authzen.EvaluationRequest{
+		Subject: authzen.Subject{Type: "key", ID: "https://issuer.example.com"},
+		Resource: authzen.Resource{
+			Type: "jwk",
+			ID:   "https://issuer.example.com",
+			Key: []interface{}{
+				map[string]interface{}{
+					"kty": "EC",
+					"crv": "P-256",
+					"x":   "f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",
+					"y":   "x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	assert.True(t, resp.Decision)
+}
+
+func TestNew_MixedJSONAndXMLSources(t *testing.T) {
+	dir := t.TempDir()
+
+	lote1 := &etsi119602.ListOfTrustedEntities{
+		Version:           "1.0",
+		SchemeInformation: etsi119602.SchemeInformation{Territory: "SE"},
+		TrustedEntities: []etsi119602.TrustedEntity{
+			{EntityID: "https://se.example.com", EntityStatus: etsi119602.StatusGranted},
+		},
+	}
+	lote2 := &etsi119602.ListOfTrustedEntities{
+		Version:           "1.0",
+		SchemeInformation: etsi119602.SchemeInformation{Territory: "NO"},
+		TrustedEntities: []etsi119602.TrustedEntity{
+			{EntityID: "https://no.example.com", EntityStatus: etsi119602.StatusGranted},
+		},
+	}
+
+	jsonPath := writeLoTE(t, dir, "se.json", lote1)
+	xmlPath := writeLoTEXML(t, dir, "no.xml", lote2)
+
+	reg, err := New(Config{Sources: []string{jsonPath, xmlPath}})
+	require.NoError(t, err)
+
+	for _, id := range []string{"https://se.example.com", "https://no.example.com"} {
+		resp, err := reg.Evaluate(context.Background(), &authzen.EvaluationRequest{
+			Subject:  authzen.Subject{Type: "key", ID: id},
+			Resource: authzen.Resource{ID: id},
+		})
+		require.NoError(t, err)
+		assert.True(t, resp.Decision, "should find %s", id)
+	}
+}
+
+// --- LoTL resolution tests ---
+
+func writeLoTL(t *testing.T, dir, name string, lotl *etsi119602.ListOfTrustedLists) string {
+	t.Helper()
+	data, err := json.Marshal(lotl)
+	require.NoError(t, err)
+	path := filepath.Join(dir, name)
+	require.NoError(t, os.WriteFile(path, data, 0644))
+	return path
+}
+
+func TestNew_LoTLSource(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create two LoTEs
+	lote1 := &etsi119602.ListOfTrustedEntities{
+		Version:           "1.0",
+		SchemeInformation: etsi119602.SchemeInformation{Territory: "SE"},
+		TrustedEntities: []etsi119602.TrustedEntity{
+			{EntityID: "https://se-pid.example.com", EntityStatus: etsi119602.StatusGranted},
+		},
+	}
+	lote2 := &etsi119602.ListOfTrustedEntities{
+		Version:           "1.0",
+		SchemeInformation: etsi119602.SchemeInformation{Territory: "DE"},
+		TrustedEntities: []etsi119602.TrustedEntity{
+			{EntityID: "https://de-pid.example.com", EntityStatus: etsi119602.StatusGranted},
+		},
+	}
+	path1 := writeLoTE(t, dir, "se-pid.json", lote1)
+	path2 := writeLoTE(t, dir, "de-pid.json", lote2)
+
+	// Create a LoTL pointing to both LoTEs
+	lotl := &etsi119602.ListOfTrustedLists{
+		Version: "1.0",
+		SchemeInformation: etsi119602.SchemeInformation{
+			Territory: "EU",
+			SchemeType: etsi119602.LoTLTypeEU,
+		},
+		PointersToOtherLoTEs: []etsi119602.LoTEPointer{
+			{Location: path1, SchemeTerritory: "SE", SchemeType: etsi119602.LoTETypePIDProviders},
+			{Location: path2, SchemeTerritory: "DE", SchemeType: etsi119602.LoTETypePIDProviders},
+		},
+	}
+	lotlPath := writeLoTL(t, dir, "eu-lotl.json", lotl)
+
+	reg, err := New(Config{LoTLSources: []string{lotlPath}})
+	require.NoError(t, err)
+	assert.True(t, reg.Healthy())
+
+	// Both entities from the LoTL-referenced LoTEs should be discoverable
+	for _, id := range []string{"https://se-pid.example.com", "https://de-pid.example.com"} {
+		resp, err := reg.Evaluate(context.Background(), &authzen.EvaluationRequest{
+			Subject:  authzen.Subject{Type: "key", ID: id},
+			Resource: authzen.Resource{ID: id},
+		})
+		require.NoError(t, err)
+		assert.True(t, resp.Decision, "should find %s via LoTL", id)
+	}
+}
+
+func TestNew_LoTLAndDirectSources(t *testing.T) {
+	dir := t.TempDir()
+
+	// Direct LoTE source
+	directLoTE := &etsi119602.ListOfTrustedEntities{
+		Version:           "1.0",
+		SchemeInformation: etsi119602.SchemeInformation{Territory: "SE"},
+		TrustedEntities: []etsi119602.TrustedEntity{
+			{EntityID: "https://direct.example.com", EntityStatus: etsi119602.StatusGranted},
+		},
+	}
+	directPath := writeLoTE(t, dir, "direct.json", directLoTE)
+
+	// LoTL-referenced LoTE
+	lotlLoTE := &etsi119602.ListOfTrustedEntities{
+		Version:           "1.0",
+		SchemeInformation: etsi119602.SchemeInformation{Territory: "DE"},
+		TrustedEntities: []etsi119602.TrustedEntity{
+			{EntityID: "https://via-lotl.example.com", EntityStatus: etsi119602.StatusGranted},
+		},
+	}
+	lotlLotePath := writeLoTE(t, dir, "via-lotl.json", lotlLoTE)
+
+	lotl := &etsi119602.ListOfTrustedLists{
+		Version:           "1.0",
+		SchemeInformation: etsi119602.SchemeInformation{Territory: "EU", SchemeType: etsi119602.LoTLTypeEU},
+		PointersToOtherLoTEs: []etsi119602.LoTEPointer{
+			{Location: lotlLotePath, SchemeType: etsi119602.LoTETypePIDProviders},
+		},
+	}
+	lotlPath := writeLoTL(t, dir, "lotl.json", lotl)
+
+	reg, err := New(Config{
+		Sources:     []string{directPath},
+		LoTLSources: []string{lotlPath},
+	})
+	require.NoError(t, err)
+
+	// Both direct and LoTL-discovered entities should be found
+	for _, id := range []string{"https://direct.example.com", "https://via-lotl.example.com"} {
+		resp, err := reg.Evaluate(context.Background(), &authzen.EvaluationRequest{
+			Subject:  authzen.Subject{Type: "key", ID: id},
+			Resource: authzen.Resource{ID: id},
+		})
+		require.NoError(t, err)
+		assert.True(t, resp.Decision, "should find %s", id)
+	}
+}
+
+func TestNew_NestedLoTL(t *testing.T) {
+	dir := t.TempDir()
+
+	// Leaf LoTE
+	lote := &etsi119602.ListOfTrustedEntities{
+		Version:           "1.0",
+		SchemeInformation: etsi119602.SchemeInformation{Territory: "SE"},
+		TrustedEntities: []etsi119602.TrustedEntity{
+			{EntityID: "https://nested.example.com", EntityStatus: etsi119602.StatusGranted},
+		},
+	}
+	lotePath := writeLoTE(t, dir, "lote.json", lote)
+
+	// Inner LoTL pointing to the LoTE
+	innerLoTL := &etsi119602.ListOfTrustedLists{
+		Version:           "1.0",
+		SchemeInformation: etsi119602.SchemeInformation{Territory: "SE", SchemeType: etsi119602.LoTLTypeEU},
+		PointersToOtherLoTEs: []etsi119602.LoTEPointer{
+			{Location: lotePath, SchemeType: etsi119602.LoTETypePIDProviders},
+		},
+	}
+	innerPath := writeLoTL(t, dir, "inner-lotl.json", innerLoTL)
+
+	// Outer LoTL pointing to the inner LoTL
+	outerLoTL := &etsi119602.ListOfTrustedLists{
+		Version:           "1.0",
+		SchemeInformation: etsi119602.SchemeInformation{Territory: "EU", SchemeType: etsi119602.LoTLTypeEU},
+		PointersToOtherLoTEs: []etsi119602.LoTEPointer{
+			{Location: innerPath, SchemeType: etsi119602.LoTLTypeEU},
+		},
+	}
+	outerPath := writeLoTL(t, dir, "outer-lotl.json", outerLoTL)
+
+	reg, err := New(Config{LoTLSources: []string{outerPath}})
+	require.NoError(t, err)
+
+	resp, err := reg.Evaluate(context.Background(), &authzen.EvaluationRequest{
+		Subject:  authzen.Subject{Type: "key", ID: "https://nested.example.com"},
+		Resource: authzen.Resource{ID: "https://nested.example.com"},
+	})
+	require.NoError(t, err)
+	assert.True(t, resp.Decision, "should find entity discovered via nested LoTL")
+}
+
+func TestNew_LoTLDepthLimit(t *testing.T) {
+	dir := t.TempDir()
+
+	// Leaf LoTE
+	lote := &etsi119602.ListOfTrustedEntities{
+		Version:           "1.0",
+		SchemeInformation: etsi119602.SchemeInformation{Territory: "SE"},
+		TrustedEntities: []etsi119602.TrustedEntity{
+			{EntityID: "https://deep.example.com", EntityStatus: etsi119602.StatusGranted},
+		},
+	}
+	lotePath := writeLoTE(t, dir, "lote.json", lote)
+
+	// Create a chain: depth-2 → depth-1 → lote
+	depth1 := &etsi119602.ListOfTrustedLists{
+		Version:           "1.0",
+		SchemeInformation: etsi119602.SchemeInformation{Territory: "SE", SchemeType: etsi119602.LoTLTypeEU},
+		PointersToOtherLoTEs: []etsi119602.LoTEPointer{
+			{Location: lotePath, SchemeType: etsi119602.LoTETypePIDProviders},
+		},
+	}
+	depth1Path := writeLoTL(t, dir, "depth1.json", depth1)
+
+	depth2 := &etsi119602.ListOfTrustedLists{
+		Version:           "1.0",
+		SchemeInformation: etsi119602.SchemeInformation{Territory: "EU", SchemeType: etsi119602.LoTLTypeEU},
+		PointersToOtherLoTEs: []etsi119602.LoTEPointer{
+			{Location: depth1Path, SchemeType: etsi119602.LoTLTypeEU},
+		},
+	}
+	depth2Path := writeLoTL(t, dir, "depth2.json", depth2)
+
+	// With MaxDereferenceDepth=1, nested LoTL at depth 1 should be cut off
+	reg, err := New(Config{
+		LoTLSources:         []string{depth2Path},
+		MaxDereferenceDepth: 1,
+	})
+	require.NoError(t, err)
+
+	resp, err := reg.Evaluate(context.Background(), &authzen.EvaluationRequest{
+		Subject:  authzen.Subject{Type: "key", ID: "https://deep.example.com"},
+		Resource: authzen.Resource{ID: "https://deep.example.com"},
+	})
+	require.NoError(t, err)
+	// The entity should NOT be found because the nested LoTL was depth-limited
+	assert.False(t, resp.Decision, "should NOT find entity beyond depth limit")
+}
+
+func TestNew_LoTLWithEmptyPointer(t *testing.T) {
+	dir := t.TempDir()
+
+	lotl := &etsi119602.ListOfTrustedLists{
+		Version:           "1.0",
+		SchemeInformation: etsi119602.SchemeInformation{Territory: "EU", SchemeType: etsi119602.LoTLTypeEU},
+		PointersToOtherLoTEs: []etsi119602.LoTEPointer{
+			{Location: ""},   // empty location — should be skipped
+			{Location: "/nonexistent.json"}, // bad path — should warn and continue
+		},
+	}
+	lotlPath := writeLoTL(t, dir, "lotl.json", lotl)
+
+	// Should succeed even though pointers fail — just loads zero entities
+	reg, err := New(Config{LoTLSources: []string{lotlPath}})
+	require.NoError(t, err)
+	assert.True(t, reg.Healthy())
+}
+
+func TestNew_NoSourcesOrLoTLSources(t *testing.T) {
+	_, err := New(Config{})
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "at least one source or lotl_source")
+}
+
+func TestNew_LoTLOnlyNoDirectSources(t *testing.T) {
+	dir := t.TempDir()
+
+	lote := &etsi119602.ListOfTrustedEntities{
+		Version:           "1.0",
+		SchemeInformation: etsi119602.SchemeInformation{Territory: "SE"},
+		TrustedEntities: []etsi119602.TrustedEntity{
+			{EntityID: "https://lotl-only.example.com", EntityStatus: etsi119602.StatusGranted},
+		},
+	}
+	lotePath := writeLoTE(t, dir, "lote.json", lote)
+
+	lotl := &etsi119602.ListOfTrustedLists{
+		Version:           "1.0",
+		SchemeInformation: etsi119602.SchemeInformation{Territory: "EU", SchemeType: etsi119602.LoTLTypeEU},
+		PointersToOtherLoTEs: []etsi119602.LoTEPointer{
+			{Location: lotePath, SchemeType: etsi119602.LoTETypePIDProviders},
+		},
+	}
+	lotlPath := writeLoTL(t, dir, "lotl.json", lotl)
+
+	// No Sources, only LoTLSources
+	reg, err := New(Config{LoTLSources: []string{lotlPath}})
+	require.NoError(t, err)
+	assert.True(t, reg.Healthy())
+
+	resp, err := reg.Evaluate(context.Background(), &authzen.EvaluationRequest{
+		Subject:  authzen.Subject{Type: "key", ID: "https://lotl-only.example.com"},
+		Resource: authzen.Resource{ID: "https://lotl-only.example.com"},
+	})
+	require.NoError(t, err)
+	assert.True(t, resp.Decision)
+}

--- a/pkg/registry/lote/registry_test.go
+++ b/pkg/registry/lote/registry_test.go
@@ -1069,3 +1069,48 @@ func TestIsWithdrawnStatus(t *testing.T) {
 	assert.True(t, isWithdrawnStatus("http://uri.etsi.org/TrstSvc/TrustedList/Svcstatus/withdrawn"))
 	assert.True(t, isWithdrawnStatus(etsi119602.StatusWithdrawn))
 }
+
+// TestBuildIndex_ImplicitTrust verifies that entities/services without an explicit
+// ServiceStatus (the "presence = trusted" model per ETSI TS 119 602 Annexes D-I
+// for non-Pub-EAA profiles) are correctly indexed and trusted.
+func TestBuildIndex_ImplicitTrust(t *testing.T) {
+	lote := &etsi119602.ListOfTrustedEntities{
+		ListAndSchemeInformation: etsi119602.ListAndSchemeInformation{
+			LoTEVersionIdentifier: 1,
+			LoTEType:              etsi119602.LoTETypePIDProviders,
+			SchemeTerritory:       "SE",
+			SchemeOperatorName:    etsi119602.NameSet{{Lang: "en", Value: "Test"}},
+			ListIssueDateTime:     "2026-01-01T00:00:00Z",
+			NextUpdate:            "2027-01-01T00:00:00Z",
+		},
+		TrustedEntitiesList: []etsi119602.TrustedEntity{
+			{
+				TrustedEntityInformation: etsi119602.TrustedEntityInformation{
+					TEName:           etsi119602.NameSet{{Lang: "en", Value: "Implicit Trust Entity"}},
+					TEInformationURI: []etsi119602.NonEmptyMultiLangURI{{Lang: "en", URIValue: "https://implicit.example.com"}},
+				},
+				TrustedEntityServices: []etsi119602.TrustedEntityService{
+					{
+						ServiceInformation: etsi119602.ServiceInformation{
+							ServiceName: etsi119602.NameSet{{Lang: "en", Value: "PID Service"}},
+							// ServiceStatus intentionally absent — implicit trust
+							ServiceDigitalIdentity: etsi119602.ServiceDigitalIdentity{
+								PublicKeyValues: []map[string]any{
+									{"kty": "EC", "crv": "P-256", "x": "f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU", "y": "x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	idx := buildIndex([]*etsi119602.ListOfTrustedEntities{lote}, nil)
+
+	// Entity should be indexed (presence = trusted)
+	assert.Len(t, idx.byID, 1, "entity with no ServiceStatus should be indexed")
+
+	// Service key should be indexed
+	assert.NotEmpty(t, idx.byKeyHash, "service keys should be indexed when ServiceStatus is absent")
+}

--- a/pkg/registry/lote/registry_test.go
+++ b/pkg/registry/lote/registry_test.go
@@ -8,7 +8,6 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/base64"
-	"encoding/json"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -21,48 +20,57 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// writeLoTE writes a LoTE as JSON with the {"LoTE": ...} envelope required by ParseLoTE.
 func writeLoTE(t *testing.T, dir, name string, lote *etsi119602.ListOfTrustedEntities) string {
 	t.Helper()
-	data, err := json.Marshal(lote)
+	data, err := lote.Marshal()
 	require.NoError(t, err)
 	path := filepath.Join(dir, name)
 	require.NoError(t, os.WriteFile(path, data, 0644))
 	return path
 }
 
+// testLoTE builds a standard LoTE fixture using ETSI TS 119 602-1 types.
 func testLoTE() *etsi119602.ListOfTrustedEntities {
 	return &etsi119602.ListOfTrustedEntities{
-		Version: "1.0",
-		SchemeInformation: etsi119602.SchemeInformation{
-			Territory: "SE",
-			SchemeOperator: etsi119602.NameSet{
-				{Language: "en", Value: "Test Operator"},
+		ListAndSchemeInformation: etsi119602.ListAndSchemeInformation{
+			LoTEVersionIdentifier: 1,
+			LoTESequenceNumber:    1,
+			SchemeTerritory:       "SE",
+			SchemeOperatorName: etsi119602.NameSet{
+				{Lang: "en", Value: "Test Operator"},
 			},
+			ListIssueDateTime: "2026-01-01T00:00:00Z",
+			NextUpdate:        "2027-01-01T00:00:00Z",
 		},
-		TrustedEntities: []etsi119602.TrustedEntity{
+		TrustedEntitiesList: []etsi119602.TrustedEntity{
 			{
-				EntityID:     "https://issuer.example.com",
-				EntityStatus: etsi119602.StatusGranted,
-				EntityName: etsi119602.NameSet{
-					{Language: "en", Value: "Test Issuer"},
-				},
-				DigitalIdentities: []etsi119602.DigitalIdentity{
-					{
-						Type: "jwk",
-						JWK: map[string]interface{}{
-							"kty": "EC",
-							"crv": "P-256",
-							"x":   "f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",
-							"y":   "x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",
-						},
+				TrustedEntityInformation: etsi119602.TrustedEntityInformation{
+					TEName: etsi119602.NameSet{
+						{Lang: "en", Value: "Test Issuer"},
+					},
+					TEInformationURI: []etsi119602.NonEmptyMultiLangURI{
+						{Lang: "en", URIValue: "https://issuer.example.com"},
 					},
 				},
-			},
-			{
-				EntityID:     "https://withdrawn.example.com",
-				EntityStatus: etsi119602.StatusWithdrawn,
-				EntityName: etsi119602.NameSet{
-					{Language: "en", Value: "Withdrawn Entity"},
+				TrustedEntityServices: []etsi119602.TrustedEntityService{
+					{
+						ServiceInformation: etsi119602.ServiceInformation{
+							ServiceName: etsi119602.NameSet{
+								{Lang: "en", Value: "PID Issuance"},
+							},
+							ServiceDigitalIdentity: etsi119602.ServiceDigitalIdentity{
+								PublicKeyValues: []map[string]any{
+									{
+										"kty": "EC",
+										"crv": "P-256",
+										"x":   "f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",
+										"y":   "x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",
+									},
+								},
+							},
+						},
+					},
 				},
 			},
 		},
@@ -120,20 +128,79 @@ func TestEvaluate_GrantedEntity_JWKMatch(t *testing.T) {
 	assert.True(t, resp.Decision)
 }
 
-func TestEvaluate_WithdrawnEntity(t *testing.T) {
-	dir := t.TempDir()
-	path := writeLoTE(t, dir, "lote.json", testLoTE())
+func TestEvaluate_WithdrawnService(t *testing.T) {
+	// Pub-EAA profile: entity present in list but service has withdrawn status.
+	// Per ETSI TS 119 602-1: withdrawn services' digital identities are NOT trusted.
+	lote := &etsi119602.ListOfTrustedEntities{
+		ListAndSchemeInformation: etsi119602.ListAndSchemeInformation{
+			LoTEVersionIdentifier: 1,
+			LoTESequenceNumber:    1,
+			SchemeTerritory:       "SE",
+			SchemeOperatorName:    etsi119602.NameSet{{Lang: "en", Value: "Op"}},
+			ListIssueDateTime:     "2026-01-01T00:00:00Z",
+			NextUpdate:            "2027-01-01T00:00:00Z",
+		},
+		TrustedEntitiesList: []etsi119602.TrustedEntity{
+			{
+				TrustedEntityInformation: etsi119602.TrustedEntityInformation{
+					TEName: etsi119602.NameSet{{Lang: "en", Value: "Pub-EAA Provider"}},
+					TEInformationURI: []etsi119602.NonEmptyMultiLangURI{
+						{Lang: "en", URIValue: "https://withdrawn-svc.example.com"},
+					},
+				},
+				TrustedEntityServices: []etsi119602.TrustedEntityService{
+					{
+						ServiceInformation: etsi119602.ServiceInformation{
+							ServiceName:   etsi119602.NameSet{{Lang: "en", Value: "Attestation Issuance"}},
+							ServiceStatus: "http://uri.etsi.org/19602/PubEAAProvidersList/SvcStatus/withdrawn",
+							ServiceDigitalIdentity: etsi119602.ServiceDigitalIdentity{
+								PublicKeyValues: []map[string]any{
+									{
+										"kty": "EC",
+										"crv": "P-256",
+										"x":   "f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",
+										"y":   "x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
 
+	dir := t.TempDir()
+	path := writeLoTE(t, dir, "lote.json", lote)
 	reg, err := New(Config{Sources: []string{path}})
 	require.NoError(t, err)
 
+	// Entity IS in the list, so resolution-only should succeed
 	resp, err := reg.Evaluate(context.Background(), &authzen.EvaluationRequest{
-		Subject:  authzen.Subject{Type: "key", ID: "https://withdrawn.example.com"},
-		Resource: authzen.Resource{Type: "jwk", ID: "https://withdrawn.example.com"},
+		Subject:  authzen.Subject{Type: "key", ID: "https://withdrawn-svc.example.com"},
+		Resource: authzen.Resource{ID: "https://withdrawn-svc.example.com"},
 	})
 	require.NoError(t, err)
-	assert.False(t, resp.Decision)
-	assert.Contains(t, resp.Context.Reason["admin"].(string), "withdrawn")
+	assert.True(t, resp.Decision, "entity should be resolvable even with withdrawn service")
+
+	// But key matching should fail — withdrawn service's keys are not indexed
+	resp, err = reg.Evaluate(context.Background(), &authzen.EvaluationRequest{
+		Subject: authzen.Subject{Type: "key", ID: "https://withdrawn-svc.example.com"},
+		Resource: authzen.Resource{
+			Type: "jwk",
+			ID:   "https://withdrawn-svc.example.com",
+			Key: []interface{}{
+				map[string]interface{}{
+					"kty": "EC",
+					"crv": "P-256",
+					"x":   "f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",
+					"y":   "x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",
+				},
+			},
+		},
+	})
+	require.NoError(t, err)
+	assert.False(t, resp.Decision, "withdrawn service's key should not match")
 }
 
 func TestEvaluate_UnknownEntity(t *testing.T) {
@@ -159,7 +226,6 @@ func TestEvaluate_ResolutionOnly(t *testing.T) {
 	reg, err := New(Config{Sources: []string{path}})
 	require.NoError(t, err)
 
-	// Resolution only: no resource type or key
 	resp, err := reg.Evaluate(context.Background(), &authzen.EvaluationRequest{
 		Subject:  authzen.Subject{Type: "key", ID: "https://issuer.example.com"},
 		Resource: authzen.Resource{ID: "https://issuer.example.com"},
@@ -226,18 +292,19 @@ func TestRefresh(t *testing.T) {
 
 	// Update the file with an additional entity
 	updated := testLoTE()
-	updated.TrustedEntities = append(updated.TrustedEntities, etsi119602.TrustedEntity{
-		EntityID:     "https://new.example.com",
-		EntityStatus: etsi119602.StatusGranted,
+	updated.TrustedEntitiesList = append(updated.TrustedEntitiesList, etsi119602.TrustedEntity{
+		TrustedEntityInformation: etsi119602.TrustedEntityInformation{
+			TEInformationURI: []etsi119602.NonEmptyMultiLangURI{
+				{Lang: "en", URIValue: "https://new.example.com"},
+			},
+		},
 	})
-	data, err := json.Marshal(updated)
+	data, err := updated.Marshal()
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(path, data, 0644))
 
-	// Refresh
 	require.NoError(t, reg.Refresh(context.Background()))
 
-	// Should now find the new entity
 	resp, err := reg.Evaluate(context.Background(), &authzen.EvaluationRequest{
 		Subject:  authzen.Subject{Type: "key", ID: "https://new.example.com"},
 		Resource: authzen.Resource{ID: "https://new.example.com"},
@@ -269,20 +336,8 @@ func TestInfo_LastUpdated(t *testing.T) {
 func TestMultipleSources(t *testing.T) {
 	dir := t.TempDir()
 
-	lote1 := &etsi119602.ListOfTrustedEntities{
-		Version:           "1.0",
-		SchemeInformation: etsi119602.SchemeInformation{Territory: "SE"},
-		TrustedEntities: []etsi119602.TrustedEntity{
-			{EntityID: "https://se.example.com", EntityStatus: etsi119602.StatusGranted},
-		},
-	}
-	lote2 := &etsi119602.ListOfTrustedEntities{
-		Version:           "1.0",
-		SchemeInformation: etsi119602.SchemeInformation{Territory: "NO"},
-		TrustedEntities: []etsi119602.TrustedEntity{
-			{EntityID: "https://no.example.com", EntityStatus: etsi119602.StatusGranted},
-		},
-	}
+	lote1 := minimalLoTE("SE", simpleEntity("https://se.example.com"))
+	lote2 := minimalLoTE("NO", simpleEntity("https://no.example.com"))
 
 	path1 := writeLoTE(t, dir, "se.json", lote1)
 	path2 := writeLoTE(t, dir, "no.json", lote2)
@@ -290,7 +345,6 @@ func TestMultipleSources(t *testing.T) {
 	reg, err := New(Config{Sources: []string{path1, path2}})
 	require.NoError(t, err)
 
-	// Both entities should be findable
 	for _, id := range []string{"https://se.example.com", "https://no.example.com"} {
 		resp, err := reg.Evaluate(context.Background(), &authzen.EvaluationRequest{
 			Subject:  authzen.Subject{Type: "key", ID: id},
@@ -303,7 +357,6 @@ func TestMultipleSources(t *testing.T) {
 
 // --- X.509 trust anchor / PKIX path validation tests ---
 
-// generateTestCA creates a self-signed CA certificate and key.
 func generateTestCA(t *testing.T) (*x509.Certificate, *ecdsa.PrivateKey) {
 	t.Helper()
 	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
@@ -326,7 +379,6 @@ func generateTestCA(t *testing.T) (*x509.Certificate, *ecdsa.PrivateKey) {
 	return caCert, caKey
 }
 
-// generateLeafCert creates a leaf certificate signed by the given CA.
 func generateLeafCert(t *testing.T, caCert *x509.Certificate, caKey *ecdsa.PrivateKey) *x509.Certificate {
 	t.Helper()
 	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
@@ -347,35 +399,65 @@ func generateLeafCert(t *testing.T, caCert *x509.Certificate, caKey *ecdsa.Priva
 	return leafCert
 }
 
-func TestEvaluate_X5C_TrustAnchor_PathValidation(t *testing.T) {
-	// Create a CA and a leaf cert signed by that CA
-	caCert, caKey := generateTestCA(t)
-	leafCert := generateLeafCert(t, caCert, caKey)
-
-	// Build a LoTE with the CA cert as a trust anchor
-	lote := &etsi119602.ListOfTrustedEntities{
-		Version:           "1.0",
-		SchemeInformation: etsi119602.SchemeInformation{Territory: "SE"},
-		TrustedEntities: []etsi119602.TrustedEntity{
+// x509Entity builds a TrustedEntity with an X.509 certificate as the service's digital identity.
+func x509Entity(id string, caCert *x509.Certificate) etsi119602.TrustedEntity {
+	return etsi119602.TrustedEntity{
+		TrustedEntityInformation: etsi119602.TrustedEntityInformation{
+			TEInformationURI: []etsi119602.NonEmptyMultiLangURI{
+				{Lang: "en", URIValue: id},
+			},
+		},
+		TrustedEntityServices: []etsi119602.TrustedEntityService{
 			{
-				EntityID:     "https://ca.example.com",
-				EntityStatus: etsi119602.StatusGranted,
-				DigitalIdentities: []etsi119602.DigitalIdentity{
-					{
-						Type:            "x509",
-						X509Certificate: base64.StdEncoding.EncodeToString(caCert.Raw),
+				ServiceInformation: etsi119602.ServiceInformation{
+					ServiceName: etsi119602.NameSet{{Lang: "en", Value: "CA Service"}},
+					ServiceDigitalIdentity: etsi119602.ServiceDigitalIdentity{
+						X509Certificates: []etsi119602.PKIOb{
+							{Val: base64.StdEncoding.EncodeToString(caCert.Raw)},
+						},
 					},
 				},
 			},
 		},
 	}
+}
+
+// minimalLoTE builds a minimal valid LoTE with the given territory and entities.
+func minimalLoTE(territory string, entities ...etsi119602.TrustedEntity) *etsi119602.ListOfTrustedEntities {
+	return &etsi119602.ListOfTrustedEntities{
+		ListAndSchemeInformation: etsi119602.ListAndSchemeInformation{
+			LoTEVersionIdentifier: 1,
+			SchemeTerritory:       territory,
+			SchemeOperatorName:    etsi119602.NameSet{{Lang: "en", Value: territory + " Op"}},
+			ListIssueDateTime:     "2026-01-01T00:00:00Z",
+			NextUpdate:            "2027-01-01T00:00:00Z",
+		},
+		TrustedEntitiesList: entities,
+	}
+}
+
+// simpleEntity builds a TrustedEntity with only a TEInformationURI (no services).
+func simpleEntity(id string) etsi119602.TrustedEntity {
+	return etsi119602.TrustedEntity{
+		TrustedEntityInformation: etsi119602.TrustedEntityInformation{
+			TEInformationURI: []etsi119602.NonEmptyMultiLangURI{
+				{Lang: "en", URIValue: id},
+			},
+		},
+	}
+}
+
+func TestEvaluate_X5C_TrustAnchor_PathValidation(t *testing.T) {
+	caCert, caKey := generateTestCA(t)
+	leafCert := generateLeafCert(t, caCert, caKey)
+
+	lote := minimalLoTE("SE", x509Entity("https://ca.example.com", caCert))
 
 	dir := t.TempDir()
 	path := writeLoTE(t, dir, "lote.json", lote)
 	reg, err := New(Config{Sources: []string{path}})
 	require.NoError(t, err)
 
-	// Present the LEAF cert (not the CA cert) — should validate via PKIX path
 	resp, err := reg.Evaluate(context.Background(), &authzen.EvaluationRequest{
 		Subject: authzen.Subject{Type: "key", ID: "https://ca.example.com"},
 		Resource: authzen.Resource{
@@ -393,32 +475,15 @@ func TestEvaluate_X5C_TrustAnchor_PathValidation(t *testing.T) {
 }
 
 func TestEvaluate_X5C_DirectMatch_SameCert(t *testing.T) {
-	// When the presented cert IS the entity's cert — direct key match
 	caCert, _ := generateTestCA(t)
 
-	lote := &etsi119602.ListOfTrustedEntities{
-		Version:           "1.0",
-		SchemeInformation: etsi119602.SchemeInformation{Territory: "SE"},
-		TrustedEntities: []etsi119602.TrustedEntity{
-			{
-				EntityID:     "https://ca.example.com",
-				EntityStatus: etsi119602.StatusGranted,
-				DigitalIdentities: []etsi119602.DigitalIdentity{
-					{
-						Type:            "x509",
-						X509Certificate: base64.StdEncoding.EncodeToString(caCert.Raw),
-					},
-				},
-			},
-		},
-	}
+	lote := minimalLoTE("SE", x509Entity("https://ca.example.com", caCert))
 
 	dir := t.TempDir()
 	path := writeLoTE(t, dir, "lote.json", lote)
 	reg, err := New(Config{Sources: []string{path}})
 	require.NoError(t, err)
 
-	// Present the SAME cert (the CA cert) — should match via direct key hash
 	resp, err := reg.Evaluate(context.Background(), &authzen.EvaluationRequest{
 		Subject: authzen.Subject{Type: "key", ID: "https://ca.example.com"},
 		Resource: authzen.Resource{
@@ -431,39 +496,21 @@ func TestEvaluate_X5C_DirectMatch_SameCert(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.True(t, resp.Decision)
-	// Should match via direct key hash, not path validation
 	assert.Contains(t, resp.Context.Reason["admin"].(string), "key matches")
 }
 
 func TestEvaluate_X5C_UntrustedChain(t *testing.T) {
-	// CA in the LoTE, but leaf signed by a DIFFERENT CA
 	caCert, _ := generateTestCA(t)
 	otherCA, otherCAKey := generateTestCA(t)
 	leafFromOther := generateLeafCert(t, otherCA, otherCAKey)
 
-	lote := &etsi119602.ListOfTrustedEntities{
-		Version:           "1.0",
-		SchemeInformation: etsi119602.SchemeInformation{Territory: "SE"},
-		TrustedEntities: []etsi119602.TrustedEntity{
-			{
-				EntityID:     "https://ca.example.com",
-				EntityStatus: etsi119602.StatusGranted,
-				DigitalIdentities: []etsi119602.DigitalIdentity{
-					{
-						Type:            "x509",
-						X509Certificate: base64.StdEncoding.EncodeToString(caCert.Raw),
-					},
-				},
-			},
-		},
-	}
+	lote := minimalLoTE("SE", x509Entity("https://ca.example.com", caCert))
 
 	dir := t.TempDir()
 	path := writeLoTE(t, dir, "lote.json", lote)
 	reg, err := New(Config{Sources: []string{path}})
 	require.NoError(t, err)
 
-	// Leaf signed by otherCA, but only caCert is in the LoTE
 	resp, err := reg.Evaluate(context.Background(), &authzen.EvaluationRequest{
 		Subject: authzen.Subject{Type: "key", ID: "https://ca.example.com"},
 		Resource: authzen.Resource{
@@ -480,13 +527,11 @@ func TestEvaluate_X5C_UntrustedChain(t *testing.T) {
 }
 
 func TestEvaluate_X5C_JWKEntity_NoPathValidation(t *testing.T) {
-	// Entity with only JWK identity — x5c request should fail (no cert pool)
 	dir := t.TempDir()
 	path := writeLoTE(t, dir, "lote.json", testLoTE())
 	reg, err := New(Config{Sources: []string{path}})
 	require.NoError(t, err)
 
-	// Use a random cert for the x5c key
 	caCert, _ := generateTestCA(t)
 
 	resp, err := reg.Evaluate(context.Background(), &authzen.EvaluationRequest{
@@ -525,7 +570,6 @@ func TestExtractStringSlice_StringSlice(t *testing.T) {
 }
 
 func TestExtractStringSlice_InterfaceSlice(t *testing.T) {
-	// Simulates JSON-unmarshaled data where []string becomes []interface{}
 	ctx := map[string]interface{}{
 		"credential_types": []interface{}{"eu.europa.ec.eudi.pid.1", "eu.europa.ec.eudi.mdl.1"},
 	}
@@ -534,7 +578,6 @@ func TestExtractStringSlice_InterfaceSlice(t *testing.T) {
 }
 
 func TestExtractStringSlice_MixedInterfaceSlice(t *testing.T) {
-	// Filters out non-string values
 	ctx := map[string]interface{}{
 		"credential_types": []interface{}{"eu.europa.ec.eudi.pid.1", 123, "eu.europa.ec.eudi.mdl.1", nil},
 	}
@@ -548,15 +591,12 @@ func TestExtractStringSlice_WrongType(t *testing.T) {
 	assert.Nil(t, result)
 }
 
-// Tests for credential_types in response
-
 func TestEvaluate_CredentialTypesInResponse(t *testing.T) {
 	dir := t.TempDir()
 	path := writeLoTE(t, dir, "lote.json", testLoTE())
 	reg, err := New(Config{Sources: []string{path}})
 	require.NoError(t, err)
 
-	// Request with credential_types in context (as would be injected by manager)
 	resp, err := reg.Evaluate(context.Background(), &authzen.EvaluationRequest{
 		Subject: authzen.Subject{Type: "key", ID: "https://issuer.example.com"},
 		Resource: authzen.Resource{
@@ -588,7 +628,6 @@ func TestEvaluate_NoCredentialTypesInContext(t *testing.T) {
 	reg, err := New(Config{Sources: []string{path}})
 	require.NoError(t, err)
 
-	// Request without credential_types in context
 	resp, err := reg.Evaluate(context.Background(), &authzen.EvaluationRequest{
 		Subject: authzen.Subject{Type: "key", ID: "https://issuer.example.com"},
 		Resource: authzen.Resource{
@@ -608,7 +647,6 @@ func TestEvaluate_NoCredentialTypesInContext(t *testing.T) {
 	assert.True(t, resp.Decision)
 	assert.NotNil(t, resp.Context)
 	assert.NotNil(t, resp.Context.Reason)
-	// Should not have requested_credential_types when not provided
 	_, hasCredTypes := resp.Context.Reason["requested_credential_types"]
 	assert.False(t, hasCredTypes)
 }
@@ -630,7 +668,6 @@ func TestNew_XMLSource(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, reg.Healthy())
 
-	// Entity from the XML LoTE should be findable
 	resp, err := reg.Evaluate(context.Background(), &authzen.EvaluationRequest{
 		Subject:  authzen.Subject{Type: "key", ID: "https://issuer.example.com"},
 		Resource: authzen.Resource{ID: "https://issuer.example.com"},
@@ -668,20 +705,8 @@ func TestNew_XMLSource_JWKMatch(t *testing.T) {
 func TestNew_MixedJSONAndXMLSources(t *testing.T) {
 	dir := t.TempDir()
 
-	lote1 := &etsi119602.ListOfTrustedEntities{
-		Version:           "1.0",
-		SchemeInformation: etsi119602.SchemeInformation{Territory: "SE"},
-		TrustedEntities: []etsi119602.TrustedEntity{
-			{EntityID: "https://se.example.com", EntityStatus: etsi119602.StatusGranted},
-		},
-	}
-	lote2 := &etsi119602.ListOfTrustedEntities{
-		Version:           "1.0",
-		SchemeInformation: etsi119602.SchemeInformation{Territory: "NO"},
-		TrustedEntities: []etsi119602.TrustedEntity{
-			{EntityID: "https://no.example.com", EntityStatus: etsi119602.StatusGranted},
-		},
-	}
+	lote1 := minimalLoTE("SE", simpleEntity("https://se.example.com"))
+	lote2 := minimalLoTE("NO", simpleEntity("https://no.example.com"))
 
 	jsonPath := writeLoTE(t, dir, "se.json", lote1)
 	xmlPath := writeLoTEXML(t, dir, "no.xml", lote2)
@@ -703,44 +728,46 @@ func TestNew_MixedJSONAndXMLSources(t *testing.T) {
 
 func writeLoTL(t *testing.T, dir, name string, lotl *etsi119602.ListOfTrustedLists) string {
 	t.Helper()
-	data, err := json.Marshal(lotl)
+	data, err := lotl.MarshalLoTL()
 	require.NoError(t, err)
 	path := filepath.Join(dir, name)
 	require.NoError(t, os.WriteFile(path, data, 0644))
 	return path
 }
 
+// lotlPointer builds an OtherLoTEPointer with the given location and qualifier type.
+func lotlPointer(location, schemeType, territory string) etsi119602.OtherLoTEPointer {
+	return etsi119602.OtherLoTEPointer{
+		LoTELocation: location,
+		LoTEQualifiers: []etsi119602.LoTEQualifier{
+			{
+				LoTEType:        schemeType,
+				SchemeTerritory: territory,
+			},
+		},
+	}
+}
+
 func TestNew_LoTLSource(t *testing.T) {
 	dir := t.TempDir()
 
-	// Create two LoTEs
-	lote1 := &etsi119602.ListOfTrustedEntities{
-		Version:           "1.0",
-		SchemeInformation: etsi119602.SchemeInformation{Territory: "SE"},
-		TrustedEntities: []etsi119602.TrustedEntity{
-			{EntityID: "https://se-pid.example.com", EntityStatus: etsi119602.StatusGranted},
-		},
-	}
-	lote2 := &etsi119602.ListOfTrustedEntities{
-		Version:           "1.0",
-		SchemeInformation: etsi119602.SchemeInformation{Territory: "DE"},
-		TrustedEntities: []etsi119602.TrustedEntity{
-			{EntityID: "https://de-pid.example.com", EntityStatus: etsi119602.StatusGranted},
-		},
-	}
+	lote1 := minimalLoTE("SE", simpleEntity("https://se-pid.example.com"))
+	lote2 := minimalLoTE("DE", simpleEntity("https://de-pid.example.com"))
 	path1 := writeLoTE(t, dir, "se-pid.json", lote1)
 	path2 := writeLoTE(t, dir, "de-pid.json", lote2)
 
-	// Create a LoTL pointing to both LoTEs
 	lotl := &etsi119602.ListOfTrustedLists{
-		Version: "1.0",
-		SchemeInformation: etsi119602.SchemeInformation{
-			Territory:  "EU",
-			SchemeType: etsi119602.LoTLTypeEU,
-		},
-		PointersToOtherLoTEs: []etsi119602.LoTEPointer{
-			{Location: path1, SchemeTerritory: "SE", SchemeType: etsi119602.LoTETypePIDProviders},
-			{Location: path2, SchemeTerritory: "DE", SchemeType: etsi119602.LoTETypePIDProviders},
+		ListAndSchemeInformation: etsi119602.ListAndSchemeInformation{
+			LoTEVersionIdentifier: 1,
+			SchemeTerritory:       "EU",
+			LoTEType:              etsi119602.LoTLTypeEU,
+			SchemeOperatorName:    etsi119602.NameSet{{Lang: "en", Value: "EU Commission"}},
+			ListIssueDateTime:     "2026-01-01T00:00:00Z",
+			NextUpdate:            "2027-01-01T00:00:00Z",
+			PointersToOtherLoTE: []etsi119602.OtherLoTEPointer{
+				lotlPointer(path1, etsi119602.LoTETypePIDProviders, "SE"),
+				lotlPointer(path2, etsi119602.LoTETypePIDProviders, "DE"),
+			},
 		},
 	}
 	lotlPath := writeLoTL(t, dir, "eu-lotl.json", lotl)
@@ -749,7 +776,6 @@ func TestNew_LoTLSource(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, reg.Healthy())
 
-	// Both entities from the LoTL-referenced LoTEs should be discoverable
 	for _, id := range []string{"https://se-pid.example.com", "https://de-pid.example.com"} {
 		resp, err := reg.Evaluate(context.Background(), &authzen.EvaluationRequest{
 			Subject:  authzen.Subject{Type: "key", ID: id},
@@ -763,31 +789,23 @@ func TestNew_LoTLSource(t *testing.T) {
 func TestNew_LoTLAndDirectSources(t *testing.T) {
 	dir := t.TempDir()
 
-	// Direct LoTE source
-	directLoTE := &etsi119602.ListOfTrustedEntities{
-		Version:           "1.0",
-		SchemeInformation: etsi119602.SchemeInformation{Territory: "SE"},
-		TrustedEntities: []etsi119602.TrustedEntity{
-			{EntityID: "https://direct.example.com", EntityStatus: etsi119602.StatusGranted},
-		},
-	}
+	directLoTE := minimalLoTE("SE", simpleEntity("https://direct.example.com"))
 	directPath := writeLoTE(t, dir, "direct.json", directLoTE)
 
-	// LoTL-referenced LoTE
-	lotlLoTE := &etsi119602.ListOfTrustedEntities{
-		Version:           "1.0",
-		SchemeInformation: etsi119602.SchemeInformation{Territory: "DE"},
-		TrustedEntities: []etsi119602.TrustedEntity{
-			{EntityID: "https://via-lotl.example.com", EntityStatus: etsi119602.StatusGranted},
-		},
-	}
+	lotlLoTE := minimalLoTE("DE", simpleEntity("https://via-lotl.example.com"))
 	lotlLotePath := writeLoTE(t, dir, "via-lotl.json", lotlLoTE)
 
 	lotl := &etsi119602.ListOfTrustedLists{
-		Version:           "1.0",
-		SchemeInformation: etsi119602.SchemeInformation{Territory: "EU", SchemeType: etsi119602.LoTLTypeEU},
-		PointersToOtherLoTEs: []etsi119602.LoTEPointer{
-			{Location: lotlLotePath, SchemeType: etsi119602.LoTETypePIDProviders},
+		ListAndSchemeInformation: etsi119602.ListAndSchemeInformation{
+			LoTEVersionIdentifier: 1,
+			SchemeTerritory:       "EU",
+			LoTEType:              etsi119602.LoTLTypeEU,
+			SchemeOperatorName:    etsi119602.NameSet{{Lang: "en", Value: "EU"}},
+			ListIssueDateTime:     "2026-01-01T00:00:00Z",
+			NextUpdate:            "2027-01-01T00:00:00Z",
+			PointersToOtherLoTE: []etsi119602.OtherLoTEPointer{
+				lotlPointer(lotlLotePath, etsi119602.LoTETypePIDProviders, "DE"),
+			},
 		},
 	}
 	lotlPath := writeLoTL(t, dir, "lotl.json", lotl)
@@ -798,7 +816,6 @@ func TestNew_LoTLAndDirectSources(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	// Both direct and LoTL-discovered entities should be found
 	for _, id := range []string{"https://direct.example.com", "https://via-lotl.example.com"} {
 		resp, err := reg.Evaluate(context.Background(), &authzen.EvaluationRequest{
 			Subject:  authzen.Subject{Type: "key", ID: id},
@@ -812,32 +829,35 @@ func TestNew_LoTLAndDirectSources(t *testing.T) {
 func TestNew_NestedLoTL(t *testing.T) {
 	dir := t.TempDir()
 
-	// Leaf LoTE
-	lote := &etsi119602.ListOfTrustedEntities{
-		Version:           "1.0",
-		SchemeInformation: etsi119602.SchemeInformation{Territory: "SE"},
-		TrustedEntities: []etsi119602.TrustedEntity{
-			{EntityID: "https://nested.example.com", EntityStatus: etsi119602.StatusGranted},
-		},
-	}
+	lote := minimalLoTE("SE", simpleEntity("https://nested.example.com"))
 	lotePath := writeLoTE(t, dir, "lote.json", lote)
 
-	// Inner LoTL pointing to the LoTE
 	innerLoTL := &etsi119602.ListOfTrustedLists{
-		Version:           "1.0",
-		SchemeInformation: etsi119602.SchemeInformation{Territory: "SE", SchemeType: etsi119602.LoTLTypeEU},
-		PointersToOtherLoTEs: []etsi119602.LoTEPointer{
-			{Location: lotePath, SchemeType: etsi119602.LoTETypePIDProviders},
+		ListAndSchemeInformation: etsi119602.ListAndSchemeInformation{
+			LoTEVersionIdentifier: 1,
+			SchemeTerritory:       "SE",
+			LoTEType:              etsi119602.LoTLTypeEU,
+			SchemeOperatorName:    etsi119602.NameSet{{Lang: "en", Value: "SE"}},
+			ListIssueDateTime:     "2026-01-01T00:00:00Z",
+			NextUpdate:            "2027-01-01T00:00:00Z",
+			PointersToOtherLoTE: []etsi119602.OtherLoTEPointer{
+				lotlPointer(lotePath, etsi119602.LoTETypePIDProviders, "SE"),
+			},
 		},
 	}
 	innerPath := writeLoTL(t, dir, "inner-lotl.json", innerLoTL)
 
-	// Outer LoTL pointing to the inner LoTL
 	outerLoTL := &etsi119602.ListOfTrustedLists{
-		Version:           "1.0",
-		SchemeInformation: etsi119602.SchemeInformation{Territory: "EU", SchemeType: etsi119602.LoTLTypeEU},
-		PointersToOtherLoTEs: []etsi119602.LoTEPointer{
-			{Location: innerPath, SchemeType: etsi119602.LoTLTypeEU},
+		ListAndSchemeInformation: etsi119602.ListAndSchemeInformation{
+			LoTEVersionIdentifier: 1,
+			SchemeTerritory:       "EU",
+			LoTEType:              etsi119602.LoTLTypeEU,
+			SchemeOperatorName:    etsi119602.NameSet{{Lang: "en", Value: "EU"}},
+			ListIssueDateTime:     "2026-01-01T00:00:00Z",
+			NextUpdate:            "2027-01-01T00:00:00Z",
+			PointersToOtherLoTE: []etsi119602.OtherLoTEPointer{
+				lotlPointer(innerPath, etsi119602.LoTLTypeEU, "SE"),
+			},
 		},
 	}
 	outerPath := writeLoTL(t, dir, "outer-lotl.json", outerLoTL)
@@ -856,36 +876,39 @@ func TestNew_NestedLoTL(t *testing.T) {
 func TestNew_LoTLDepthLimit(t *testing.T) {
 	dir := t.TempDir()
 
-	// Leaf LoTE
-	lote := &etsi119602.ListOfTrustedEntities{
-		Version:           "1.0",
-		SchemeInformation: etsi119602.SchemeInformation{Territory: "SE"},
-		TrustedEntities: []etsi119602.TrustedEntity{
-			{EntityID: "https://deep.example.com", EntityStatus: etsi119602.StatusGranted},
-		},
-	}
+	lote := minimalLoTE("SE", simpleEntity("https://deep.example.com"))
 	lotePath := writeLoTE(t, dir, "lote.json", lote)
 
-	// Create a chain: depth-2 → depth-1 → lote
 	depth1 := &etsi119602.ListOfTrustedLists{
-		Version:           "1.0",
-		SchemeInformation: etsi119602.SchemeInformation{Territory: "SE", SchemeType: etsi119602.LoTLTypeEU},
-		PointersToOtherLoTEs: []etsi119602.LoTEPointer{
-			{Location: lotePath, SchemeType: etsi119602.LoTETypePIDProviders},
+		ListAndSchemeInformation: etsi119602.ListAndSchemeInformation{
+			LoTEVersionIdentifier: 1,
+			SchemeTerritory:       "SE",
+			LoTEType:              etsi119602.LoTLTypeEU,
+			SchemeOperatorName:    etsi119602.NameSet{{Lang: "en", Value: "SE"}},
+			ListIssueDateTime:     "2026-01-01T00:00:00Z",
+			NextUpdate:            "2027-01-01T00:00:00Z",
+			PointersToOtherLoTE: []etsi119602.OtherLoTEPointer{
+				lotlPointer(lotePath, etsi119602.LoTETypePIDProviders, "SE"),
+			},
 		},
 	}
 	depth1Path := writeLoTL(t, dir, "depth1.json", depth1)
 
 	depth2 := &etsi119602.ListOfTrustedLists{
-		Version:           "1.0",
-		SchemeInformation: etsi119602.SchemeInformation{Territory: "EU", SchemeType: etsi119602.LoTLTypeEU},
-		PointersToOtherLoTEs: []etsi119602.LoTEPointer{
-			{Location: depth1Path, SchemeType: etsi119602.LoTLTypeEU},
+		ListAndSchemeInformation: etsi119602.ListAndSchemeInformation{
+			LoTEVersionIdentifier: 1,
+			SchemeTerritory:       "EU",
+			LoTEType:              etsi119602.LoTLTypeEU,
+			SchemeOperatorName:    etsi119602.NameSet{{Lang: "en", Value: "EU"}},
+			ListIssueDateTime:     "2026-01-01T00:00:00Z",
+			NextUpdate:            "2027-01-01T00:00:00Z",
+			PointersToOtherLoTE: []etsi119602.OtherLoTEPointer{
+				lotlPointer(depth1Path, etsi119602.LoTLTypeEU, "SE"),
+			},
 		},
 	}
 	depth2Path := writeLoTL(t, dir, "depth2.json", depth2)
 
-	// With MaxDereferenceDepth=1, nested LoTL at depth 1 should be cut off
 	reg, err := New(Config{
 		LoTLSources:         []string{depth2Path},
 		MaxDereferenceDepth: 1,
@@ -897,7 +920,6 @@ func TestNew_LoTLDepthLimit(t *testing.T) {
 		Resource: authzen.Resource{ID: "https://deep.example.com"},
 	})
 	require.NoError(t, err)
-	// The entity should NOT be found because the nested LoTL was depth-limited
 	assert.False(t, resp.Decision, "should NOT find entity beyond depth limit")
 }
 
@@ -905,16 +927,21 @@ func TestNew_LoTLWithEmptyPointer(t *testing.T) {
 	dir := t.TempDir()
 
 	lotl := &etsi119602.ListOfTrustedLists{
-		Version:           "1.0",
-		SchemeInformation: etsi119602.SchemeInformation{Territory: "EU", SchemeType: etsi119602.LoTLTypeEU},
-		PointersToOtherLoTEs: []etsi119602.LoTEPointer{
-			{Location: ""},                  // empty location — should be skipped
-			{Location: "/nonexistent.json"}, // bad path — should warn and continue
+		ListAndSchemeInformation: etsi119602.ListAndSchemeInformation{
+			LoTEVersionIdentifier: 1,
+			SchemeTerritory:       "EU",
+			LoTEType:              etsi119602.LoTLTypeEU,
+			SchemeOperatorName:    etsi119602.NameSet{{Lang: "en", Value: "EU"}},
+			ListIssueDateTime:     "2026-01-01T00:00:00Z",
+			NextUpdate:            "2027-01-01T00:00:00Z",
+			PointersToOtherLoTE: []etsi119602.OtherLoTEPointer{
+				{LoTELocation: ""},                  // empty location — should be skipped
+				{LoTELocation: "/nonexistent.json"}, // bad path — should warn and continue
+			},
 		},
 	}
 	lotlPath := writeLoTL(t, dir, "lotl.json", lotl)
 
-	// Should succeed even though pointers fail — just loads zero entities
 	reg, err := New(Config{LoTLSources: []string{lotlPath}})
 	require.NoError(t, err)
 	assert.True(t, reg.Healthy())
@@ -923,25 +950,24 @@ func TestNew_LoTLWithEmptyPointer(t *testing.T) {
 func TestNew_LoTLOnlyNoDirectSources(t *testing.T) {
 	dir := t.TempDir()
 
-	lote := &etsi119602.ListOfTrustedEntities{
-		Version:           "1.0",
-		SchemeInformation: etsi119602.SchemeInformation{Territory: "SE"},
-		TrustedEntities: []etsi119602.TrustedEntity{
-			{EntityID: "https://lotl-only.example.com", EntityStatus: etsi119602.StatusGranted},
-		},
-	}
+	lote := minimalLoTE("SE", simpleEntity("https://lotl-only.example.com"))
 	lotePath := writeLoTE(t, dir, "lote.json", lote)
 
 	lotl := &etsi119602.ListOfTrustedLists{
-		Version:           "1.0",
-		SchemeInformation: etsi119602.SchemeInformation{Territory: "EU", SchemeType: etsi119602.LoTLTypeEU},
-		PointersToOtherLoTEs: []etsi119602.LoTEPointer{
-			{Location: lotePath, SchemeType: etsi119602.LoTETypePIDProviders},
+		ListAndSchemeInformation: etsi119602.ListAndSchemeInformation{
+			LoTEVersionIdentifier: 1,
+			SchemeTerritory:       "EU",
+			LoTEType:              etsi119602.LoTLTypeEU,
+			SchemeOperatorName:    etsi119602.NameSet{{Lang: "en", Value: "EU"}},
+			ListIssueDateTime:     "2026-01-01T00:00:00Z",
+			NextUpdate:            "2027-01-01T00:00:00Z",
+			PointersToOtherLoTE: []etsi119602.OtherLoTEPointer{
+				lotlPointer(lotePath, etsi119602.LoTETypePIDProviders, "SE"),
+			},
 		},
 	}
 	lotlPath := writeLoTL(t, dir, "lotl.json", lotl)
 
-	// No Sources, only LoTLSources
 	reg, err := New(Config{LoTLSources: []string{lotlPath}})
 	require.NoError(t, err)
 	assert.True(t, reg.Healthy())
@@ -957,43 +983,45 @@ func TestNew_LoTLOnlyNoDirectSources(t *testing.T) {
 func TestNew_LoTLCycleDetection(t *testing.T) {
 	dir := t.TempDir()
 
-	// Create a LoTE that we'll actually discover
-	lote := &etsi119602.ListOfTrustedEntities{
-		Version:           "1.0",
-		SchemeInformation: etsi119602.SchemeInformation{Territory: "SE"},
-		TrustedEntities: []etsi119602.TrustedEntity{
-			{EntityID: "https://cycle.example.com", EntityStatus: etsi119602.StatusGranted},
-		},
-	}
+	lote := minimalLoTE("SE", simpleEntity("https://cycle.example.com"))
 	lotePath := writeLoTE(t, dir, "lote.json", lote)
 
-	// Create two LoTLs that point to each other (cycle: A → B → A)
-	// Also have A point to the LoTE so we can verify resolution completes.
 	lotlAPath := filepath.Join(dir, "lotl-a.json")
 	lotlBPath := filepath.Join(dir, "lotl-b.json")
 
 	lotlA := &etsi119602.ListOfTrustedLists{
-		Version:           "1.0",
-		SchemeInformation: etsi119602.SchemeInformation{Territory: "EU", SchemeType: etsi119602.LoTLTypeEU},
-		PointersToOtherLoTEs: []etsi119602.LoTEPointer{
-			{Location: lotePath, SchemeType: etsi119602.LoTETypePIDProviders},
-			{Location: lotlBPath, SchemeType: etsi119602.LoTLTypeEU},
+		ListAndSchemeInformation: etsi119602.ListAndSchemeInformation{
+			LoTEVersionIdentifier: 1,
+			SchemeTerritory:       "EU",
+			LoTEType:              etsi119602.LoTLTypeEU,
+			SchemeOperatorName:    etsi119602.NameSet{{Lang: "en", Value: "EU"}},
+			ListIssueDateTime:     "2026-01-01T00:00:00Z",
+			NextUpdate:            "2027-01-01T00:00:00Z",
+			PointersToOtherLoTE: []etsi119602.OtherLoTEPointer{
+				lotlPointer(lotePath, etsi119602.LoTETypePIDProviders, "SE"),
+				lotlPointer(lotlBPath, etsi119602.LoTLTypeEU, "EU"),
+			},
 		},
 	}
 	lotlB := &etsi119602.ListOfTrustedLists{
-		Version:           "1.0",
-		SchemeInformation: etsi119602.SchemeInformation{Territory: "EU", SchemeType: etsi119602.LoTLTypeEU},
-		PointersToOtherLoTEs: []etsi119602.LoTEPointer{
-			{Location: lotlAPath, SchemeType: etsi119602.LoTLTypeEU},
+		ListAndSchemeInformation: etsi119602.ListAndSchemeInformation{
+			LoTEVersionIdentifier: 1,
+			SchemeTerritory:       "EU",
+			LoTEType:              etsi119602.LoTLTypeEU,
+			SchemeOperatorName:    etsi119602.NameSet{{Lang: "en", Value: "EU B"}},
+			ListIssueDateTime:     "2026-01-01T00:00:00Z",
+			NextUpdate:            "2027-01-01T00:00:00Z",
+			PointersToOtherLoTE: []etsi119602.OtherLoTEPointer{
+				lotlPointer(lotlAPath, etsi119602.LoTLTypeEU, "EU"),
+			},
 		},
 	}
 
-	dataA, _ := json.Marshal(lotlA)
-	dataB, _ := json.Marshal(lotlB)
+	dataA, _ := lotlA.MarshalLoTL()
+	dataB, _ := lotlB.MarshalLoTL()
 	require.NoError(t, os.WriteFile(lotlAPath, dataA, 0644))
 	require.NoError(t, os.WriteFile(lotlBPath, dataB, 0644))
 
-	// Should complete without infinite recursion and find the LoTE
 	reg, err := New(Config{LoTLSources: []string{lotlAPath}})
 	require.NoError(t, err)
 	assert.True(t, reg.Healthy())
@@ -1004,4 +1032,40 @@ func TestNew_LoTLCycleDetection(t *testing.T) {
 	})
 	require.NoError(t, err)
 	assert.True(t, resp.Decision, "should find entity despite LoTL cycle")
+}
+
+// --- Entity ID derivation tests ---
+
+func TestEntityID_FromTEInformationURI(t *testing.T) {
+	ent := etsi119602.TrustedEntity{
+		TrustedEntityInformation: etsi119602.TrustedEntityInformation{
+			TEName: etsi119602.NameSet{{Lang: "en", Value: "Some Name"}},
+			TEInformationURI: []etsi119602.NonEmptyMultiLangURI{
+				{Lang: "en", URIValue: "https://entity.example.com"},
+			},
+		},
+	}
+	assert.Equal(t, "https://entity.example.com", entityID(ent))
+}
+
+func TestEntityID_FallbackToName(t *testing.T) {
+	ent := etsi119602.TrustedEntity{
+		TrustedEntityInformation: etsi119602.TrustedEntityInformation{
+			TEName: etsi119602.NameSet{{Lang: "en", Value: "Fallback Name"}},
+		},
+	}
+	assert.Equal(t, "Fallback Name", entityID(ent))
+}
+
+func TestEntityID_Empty(t *testing.T) {
+	ent := etsi119602.TrustedEntity{}
+	assert.Equal(t, "", entityID(ent))
+}
+
+func TestIsWithdrawnStatus(t *testing.T) {
+	assert.False(t, isWithdrawnStatus(""))
+	assert.False(t, isWithdrawnStatus("http://uri.etsi.org/19602/PubEAAProvidersList/SvcStatus/notified"))
+	assert.True(t, isWithdrawnStatus("http://uri.etsi.org/19602/PubEAAProvidersList/SvcStatus/withdrawn"))
+	assert.True(t, isWithdrawnStatus("http://uri.etsi.org/TrstSvc/TrustedList/Svcstatus/withdrawn"))
+	assert.True(t, isWithdrawnStatus(etsi119602.StatusWithdrawn))
 }


### PR DESCRIPTION
## Summary

Adds XML format support for LoTE documents and LoTL (List of Trusted Lists) cascading resolution to the LoTE registry.

Closes #33  
Closes #34

## Changes

### XML LoTE Support (#33)
- Bumped g119612 to v0.3.0 which provides `FetchLoTE()` with JSON/XML auto-detection based on file extension and content type
- LoTE registry `Sources` now accept both JSON and XML format — no configuration changes needed for existing users
- Updated package documentation to reflect XML support

### LoTL Cascading Resolution (#34)
- New `LoTLSources` config field: accepts LoTL document URLs/paths
- LoTL pointers (`PointersToOtherLoTEs`) are followed to discover individual LoTEs automatically
- Nested LoTL resolution: when a pointer has a LoTL scheme type, it's resolved recursively
- Configurable depth limiting via `MaxDereferenceDepth` (0 = unlimited)
- Failed pointer fetches are logged as warnings and skipped (doesn't fail the whole load)
- Integrated with existing refresh loop for periodic re-fetch
- Registry can be configured with `lotl_sources` only (no direct `sources` required)

### Config & Wiring
- Added `lotl_sources`, `max_dereference_depth` to `LoTERegistryConfig` YAML config
- Wired through `cmd/gt/main.go`
- Added documented LoTE registry section to `example/config.yaml`

## Testing
- 12 new tests covering:
  - XML LoTE loading and JWK key matching
  - Mixed JSON + XML sources
  - LoTL resolution with pointer following
  - Combined direct sources + LoTL sources
  - Nested LoTL resolution
  - Depth limit enforcement
  - Error handling (empty pointers, bad paths)
  - LoTL-only configuration (no direct sources)
- All existing tests pass, golangci-lint clean