### PR TITLE
fix(lote): implement ETSI TS 119 602 profile-based status checking

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -15,6 +15,10 @@ jobs:
   sonarcloud:
     name: SonarCloud Scan
     runs-on: ubuntu-latest
+    # Skip on fork PRs: GitHub does not pass secrets (including SONAR_TOKEN) to
+    # pull_request workflows triggered from forks. Analysis still runs on push to
+    # main and on PRs opened from within the same repository.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/checkout@v7
         with:

--- a/pkg/registry/lote/registry.go
+++ b/pkg/registry/lote/registry.go
@@ -81,13 +81,28 @@ type entityIndex struct {
 
 // indexedEntity holds a single entity and its precomputed key hashes.
 type indexedEntity struct {
-	entity    etsi119602.TrustedEntity
-	entityID  string
-	territory string
-	keyHashes map[string]bool // SHA-256 fingerprints of all digital identities
+	entity     etsi119602.TrustedEntity
+	entityID   string
+	territory  string
+	schemeType string          // LoTE schemeType URI (determines status checking behavior)
+	keyHashes  map[string]bool // SHA-256 fingerprints of all digital identities
 	// certPool contains X.509 certificates from this entity's digital identities,
 	// used as trust anchors for PKIX path validation of x5c requests.
 	certPool *x509.CertPool
+}
+
+// Pub-EAA service status URI for "notified" (trusted) status.
+const pubEAAStatusNotified = "http://uri.etsi.org/19602/PubEAAProvidersList/SvcStatus/notified"
+
+// hasNotifiedService checks if a Pub-EAA entity has at least one service with "notified" status.
+// Per ETSI TS 119 602 Annex H, Pub-EAA services must have explicit ServiceStatus.
+func hasNotifiedService(entity etsi119602.TrustedEntity) bool {
+	for _, svc := range entity.TrustedEntityServices {
+		if svc.ServiceInformation.ServiceStatus == pubEAAStatusNotified {
+			return true
+		}
+	}
+	return false
 }
 
 var _ registry.TrustRegistry = (*Registry)(nil)
@@ -182,8 +197,26 @@ func (r *Registry) Evaluate(_ context.Context, req *authzen.EvaluationRequest) (
 		}, nil
 	}
 
-	// Per ETSI TS 119 602-1: presence in the list = trusted (no entity-level status).
-	// Withdrawn services are excluded during indexing.
+	// Check trust status based on LoTE profile type (ETSI TS 119 602 compliance).
+	// - Pub-EAA (Annex H): ServiceStatus is mandatory, check at service level
+	// - All other profiles (PID, Wallet, WRPAC, WRPRC, Registrars): presence in list = trusted
+	// Withdrawn services are excluded during indexing for all profiles.
+	if etsi119602.IsPubEAASchemeType(ent.schemeType) {
+		// Pub-EAA requires explicit service status check
+		if !hasNotifiedService(ent.entity) {
+			reason := map[string]interface{}{
+				"admin": fmt.Sprintf("entity %q has no service with 'notified' status", subjectID),
+			}
+			addCredentialTypesToReason(reason, credentialTypes)
+			return &authzen.EvaluationResponse{
+				Decision: false,
+				Context: &authzen.EvaluationResponseContext{
+					Reason: reason,
+				},
+			}, nil
+		}
+	}
+	// For non-Pub-EAA profiles: presence in list means trusted (no status check needed)
 
 	// Resolution-only: no key check needed.
 	if req.IsResolutionOnlyRequest() {
@@ -426,13 +459,15 @@ func buildIndex(lotes []*etsi119602.ListOfTrustedEntities, ext *cryptoutil.Exten
 
 	for _, lote := range lotes {
 		territory := lote.ListAndSchemeInformation.SchemeTerritory
+		schemeType := lote.ListAndSchemeInformation.LoTEType
 		for _, ent := range lote.TrustedEntitiesList {
 			id := entityID(ent)
 			ie := &indexedEntity{
-				entity:    ent,
-				entityID:  id,
-				territory: territory,
-				keyHashes: make(map[string]bool),
+				entity:     ent,
+				entityID:   id,
+				territory:  territory,
+				schemeType: schemeType,
+				keyHashes:  make(map[string]bool),
 			}
 
 			// Index service digital identities; skip withdrawn services.

--- a/pkg/registry/lote/registry.go
+++ b/pkg/registry/lote/registry.go
@@ -633,6 +633,7 @@ func buildIndex(lotes []*etsi119602.ListOfTrustedEntities, ext *cryptoutil.Exten
 	for _, lote := range lotes {
 		territory := lote.ListAndSchemeInformation.SchemeTerritory
 		schemeType := lote.ListAndSchemeInformation.LoTEType
+		isPubEAA := etsi119602.IsPubEAASchemeType(schemeType)
 		for _, ent := range lote.TrustedEntitiesList {
 			id := entityID(ent)
 			ie := &indexedEntity{
@@ -643,10 +644,23 @@ func buildIndex(lotes []*etsi119602.ListOfTrustedEntities, ext *cryptoutil.Exten
 				keyHashes:  make(map[string]bool),
 			}
 
-			// Index service digital identities; skip withdrawn services.
+			// Index service digital identities.
+			// - Non-Pub-EAA LoTEs: skip withdrawn services only (presence = trusted).
+			// - Pub-EAA LoTEs (ETSI TS 119 602 Annex H): only index services with
+			//   an explicit "notified" status. Services with absent, withdrawn, or
+			//   any other status are excluded so that a key from a non-notified
+			//   service is never reachable through the index even when the entity
+			//   also has a notified service.
 			for _, svc := range ent.TrustedEntityServices {
-				if isWithdrawnStatus(svc.ServiceInformation.ServiceStatus) {
-					continue
+				status := svc.ServiceInformation.ServiceStatus
+				if isPubEAA {
+					if status != pubEAAStatusNotified {
+						continue
+					}
+				} else {
+					if isWithdrawnStatus(status) {
+						continue
+					}
 				}
 				sdi := svc.ServiceInformation.ServiceDigitalIdentity
 				hashes := hashServiceDigitalIdentity(sdi, ext)

--- a/pkg/registry/lote/registry_test.go
+++ b/pkg/registry/lote/registry_test.go
@@ -1114,3 +1114,194 @@ func TestBuildIndex_ImplicitTrust(t *testing.T) {
 	// Service key should be indexed
 	assert.NotEmpty(t, idx.byKeyHash, "service keys should be indexed when ServiceStatus is absent")
 }
+
+// TestEvaluate_PubEAA_NotifiedService verifies that Pub-EAA entities with
+// a "notified" service status are trusted.
+func TestEvaluate_PubEAA_NotifiedService(t *testing.T) {
+	lote := &etsi119602.ListOfTrustedEntities{
+		ListAndSchemeInformation: etsi119602.ListAndSchemeInformation{
+			LoTEVersionIdentifier: 1,
+			LoTEType:              etsi119602.LoTETypePubEAAProviders, // Pub-EAA profile
+			SchemeTerritory:       "SE",
+			SchemeOperatorName:    etsi119602.NameSet{{Lang: "en", Value: "Test"}},
+			ListIssueDateTime:     "2026-01-01T00:00:00Z",
+			NextUpdate:            "2027-01-01T00:00:00Z",
+		},
+		TrustedEntitiesList: []etsi119602.TrustedEntity{
+			{
+				TrustedEntityInformation: etsi119602.TrustedEntityInformation{
+					TEName:           etsi119602.NameSet{{Lang: "en", Value: "Pub-EAA Provider"}},
+					TEInformationURI: []etsi119602.NonEmptyMultiLangURI{{Lang: "en", URIValue: "https://pubeaa-notified.example.com"}},
+				},
+				TrustedEntityServices: []etsi119602.TrustedEntityService{
+					{
+						ServiceInformation: etsi119602.ServiceInformation{
+							ServiceName:           etsi119602.NameSet{{Lang: "en", Value: "PubEAA Issuance"}},
+							ServiceTypeIdentifier: "http://uri.etsi.org/19602/SvcType/PubEAA/Issuance",
+							ServiceStatus:         "http://uri.etsi.org/19602/PubEAAProvidersList/SvcStatus/notified",
+							ServiceDigitalIdentity: etsi119602.ServiceDigitalIdentity{
+								PublicKeyValues: []map[string]any{
+									{"kty": "EC", "crv": "P-256", "x": "f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU", "y": "x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	dir := t.TempDir()
+	path := writeLoTE(t, dir, "lote.json", lote)
+	reg, err := New(Config{Sources: []string{path}})
+	require.NoError(t, err)
+
+	// Resolution-only should succeed for notified Pub-EAA entity
+	resp, err := reg.Evaluate(context.Background(), &authzen.EvaluationRequest{
+		Subject:  authzen.Subject{Type: "key", ID: "https://pubeaa-notified.example.com"},
+		Resource: authzen.Resource{ID: "https://pubeaa-notified.example.com"},
+	})
+	require.NoError(t, err)
+	assert.True(t, resp.Decision, "Pub-EAA entity with notified service should be trusted")
+}
+
+// TestEvaluate_PubEAA_NoNotifiedService verifies that Pub-EAA entities without
+// any "notified" service status are NOT trusted (per ETSI TS 119 602 Annex H).
+func TestEvaluate_PubEAA_NoNotifiedService(t *testing.T) {
+	lote := &etsi119602.ListOfTrustedEntities{
+		ListAndSchemeInformation: etsi119602.ListAndSchemeInformation{
+			LoTEVersionIdentifier: 1,
+			LoTEType:              etsi119602.LoTETypePubEAAProviders, // Pub-EAA profile
+			SchemeTerritory:       "SE",
+			SchemeOperatorName:    etsi119602.NameSet{{Lang: "en", Value: "Test"}},
+			ListIssueDateTime:     "2026-01-01T00:00:00Z",
+			NextUpdate:            "2027-01-01T00:00:00Z",
+		},
+		TrustedEntitiesList: []etsi119602.TrustedEntity{
+			{
+				TrustedEntityInformation: etsi119602.TrustedEntityInformation{
+					TEName:           etsi119602.NameSet{{Lang: "en", Value: "Pub-EAA Provider No Status"}},
+					TEInformationURI: []etsi119602.NonEmptyMultiLangURI{{Lang: "en", URIValue: "https://pubeaa-nostatus.example.com"}},
+				},
+				TrustedEntityServices: []etsi119602.TrustedEntityService{
+					{
+						ServiceInformation: etsi119602.ServiceInformation{
+							ServiceName:           etsi119602.NameSet{{Lang: "en", Value: "PubEAA Issuance"}},
+							ServiceTypeIdentifier: "http://uri.etsi.org/19602/SvcType/PubEAA/Issuance",
+							// ServiceStatus intentionally absent - per Annex H this should NOT be trusted
+							ServiceDigitalIdentity: etsi119602.ServiceDigitalIdentity{
+								PublicKeyValues: []map[string]any{
+									{"kty": "EC", "crv": "P-256", "x": "f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU", "y": "x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	dir := t.TempDir()
+	path := writeLoTE(t, dir, "lote.json", lote)
+	reg, err := New(Config{Sources: []string{path}})
+	require.NoError(t, err)
+
+	// Resolution-only should FAIL for Pub-EAA entity without notified status
+	resp, err := reg.Evaluate(context.Background(), &authzen.EvaluationRequest{
+		Subject:  authzen.Subject{Type: "key", ID: "https://pubeaa-nostatus.example.com"},
+		Resource: authzen.Resource{ID: "https://pubeaa-nostatus.example.com"},
+	})
+	require.NoError(t, err)
+	assert.False(t, resp.Decision, "Pub-EAA entity without notified service should NOT be trusted")
+	assert.Contains(t, resp.Context.Reason["admin"], "no service with 'notified' status")
+}
+
+// TestEvaluate_PubEAA_WithdrawnOnlyService verifies that Pub-EAA entities with
+// only withdrawn services are NOT trusted.
+func TestEvaluate_PubEAA_WithdrawnOnlyService(t *testing.T) {
+	lote := &etsi119602.ListOfTrustedEntities{
+		ListAndSchemeInformation: etsi119602.ListAndSchemeInformation{
+			LoTEVersionIdentifier: 1,
+			LoTEType:              etsi119602.LoTETypePubEAAProviders, // Pub-EAA profile
+			SchemeTerritory:       "SE",
+			SchemeOperatorName:    etsi119602.NameSet{{Lang: "en", Value: "Test"}},
+			ListIssueDateTime:     "2026-01-01T00:00:00Z",
+			NextUpdate:            "2027-01-01T00:00:00Z",
+		},
+		TrustedEntitiesList: []etsi119602.TrustedEntity{
+			{
+				TrustedEntityInformation: etsi119602.TrustedEntityInformation{
+					TEName:           etsi119602.NameSet{{Lang: "en", Value: "Pub-EAA Provider Withdrawn"}},
+					TEInformationURI: []etsi119602.NonEmptyMultiLangURI{{Lang: "en", URIValue: "https://pubeaa-withdrawn.example.com"}},
+				},
+				TrustedEntityServices: []etsi119602.TrustedEntityService{
+					{
+						ServiceInformation: etsi119602.ServiceInformation{
+							ServiceName:           etsi119602.NameSet{{Lang: "en", Value: "PubEAA Issuance"}},
+							ServiceTypeIdentifier: "http://uri.etsi.org/19602/SvcType/PubEAA/Issuance",
+							ServiceStatus:         "http://uri.etsi.org/19602/PubEAAProvidersList/SvcStatus/withdrawn",
+							ServiceDigitalIdentity: etsi119602.ServiceDigitalIdentity{
+								PublicKeyValues: []map[string]any{
+									{"kty": "EC", "crv": "P-256", "x": "f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU", "y": "x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	dir := t.TempDir()
+	path := writeLoTE(t, dir, "lote.json", lote)
+	reg, err := New(Config{Sources: []string{path}})
+	require.NoError(t, err)
+
+	// Resolution-only should FAIL for Pub-EAA entity with only withdrawn services
+	resp, err := reg.Evaluate(context.Background(), &authzen.EvaluationRequest{
+		Subject:  authzen.Subject{Type: "key", ID: "https://pubeaa-withdrawn.example.com"},
+		Resource: authzen.Resource{ID: "https://pubeaa-withdrawn.example.com"},
+	})
+	require.NoError(t, err)
+	assert.False(t, resp.Decision, "Pub-EAA entity with only withdrawn service should NOT be trusted")
+}
+
+func TestHasNotifiedService(t *testing.T) {
+	// Entity with notified service
+	entNotified := etsi119602.TrustedEntity{
+		TrustedEntityServices: []etsi119602.TrustedEntityService{
+			{
+				ServiceInformation: etsi119602.ServiceInformation{
+					ServiceStatus: "http://uri.etsi.org/19602/PubEAAProvidersList/SvcStatus/notified",
+				},
+			},
+		},
+	}
+	assert.True(t, hasNotifiedService(entNotified), "should detect notified service")
+
+	// Entity with withdrawn service only
+	entWithdrawn := etsi119602.TrustedEntity{
+		TrustedEntityServices: []etsi119602.TrustedEntityService{
+			{
+				ServiceInformation: etsi119602.ServiceInformation{
+					ServiceStatus: "http://uri.etsi.org/19602/PubEAAProvidersList/SvcStatus/withdrawn",
+				},
+			},
+		},
+	}
+	assert.False(t, hasNotifiedService(entWithdrawn), "should not detect withdrawn as notified")
+
+	// Entity with no status
+	entNoStatus := etsi119602.TrustedEntity{
+		TrustedEntityServices: []etsi119602.TrustedEntityService{
+			{
+				ServiceInformation: etsi119602.ServiceInformation{},
+			},
+		},
+	}
+	assert.False(t, hasNotifiedService(entNoStatus), "should not detect empty status as notified")
+
+	// Entity with no services
+	entNoServices := etsi119602.TrustedEntity{}
+	assert.False(t, hasNotifiedService(entNoServices), "should not detect notified with no services")
+}

--- a/pkg/registry/lote/registry_test.go
+++ b/pkg/registry/lote/registry_test.go
@@ -1625,3 +1625,80 @@ func TestBuildIndex_SchemeTypePropagation(t *testing.T) {
 	assert.Equal(t, etsi119602.LoTETypePubEAAProviders, ent.schemeType,
 		"schemeType must be propagated from LoTEType during buildIndex")
 }
+
+// TestEvaluate_PubEAA_MixedServices_OnlyNotifiedKeyAccepted verifies that for a
+// Pub-EAA entity with two services — one notified and one with absent status —
+// only the notified service's key is accepted. The key from the absent-status
+// service must be rejected even though the entity has a notified service.
+// This addresses the Copilot review finding that buildIndex previously indexed
+// keys from all non-withdrawn services regardless of Pub-EAA status.
+func TestEvaluate_PubEAA_MixedServices_OnlyNotifiedKeyAccepted(t *testing.T) {
+	entityID := "https://pubeaa-mixed.example.com"
+
+	// Two distinct EC P-256 public keys. Key A belongs to the notified service,
+	// key B to the absent-status service.
+	keyNotified := map[string]any{
+		"kty": "EC", "crv": "P-256",
+		"x": "f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",
+		"y": "x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",
+	}
+	keyAbsent := map[string]any{
+		"kty": "EC", "crv": "P-256",
+		"x": "MKBCTNIcKUSDii11ySs3526iDZ8AiTo7Tu6KPAqv7D4",
+		"y": "4Etl6SRW2YiLUrN5vfvVHuhp7x8PxltmWWlbbM4IFyM",
+	}
+
+	ent := etsi119602.TrustedEntity{
+		TrustedEntityInformation: etsi119602.TrustedEntityInformation{
+			TEInformationURI: []etsi119602.NonEmptyMultiLangURI{{Lang: "en", URIValue: entityID}},
+		},
+		TrustedEntityServices: []etsi119602.TrustedEntityService{
+			{
+				ServiceInformation: etsi119602.ServiceInformation{
+					ServiceName:           etsi119602.NameSet{{Lang: "en", Value: "Notified Issuance"}},
+					ServiceTypeIdentifier: "http://uri.etsi.org/19602/SvcType/PubEAA/Issuance",
+					ServiceStatus:         pubEAAStatusNotified,
+					ServiceDigitalIdentity: etsi119602.ServiceDigitalIdentity{
+						PublicKeyValues: []map[string]any{keyNotified},
+					},
+				},
+			},
+			{
+				ServiceInformation: etsi119602.ServiceInformation{
+					ServiceName:           etsi119602.NameSet{{Lang: "en", Value: "Absent-Status Issuance"}},
+					ServiceTypeIdentifier: "http://uri.etsi.org/19602/SvcType/PubEAA/Issuance",
+					// ServiceStatus intentionally absent — must NOT be indexed
+					ServiceDigitalIdentity: etsi119602.ServiceDigitalIdentity{
+						PublicKeyValues: []map[string]any{keyAbsent},
+					},
+				},
+			},
+		},
+	}
+	lote := minimalPubEAALoTE("SE", ent)
+	path := writeLoTE(t, t.TempDir(), "lote.json", lote)
+	reg, err := New(Config{Sources: []string{path}})
+	require.NoError(t, err)
+
+	makeReq := func(key map[string]any) *authzen.EvaluationRequest {
+		return &authzen.EvaluationRequest{
+			Subject: authzen.Subject{Type: "key", ID: entityID},
+			Resource: authzen.Resource{
+				Type: "jwk",
+				ID:   entityID,
+				Key:  []interface{}{key},
+			},
+		}
+	}
+
+	// The notified service's key must be accepted.
+	respOK, err := reg.Evaluate(context.Background(), makeReq(keyNotified))
+	require.NoError(t, err)
+	assert.True(t, respOK.Decision, "notified service key must be trusted")
+
+	// The absent-status service's key must be rejected, even though the entity
+	// has another service that is notified.
+	respDeny, err := reg.Evaluate(context.Background(), makeReq(keyAbsent))
+	require.NoError(t, err)
+	assert.False(t, respDeny.Decision, "absent-status service key must NOT be trusted")
+}


### PR DESCRIPTION
feat(lote): add Pub-EAA profile status checking per ETSI TS 119 602

Pub-EAA (Annex H): ServiceStatus is mandatory; only "notified" services are trusted.
Other profiles (PID, Wallet, WRPAC, WRPRC, Registrars): unchanged (presence = trusted).

Changes:
- Add schemeType field to indexedEntity for profile-aware evaluation
- Add hasNotifiedService() helper function
- Add Pub-EAA check in Evaluate() using etsi119602.IsPubEAASchemeType()
- Add tests: TestEvaluate_PubEAA_NotifiedService, TestEvaluate_PubEAA_NoNotifiedService,
  TestEvaluate_PubEAA_WithdrawnOnlyService, TestHasNotifiedService