### PR TITLE
feat: log reason for trust decisions

### DIFF
--- a/pkg/registry/manager.go
+++ b/pkg/registry/manager.go
@@ -585,12 +585,17 @@ func NormalizeSubjectID(id string) string {
 }
 
 // extractDecisionReason extracts a human-readable reason string from an
-// evaluation response. It checks for common reason keys in Context.Reason,
-// preferring the key that matches the decision: "error" for denials, "user"
-// for allows, falling back to the other key if the preferred one is absent.
+// evaluation response. It checks for common reason keys in Context.Reason.
+// Priority: "admin" (server-side diagnostics, e.g. from LoTE/whitelist registries),
+// then decision-specific keys: "error" for denials, "user" for allows.
 func extractDecisionReason(resp *authzen.EvaluationResponse) string {
 	if resp.Context == nil || resp.Context.Reason == nil {
 		return ""
+	}
+	// "admin" contains server-side diagnostic detail (e.g. "entity X not found in any LoTE")
+	// and is the most informative reason for operator logs.
+	if v, ok := resp.Context.Reason["admin"]; ok {
+		return fmt.Sprintf("%v", v)
 	}
 	if resp.Decision {
 		// Allow: prefer "user" (e.g. "trusted via whitelist (pid-issuers)")

--- a/pkg/registry/manager.go
+++ b/pkg/registry/manager.go
@@ -585,18 +585,29 @@ func NormalizeSubjectID(id string) string {
 }
 
 // extractDecisionReason extracts a human-readable reason string from an
-// evaluation response. It checks for common reason keys in Context.Reason.
+// evaluation response. It checks for common reason keys in Context.Reason,
+// preferring the key that matches the decision: "error" for denials, "user"
+// for allows, falling back to the other key if the preferred one is absent.
 func extractDecisionReason(resp *authzen.EvaluationResponse) string {
 	if resp.Context == nil || resp.Context.Reason == nil {
 		return ""
 	}
-	// "user" is set by registries for allow decisions (e.g. "trusted via whitelist (pid-issuers)")
-	if v, ok := resp.Context.Reason["user"]; ok {
-		return fmt.Sprintf("%v", v)
-	}
-	// "error" is set for deny decisions (e.g. "subject not in whitelist for action 'issuer'")
-	if v, ok := resp.Context.Reason["error"]; ok {
-		return fmt.Sprintf("%v", v)
+	if resp.Decision {
+		// Allow: prefer "user" (e.g. "trusted via whitelist (pid-issuers)")
+		if v, ok := resp.Context.Reason["user"]; ok {
+			return fmt.Sprintf("%v", v)
+		}
+		if v, ok := resp.Context.Reason["error"]; ok {
+			return fmt.Sprintf("%v", v)
+		}
+	} else {
+		// Deny: prefer "error" (e.g. "subject not in whitelist for action 'issuer'")
+		if v, ok := resp.Context.Reason["error"]; ok {
+			return fmt.Sprintf("%v", v)
+		}
+		if v, ok := resp.Context.Reason["user"]; ok {
+			return fmt.Sprintf("%v", v)
+		}
 	}
 	return ""
 }

--- a/pkg/registry/manager.go
+++ b/pkg/registry/manager.go
@@ -187,10 +187,25 @@ func (m *RegistryManager) Evaluate(ctx context.Context, req *authzen.EvaluationR
 			logging.F("error", err.Error()),
 			logging.F("duration_ms", duration.Milliseconds()))
 	} else {
-		logger.Debug("Evaluate: completed",
+		// Log decision with reason: deny at Info level, allow at Debug level.
+		action := ""
+		if req.Action != nil {
+			action = req.Action.Name
+		}
+		reason := extractDecisionReason(resp)
+		fields := []logging.Field{
 			logging.F("decision", resp.Decision),
+			logging.F("subject_id", req.Subject.ID),
+			logging.F("resource_type", req.Resource.Type),
+			logging.F("action", action),
+			logging.F("reason", reason),
 			logging.F("duration_ms", duration.Milliseconds()),
-			logging.F("subject_id", req.Subject.ID))
+		}
+		if resp.Decision {
+			logger.Debug("trust decision: allow", fields...)
+		} else {
+			logger.Info("trust decision: deny", fields...)
+		}
 	}
 
 	return resp, err
@@ -567,4 +582,21 @@ func NormalizeSubjectID(id string) string {
 		}
 	}
 	return id
+}
+
+// extractDecisionReason extracts a human-readable reason string from an
+// evaluation response. It checks for common reason keys in Context.Reason.
+func extractDecisionReason(resp *authzen.EvaluationResponse) string {
+	if resp.Context == nil || resp.Context.Reason == nil {
+		return ""
+	}
+	// "user" is set by registries for allow decisions (e.g. "trusted via whitelist (pid-issuers)")
+	if v, ok := resp.Context.Reason["user"]; ok {
+		return fmt.Sprintf("%v", v)
+	}
+	// "error" is set for deny decisions (e.g. "subject not in whitelist for action 'issuer'")
+	if v, ok := resp.Context.Reason["error"]; ok {
+		return fmt.Sprintf("%v", v)
+	}
+	return ""
 }

--- a/pkg/registry/manager_test.go
+++ b/pkg/registry/manager_test.go
@@ -787,10 +787,10 @@ func (l *capturingLogger) Error(msg string, fields ...logging.Field) {
 func (l *capturingLogger) Fatal(msg string, fields ...logging.Field) {
 	l.log(logging.FatalLevel, msg, fields...)
 }
-func (l *capturingLogger) WithContext(_ context.Context) logging.Logger { return l }
+func (l *capturingLogger) WithContext(_ context.Context) logging.Logger     { return l }
 func (l *capturingLogger) WithField(_ string, _ interface{}) logging.Logger { return l }
-func (l *capturingLogger) WithFields(_ ...logging.Field) logging.Logger    { return l }
-func (l *capturingLogger) GetLevel() logging.LogLevel                      { return l.level }
+func (l *capturingLogger) WithFields(_ ...logging.Field) logging.Logger     { return l }
+func (l *capturingLogger) GetLevel() logging.LogLevel                       { return l.level }
 func (l *capturingLogger) SetLevel(level logging.LogLevel)                  { l.level = level }
 
 func (l *capturingLogger) findEntry(msg string) *logEntry {

--- a/pkg/registry/manager_test.go
+++ b/pkg/registry/manager_test.go
@@ -3,9 +3,11 @@ package registry
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/sirosfoundation/g119612/pkg/logging"
 	"github.com/sirosfoundation/go-trust/pkg/authzen"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -748,4 +750,129 @@ func TestRegistryManager_Evaluate_NormalizesSubjectID(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, resp.Decision)
 	assert.Equal(t, "https://verifier.example.com", capturedSubjectID)
+}
+
+// logEntry records a single log call.
+type logEntry struct {
+	level  logging.LogLevel
+	msg    string
+	fields []logging.Field
+}
+
+// capturingLogger records log calls for test assertions.
+type capturingLogger struct {
+	mu      sync.Mutex
+	entries []logEntry
+	level   logging.LogLevel
+}
+
+func (l *capturingLogger) log(level logging.LogLevel, msg string, fields ...logging.Field) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	l.entries = append(l.entries, logEntry{level: level, msg: msg, fields: fields})
+}
+
+func (l *capturingLogger) Debug(msg string, fields ...logging.Field) {
+	l.log(logging.DebugLevel, msg, fields...)
+}
+func (l *capturingLogger) Info(msg string, fields ...logging.Field) {
+	l.log(logging.InfoLevel, msg, fields...)
+}
+func (l *capturingLogger) Warn(msg string, fields ...logging.Field) {
+	l.log(logging.WarnLevel, msg, fields...)
+}
+func (l *capturingLogger) Error(msg string, fields ...logging.Field) {
+	l.log(logging.ErrorLevel, msg, fields...)
+}
+func (l *capturingLogger) Fatal(msg string, fields ...logging.Field) {
+	l.log(logging.FatalLevel, msg, fields...)
+}
+func (l *capturingLogger) WithContext(_ context.Context) logging.Logger { return l }
+func (l *capturingLogger) WithField(_ string, _ interface{}) logging.Logger { return l }
+func (l *capturingLogger) WithFields(_ ...logging.Field) logging.Logger    { return l }
+func (l *capturingLogger) GetLevel() logging.LogLevel                      { return l.level }
+func (l *capturingLogger) SetLevel(level logging.LogLevel)                  { l.level = level }
+
+func (l *capturingLogger) findEntry(msg string) *logEntry {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	for i := range l.entries {
+		if l.entries[i].msg == msg {
+			return &l.entries[i]
+		}
+	}
+	return nil
+}
+
+func TestRegistryManager_DecisionLogging_DenyAtInfo(t *testing.T) {
+	logger := &capturingLogger{level: logging.DebugLevel}
+	mgr := NewRegistryManager(FirstMatch, 10*time.Second)
+	mgr.SetLogger(logger)
+
+	// Registry that denies
+	reg := &mockRegistry{
+		name:          "deny-registry",
+		resourceTypes: []string{"x5c"},
+		healthy:       true,
+		evaluateResponse: &authzen.EvaluationResponse{
+			Decision: false,
+			Context: &authzen.EvaluationResponseContext{
+				Reason: map[string]interface{}{
+					"error": "subject not in whitelist",
+				},
+			},
+		},
+	}
+	mgr.Register(reg)
+
+	req := &authzen.EvaluationRequest{
+		Subject:  authzen.Subject{Type: "key", ID: "https://untrusted.example.com"},
+		Resource: authzen.Resource{Type: "x5c", ID: "https://untrusted.example.com", Key: []interface{}{"test"}},
+		Action:   &authzen.Action{Name: "verifier"},
+	}
+
+	resp, err := mgr.Evaluate(context.Background(), req)
+	require.NoError(t, err)
+	assert.False(t, resp.Decision)
+
+	entry := logger.findEntry("trust decision: deny")
+	require.NotNil(t, entry, "expected 'trust decision: deny' log entry")
+	assert.Equal(t, logging.InfoLevel, entry.level, "deny decisions should log at Info level")
+}
+
+func TestRegistryManager_DecisionLogging_AllowAtDebug(t *testing.T) {
+	logger := &capturingLogger{level: logging.DebugLevel}
+	mgr := NewRegistryManager(FirstMatch, 10*time.Second)
+	mgr.SetLogger(logger)
+
+	// Registry that allows
+	reg := &mockRegistry{
+		name:          "allow-registry",
+		resourceTypes: []string{"x5c"},
+		healthy:       true,
+		evaluateResponse: &authzen.EvaluationResponse{
+			Decision: true,
+			Context: &authzen.EvaluationResponseContext{
+				Reason: map[string]interface{}{
+					"user":     "trusted via whitelist (issuers)",
+					"registry": "test-whitelist",
+				},
+			},
+		},
+	}
+	mgr.Register(reg)
+
+	req := &authzen.EvaluationRequest{
+		Subject:  authzen.Subject{Type: "key", ID: "https://trusted.example.com"},
+		Resource: authzen.Resource{Type: "x5c", ID: "https://trusted.example.com", Key: []interface{}{"test"}},
+		Action:   &authzen.Action{Name: "issuer"},
+	}
+
+	resp, err := mgr.Evaluate(context.Background(), req)
+	require.NoError(t, err)
+	assert.True(t, resp.Decision)
+
+	entry := logger.findEntry("trust decision: allow")
+	require.NotNil(t, entry, "expected 'trust decision: allow' log entry")
+	assert.Equal(t, logging.DebugLevel, entry.level, "allow decisions should log at Debug level")
 }


### PR DESCRIPTION
Closes #45

## Problem

Go-trust doesn't explain why a trust decision was made, making debugging of unexpected decisions challenging.

## Solution

Add decision-aware logging in `RegistryManager.Evaluate()` — the single chokepoint through which all trust decisions pass:

- **`decision: false`** → logs at **Info** level (`"trust decision: deny"`)
- **`decision: true`** → logs at **Debug** level (`"trust decision: allow"`)

Each log entry includes: `decision`, `subject_id`, `resource_type`, `action`, `reason`, `duration_ms`.

The reason is extracted from `Context.Reason["error"]` (for denials) or `Context.Reason["user"]` (for allows), which all registries already populate.

## Tests

- `TestRegistryManager_DecisionLogging_DenyAtInfo` — verifies deny logs at Info
- `TestRegistryManager_DecisionLogging_AllowAtDebug` — verifies allow logs at Debug