### PR TITLE
Skip healthz access log and gate network tests

### DIFF
--- a/cmd/gt/main.go
+++ b/cmd/gt/main.go
@@ -302,10 +302,22 @@ func main() {
 		logging.F("url", baseURL))
 
 	// Gin API server
-	if *logLevel != "debug" {
+	debugMode := *logLevel == "debug"
+	if !debugMode {
 		gin.SetMode(gin.ReleaseMode)
 	}
-	r := gin.Default()
+	r := gin.New()
+	r.Use(gin.LoggerWithConfig(gin.LoggerConfig{
+		Skip: func(c *gin.Context) bool {
+			// In debug mode, always log everything
+			if debugMode {
+				return false
+			}
+			// Skip successful health check requests to reduce log noise
+			return c.Request.URL.Path == "/healthz" && c.Writer.Status() == 200
+		},
+	}))
+	r.Use(gin.Recovery())
 
 	// Initialize metrics
 	metrics := api.NewMetrics()

--- a/pkg/registry/didwebvh/didwebvh_registry_test.go
+++ b/pkg/registry/didwebvh/didwebvh_registry_test.go
@@ -570,13 +570,10 @@ func TestMergeParameters(t *testing.T) {
 // =============================================================================
 
 // TestPublicMediatorResolution tests resolution of the public mediator DID.
-// This test requires network access and is skipped if the mediator is unavailable.
+// This test requires network access and is skipped unless RUN_NETWORK_TESTS=1 is set.
 func TestPublicMediatorResolution(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping network-dependent test in short mode")
-	}
-	if os.Getenv("SKIP_NETWORK_TESTS") != "" {
-		t.Skip("Skipping network test (SKIP_NETWORK_TESTS set)")
+	if os.Getenv("RUN_NETWORK_TESTS") != "1" {
+		t.Skip("skipping network-dependent test (set RUN_NETWORK_TESTS=1 to run)")
 	}
 
 	// Public mediator DID


### PR DESCRIPTION
## Summary

Excludes successful `/healthz` requests from access logs to reduce noise from monitoring tools and load balancers, and gates network-dependent tests behind an opt-in environment variable.

## Changes

### Healthz access log filtering
- Replace `gin.Default()` with `gin.New()` + explicit `gin.LoggerWithConfig` and `gin.Recovery()` middleware
- Use Gin's `Skip` function to suppress logging of `/healthz` requests that return HTTP 200
- In debug mode (`--log-level debug`), all requests including healthz are still logged

### Network test gating
- Change `TestPublicMediatorResolution` from opt-out (`SKIP_NETWORK_TESTS`) to opt-in (`RUN_NETWORK_TESTS=1`)
- Prevents CI failures caused by external service unavailability

Closes #44