### PR TITLE
fix: fall back to JWT header key for signed_metadata verification

### DIFF
--- a/pkg/issuermetadata/resolver.go
+++ b/pkg/issuermetadata/resolver.go
@@ -335,18 +335,28 @@ func (r *Resolver) handleJSONResponse(ctx context.Context, issuerURL string, bod
 // JWKS and returns the JWT payload claims as the authoritative metadata.
 // The signed_metadata string is preserved in the returned map.
 //
-// Key selection: if the JWT header contains a kid, keys matching that kid are
-// tried first. If none match the kid or no kid is present, all JWKS keys are
-// tried in order.
+// Key resolution order:
+//  1. Inline jwks or jwks_uri from the metadata body
+//  2. JWT header (x5c certificate chain or embedded key)
+//
+// When using JWKS, if the JWT header contains a kid, keys matching that kid
+// are tried first. If none match the kid or no kid is present, all JWKS keys
+// are tried in order.
 func (r *Resolver) validateSignedMetadata(ctx context.Context, issuerURL string, raw map[string]interface{}, signedMetadata string) (map[string]interface{}, error) {
 	jws, err := jose.ParseSigned(signedMetadata, supportedSignatureAlgorithms)
 	if err != nil {
 		return nil, fmt.Errorf("parsing signed_metadata JWT: %w", err)
 	}
 
-	jwks, err := r.resolveJWKS(ctx, raw)
-	if err != nil {
-		return nil, fmt.Errorf("resolving JWKS for signed_metadata verification: %w", err)
+	jwks, jwksErr := r.resolveJWKS(ctx, raw)
+	if jwksErr != nil {
+		// No JWKS in metadata body — fall back to JWT header key (x5c, embedded key).
+		claims, headerErr := r.verifyJWSFromHeader(ctx, issuerURL, jws)
+		if headerErr != nil {
+			return nil, fmt.Errorf("resolving JWKS for signed_metadata verification: %w (header fallback: %v)", jwksErr, headerErr)
+		}
+		claims["signed_metadata"] = signedMetadata
+		return claims, nil
 	}
 
 	// Determine the candidate keys to try for verification.

--- a/pkg/issuermetadata/resolver.go
+++ b/pkg/issuermetadata/resolver.go
@@ -31,6 +31,7 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"mime"
 	"net/http"
@@ -337,7 +338,8 @@ func (r *Resolver) handleJSONResponse(ctx context.Context, issuerURL string, bod
 //
 // Key resolution order:
 //  1. Inline jwks or jwks_uri from the metadata body
-//  2. JWT header (x5c certificate chain or embedded key)
+//  2. x5c certificate chain from the JWT header (only when metadata has
+//     no jwks or jwks_uri at all; transient fetch errors are not bypassed)
 //
 // When using JWKS, if the JWT header contains a kid, keys matching that kid
 // are tried first. If none match the kid or no kid is present, all JWKS keys
@@ -350,10 +352,15 @@ func (r *Resolver) validateSignedMetadata(ctx context.Context, issuerURL string,
 
 	jwks, jwksErr := r.resolveJWKS(ctx, raw)
 	if jwksErr != nil {
-		// No JWKS in metadata body — fall back to JWT header key (x5c, embedded key).
+		// Only fall back to header key when metadata truly has no JWKS.
+		// Transient fetch/parse errors from jwks_uri must not be silently bypassed.
+		if !errors.Is(jwksErr, errNoJWKS) {
+			return nil, fmt.Errorf("resolving JWKS for signed_metadata verification: %w", jwksErr)
+		}
+		// No JWKS in metadata body — fall back to x5c from JWT header.
 		claims, headerErr := r.verifyJWSFromHeader(ctx, issuerURL, jws)
 		if headerErr != nil {
-			return nil, fmt.Errorf("resolving JWKS for signed_metadata verification: %w (header fallback: %v)", jwksErr, headerErr)
+			return nil, fmt.Errorf("signed_metadata verification failed: no JWKS in metadata and header key extraction failed: %w", headerErr)
 		}
 		claims["signed_metadata"] = signedMetadata
 		return claims, nil
@@ -430,10 +437,10 @@ func (r *Resolver) verifyJWSFromHeader(ctx context.Context, issuerURL string, jw
 
 	// Try kid — look up from issuer's JWKS (fetch metadata as JSON to get JWKS)
 	if kid := headers.KeyID; kid != "" {
-		return nil, fmt.Errorf("JWT response with kid but no x5c header: key resolution via kid requires JWKS endpoint (not yet supported for application/jwt responses)")
+		return nil, fmt.Errorf("kid header present but no x5c: key resolution via kid requires JWKS endpoint (not yet supported)")
 	}
 
-	return nil, fmt.Errorf("JWT response has no x5c or kid in JOSE header; cannot resolve signing key")
+	return nil, fmt.Errorf("no x5c or kid in JOSE header; cannot resolve signing key")
 }
 
 // extractX5CCerts extracts x5c certificates from a JWS by looking at the
@@ -610,8 +617,12 @@ func (r *Resolver) evaluateJWKTrust(ctx context.Context, issuerURL string, jwk *
 	return nil
 }
 
+// errNoJWKS is returned by resolveJWKS when metadata contains neither jwks nor jwks_uri.
+var errNoJWKS = errors.New("no JWKS found in metadata (jwks or jwks_uri required)")
+
 // resolveJWKS returns the JWKS for validating the signed_metadata JWT.
 // Inline jwks is preferred over jwks_uri.
+// Returns errNoJWKS when neither jwks nor jwks_uri is present.
 func (r *Resolver) resolveJWKS(ctx context.Context, meta map[string]interface{}) (jose.JSONWebKeySet, error) {
 	// Prefer inline JWKS.
 	if jwksRaw, ok := meta["jwks"]; ok {
@@ -629,7 +640,7 @@ func (r *Resolver) resolveJWKS(ctx context.Context, meta map[string]interface{})
 		return r.fetchJWKSFromURI(ctx, uri)
 	}
 
-	return jose.JSONWebKeySet{}, fmt.Errorf("signed_metadata present but no JWKS found in metadata (jwks or jwks_uri required)")
+	return jose.JSONWebKeySet{}, errNoJWKS
 }
 
 // fetchJWKSFromURI fetches and parses a JWKS from the given URI.

--- a/pkg/issuermetadata/resolver_test.go
+++ b/pkg/issuermetadata/resolver_test.go
@@ -253,7 +253,7 @@ func TestResolve_SignedMetadata_NoJWKS(t *testing.T) {
 	outer := map[string]interface{}{
 		"credential_issuer": "https://issuer.example.com",
 		"signed_metadata":   token,
-		// no jwks or jwks_uri
+		// no jwks or jwks_uri, and no x5c in JWT header
 	}
 
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -268,7 +268,58 @@ func TestResolve_SignedMetadata_NoJWKS(t *testing.T) {
 
 	_, err := newTestResolver(t).Resolve(context.Background(), server.URL)
 	if err == nil {
-		t.Error("expected error when signed_metadata present but no JWKS available, got nil")
+		t.Error("expected error when signed_metadata has no JWKS and no x5c header, got nil")
+	}
+}
+
+// TestResolve_SignedMetadata_X5CFallback verifies that when signed_metadata is
+// present and the outer metadata has no jwks/jwks_uri, the resolver falls back
+// to extracting the signing key from the JWT's x5c header.
+func TestResolve_SignedMetadata_X5CFallback(t *testing.T) {
+	priv, _ := newTestKey(t)
+	cert := newTestCert(t, priv)
+
+	jwtClaims := map[string]interface{}{
+		"credential_issuer": "https://issuer.example.com",
+		"credential_configurations_supported": map[string]interface{}{
+			"PID": map[string]interface{}{"format": "dc+sd-jwt"},
+		},
+	}
+	// Sign with x5c in header, no type (standard JWT)
+	token := signClaimsWithX5C(t, priv, []*x509.Certificate{cert}, "JWT", jwtClaims)
+
+	// Outer metadata has signed_metadata but no jwks or jwks_uri
+	outer := map[string]interface{}{
+		"credential_issuer": "https://issuer.example.com",
+		"signed_metadata":   token,
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/.well-known/openid-credential-issuer" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(outer) //nolint:errcheck
+	}))
+	defer server.Close()
+
+	got, err := newTestResolver(t).Resolve(context.Background(), server.URL)
+	if err != nil {
+		t.Fatalf("Resolve() error: %v", err)
+	}
+
+	// Authoritative claim comes from the JWT payload.
+	if got["credential_issuer"] != "https://issuer.example.com" {
+		t.Errorf("credential_issuer: got %v", got["credential_issuer"])
+	}
+	// signed_metadata is preserved.
+	if got["signed_metadata"] != token {
+		t.Errorf("signed_metadata not preserved")
+	}
+	// JWT payload claim is returned.
+	if _, ok := got["credential_configurations_supported"]; !ok {
+		t.Error("credential_configurations_supported not found in JWT payload claims")
 	}
 }
 

--- a/pkg/issuermetadata/resolver_test.go
+++ b/pkg/issuermetadata/resolver_test.go
@@ -285,7 +285,7 @@ func TestResolve_SignedMetadata_X5CFallback(t *testing.T) {
 			"PID": map[string]interface{}{"format": "dc+sd-jwt"},
 		},
 	}
-	// Sign with x5c in header, no type (standard JWT)
+	// Sign with x5c in header and typ=JWT
 	token := signClaimsWithX5C(t, priv, []*x509.Certificate{cert}, "JWT", jwtClaims)
 
 	// Outer metadata has signed_metadata but no jwks or jwks_uri


### PR DESCRIPTION
## Problem

When issuer metadata is returned as JSON with a `signed_metadata` field, the resolver requires `jwks` or `jwks_uri` in the metadata body to find the verification key. This fails for issuers (e.g. wwWallet v2 at `issuer-v2-oid-t8s.smncd.app.siros.org`) that embed the signing key as an `x5c` certificate chain in the JWT header without publishing a separate JWKS.

**Error**: `resolving JWKS for signed_metadata verification: signed_metadata present but no JWKS found in metadata (jwks or jwks_uri required)`

## Fix

When `resolveJWKS` fails (no `jwks` or `jwks_uri` in metadata body), `validateSignedMetadata` now falls back to `verifyJWSFromHeader`, which extracts the verification key from the JWT's own JOSE header (`x5c` certificate chain or embedded key). This is the same path already used for `application/jwt` responses.

**Key resolution order:**
1. Inline `jwks` or `jwks_uri` from metadata body (preferred, unchanged)
2. JWT header (`x5c`, embedded key) — **new fallback**

If both paths fail, a combined error message is returned.

## Tests

- Updated `TestResolve_SignedMetadata_NoJWKS` — still errors when JWT has no x5c header
- Added `TestResolve_SignedMetadata_X5CFallback` — verifies x5c fallback works correctly