### PR TITLE
feat: JWKS fetch resilience with retry and stale-cache fallback

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sirosfoundation/go-trust
 
-go 1.26.2
+go 1.26.3
 
 replace github.com/moov-io/signedxml v1.2.3 => github.com/sirosfoundation/signedxml v1.4.0-siros1
 

--- a/pkg/authzen/types_test.go
+++ b/pkg/authzen/types_test.go
@@ -326,6 +326,7 @@ func TestTrustMetadataOmitEmpty(t *testing.T) {
 		t.Error("trust_metadata should be omitted when nil")
 	}
 }
+
 // TestActionParametersSerialization tests that action.parameters serializes correctly
 func TestActionParametersSerialization(t *testing.T) {
 	request := EvaluationRequest{

--- a/pkg/registry/didjwks/didjwks_registry.go
+++ b/pkg/registry/didjwks/didjwks_registry.go
@@ -57,9 +57,9 @@ type Config struct {
 	// DisableOIDCDiscovery disables the OAuth2/OIDC discovery fallback.
 	DisableOIDCDiscovery bool
 
-	// MaxRetries is the maximum number of fetch attempts for transient failures.
+	// MaxAttempts is the maximum number of fetch attempts for transient failures.
 	// Uses exponential backoff starting at 500ms. Default: 3.
-	MaxRetries int
+	MaxAttempts int
 }
 
 // Registry implements the TrustRegistry interface for the did:jwks method.
@@ -106,7 +106,8 @@ func NewRegistry(config Config) (*Registry, error) {
 	}
 
 	reg.fetcher = resilience.NewFetcher[*JWKS](httpClient, parseJWKS, resilience.FetcherConfig{
-		MaxRetries: config.MaxRetries,
+		MaxAttempts:  config.MaxAttempts,
+		MaxBodyBytes: int64(registry.GetMaxResponseBodyBytes()),
 	})
 
 	return reg, nil

--- a/pkg/registry/didjwks/didjwks_registry.go
+++ b/pkg/registry/didjwks/didjwks_registry.go
@@ -33,6 +33,7 @@ import (
 
 	"github.com/sirosfoundation/go-trust/pkg/authzen"
 	"github.com/sirosfoundation/go-trust/pkg/registry"
+	"github.com/sirosfoundation/go-trust/pkg/resilience"
 )
 
 // Config holds configuration for the did:jwks registry.
@@ -55,6 +56,10 @@ type Config struct {
 
 	// DisableOIDCDiscovery disables the OAuth2/OIDC discovery fallback.
 	DisableOIDCDiscovery bool
+
+	// MaxRetries is the maximum number of fetch attempts for transient failures.
+	// Uses exponential backoff starting at 500ms. Default: 3.
+	MaxRetries int
 }
 
 // Registry implements the TrustRegistry interface for the did:jwks method.
@@ -64,6 +69,7 @@ type Registry struct {
 	description          string
 	allowHTTP            bool
 	disableOIDCDiscovery bool
+	fetcher              *resilience.Fetcher[*JWKS]
 }
 
 // NewRegistry creates a new did:jwks trust registry.
@@ -91,13 +97,19 @@ func NewRegistry(config Config) (*Registry, error) {
 		InsecureSkipVerify: config.InsecureSkipVerify,
 	})
 
-	return &Registry{
+	reg := &Registry{
 		httpClient:           httpClient,
 		timeout:              timeout,
 		description:          description,
 		allowHTTP:            config.AllowHTTP,
 		disableOIDCDiscovery: config.DisableOIDCDiscovery,
-	}, nil
+	}
+
+	reg.fetcher = resilience.NewFetcher[*JWKS](httpClient, parseJWKS, resilience.FetcherConfig{
+		MaxRetries: config.MaxRetries,
+	})
+
+	return reg, nil
 }
 
 // Evaluate implements TrustRegistry.Evaluate by resolving did:jwks DIDs and validating key bindings.
@@ -222,6 +234,7 @@ func (r *Registry) Refresh(_ context.Context) error {
 // SetHTTPClient allows overriding the HTTP client (for testing).
 func (r *Registry) SetHTTPClient(client *http.Client) {
 	r.httpClient = client
+	r.fetcher = resilience.NewFetcher[*JWKS](client, parseJWKS, r.fetcher.Config())
 }
 
 // --- DID Parsing ---
@@ -321,7 +334,20 @@ func buildDiscoveryURL(scheme, domain, path string) string {
 	return fmt.Sprintf("%s://%s/.well-known/openid-configuration/%s", scheme, domain, path)
 }
 
-// fetchJWKS fetches and parses a JWKS from the given URL.
+// parseJWKS parses a JWKS JSON document.
+func parseJWKS(body []byte) (*JWKS, error) {
+	var jwks JWKS
+	if err := json.Unmarshal(body, &jwks); err != nil {
+		return nil, fmt.Errorf("parsing JWKS: %w", err)
+	}
+	if len(jwks.Keys) == 0 {
+		return nil, fmt.Errorf("JWKS contains no keys")
+	}
+	return &jwks, nil
+}
+
+// fetchJWKS fetches and parses a JWKS from the given URL using the resilience
+// fetcher (with retry and stale-cache fallback).
 func (r *Registry) fetchJWKS(ctx context.Context, jwksURL string) (*JWKS, error) {
 	// Validate URL
 	parsed, err := url.Parse(jwksURL)
@@ -332,37 +358,11 @@ func (r *Registry) fetchJWKS(ctx context.Context, jwksURL string) (*JWKS, error)
 		return nil, fmt.Errorf("JWKS URL must use HTTPS: %s", jwksURL)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, jwksURL, nil)
+	result, _, err := r.fetcher.Fetch(ctx, jwksURL)
 	if err != nil {
-		return nil, fmt.Errorf("creating request: %w", err)
+		return nil, fmt.Errorf("fetching JWKS from %s: %w", jwksURL, err)
 	}
-	req.Header.Set("Accept", "application/json")
-
-	resp, err := r.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("HTTP request failed: %w", err)
-	}
-	defer resp.Body.Close() //nolint:errcheck
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("HTTP %d from %s", resp.StatusCode, jwksURL)
-	}
-
-	body, err := registry.ReadLimitedBody(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("reading response: %w", err)
-	}
-
-	var jwks JWKS
-	if err := json.Unmarshal(body, &jwks); err != nil {
-		return nil, fmt.Errorf("parsing JWKS: %w", err)
-	}
-
-	if len(jwks.Keys) == 0 {
-		return nil, fmt.Errorf("JWKS contains no keys")
-	}
-
-	return &jwks, nil
+	return result, nil
 }
 
 // fetchDiscoveryJWKSURI fetches an OIDC discovery document and extracts jwks_uri.

--- a/pkg/registry/didjwks/didjwks_registry_test.go
+++ b/pkg/registry/didjwks/didjwks_registry_test.go
@@ -377,7 +377,7 @@ func TestEvaluateResolutionOnly(t *testing.T) {
 	domain := testDomain(server)
 
 	req := &authzen.EvaluationRequest{
-		Subject: authzen.Subject{Type: "key", ID: fmt.Sprintf("did:jwks:%s", domain)},
+		Subject:  authzen.Subject{Type: "key", ID: fmt.Sprintf("did:jwks:%s", domain)},
 		Resource: authzen.Resource{
 			// No type or key = resolution-only
 		},

--- a/pkg/registry/etsi/policy_filter_test.go
+++ b/pkg/registry/etsi/policy_filter_test.go
@@ -366,6 +366,7 @@ func TestTSLRegistry_Evaluate_X5CIntermediateWithFilter(t *testing.T) {
 		t.Error("expected true decision for valid intermediate chain with filter context")
 	}
 }
+
 // TestTSLRegistry_EvaluateWithCredentialTypesContext verifies credential_types
 // are extracted from context and included in the response.
 func TestTSLRegistry_EvaluateWithCredentialTypesContext(t *testing.T) {

--- a/pkg/registry/policy_injection_test.go
+++ b/pkg/registry/policy_injection_test.go
@@ -291,6 +291,7 @@ func TestApplyPolicyToRequest_DIDPartialConstraints(t *testing.T) {
 	assert.Nil(t, req.Context["required_verification_methods"])
 	assert.Equal(t, true, req.Context["require_verifiable_history"])
 }
+
 // TestApplyPolicyToRequest_ActionParameters verifies that action.parameters
 // are merged into the request context.
 func TestApplyPolicyToRequest_ActionParameters(t *testing.T) {

--- a/pkg/registry/static/whitelist.go
+++ b/pkg/registry/static/whitelist.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/sirosfoundation/go-trust/pkg/authzen"
 	"github.com/sirosfoundation/go-trust/pkg/registry"
+	"github.com/sirosfoundation/go-trust/pkg/resilience"
 )
 
 // DefaultRefreshInterval is the default JWKS refresh interval when none is configured.
@@ -72,6 +73,9 @@ type WhitelistRegistry struct {
 	refreshInterval time.Duration
 	refreshStopCh   chan struct{}
 	refreshOnce     sync.Once // guards Close of refreshStopCh
+
+	// jwksFetcher handles JWKS fetches with retry and stale-cache fallback.
+	jwksFetcher *resilience.Fetcher[[]crypto.PublicKey]
 }
 
 // WhitelistConfig holds the whitelist configuration.
@@ -186,6 +190,9 @@ func NewWhitelistRegistry(opts ...WhitelistOption) *WhitelistRegistry {
 	for _, opt := range opts {
 		opt(r)
 	}
+
+	// Create JWKS fetcher with retry (uses the configured HTTP client).
+	r.jwksFetcher = resilience.NewFetcher(r.httpClient, parseJWKSPublicKeys, resilience.FetcherConfig{})
 
 	r.resolveConfig()
 
@@ -704,6 +711,11 @@ func (r *WhitelistRegistry) Healthy() bool {
 }
 
 // Refresh fetches JWKS for all whitelisted entities and caches their key fingerprints.
+//
+// On partial failure, previously cached keys for entities that failed to refresh
+// are preserved (stale-cache fallback). The registry remains healthy as long as
+// at least some keys were loaded, allowing continued operation during transient
+// outages of individual issuers.
 func (r *WhitelistRegistry) Refresh(ctx context.Context) error {
 	r.mu.Lock()
 	defer r.mu.Unlock()
@@ -718,8 +730,8 @@ func (r *WhitelistRegistry) Refresh(ctx context.Context) error {
 		}
 	}
 
-	// Clear existing key hashes
-	r.keyHashes = make(map[string]map[string]bool)
+	// Build new key hashes map, preserving stale entries for failed fetches
+	newKeyHashes := make(map[string]map[string]bool)
 
 	// Fetch JWKS for each entity
 	var errors []string
@@ -730,6 +742,13 @@ func (r *WhitelistRegistry) Refresh(ctx context.Context) error {
 				"entity", entity,
 				"error", err)
 			errors = append(errors, fmt.Sprintf("%s: %s", entity, err))
+			// Preserve stale keys for this entity if available
+			if stale, ok := r.keyHashes[entity]; ok && len(stale) > 0 {
+				newKeyHashes[entity] = stale
+				r.logger.Info("preserving stale keys for entity",
+					"entity", entity,
+					"stale_key_count", len(stale))
+			}
 			continue
 		}
 
@@ -746,17 +765,19 @@ func (r *WhitelistRegistry) Refresh(ctx context.Context) error {
 		}
 
 		if len(keySet) > 0 {
-			r.keyHashes[entity] = keySet
+			newKeyHashes[entity] = keySet
 			r.logger.Info("loaded keys for entity",
 				"entity", entity,
 				"key_count", len(keySet))
 		}
 	}
 
+	r.keyHashes = newKeyHashes
 	r.lastRefresh = time.Now()
 
 	if len(errors) > 0 {
-		r.keysLoaded = false
+		// Still consider loaded if at least some entities have keys
+		r.keysLoaded = len(newKeyHashes) > 0
 		return fmt.Errorf("failed to fetch keys for %d entities", len(errors))
 	}
 
@@ -813,40 +834,28 @@ func (r *WhitelistRegistry) fetchEntityKeys(ctx context.Context, entity string) 
 	return r.fetchJWKSFromURL(ctx, fallbackURL)
 }
 
-// fetchJWKSFromURL fetches and parses a JWKS from the given URL.
+// parseJWKSPublicKeys parses a JWKS JSON body into public keys.
+func parseJWKSPublicKeys(body []byte) ([]crypto.PublicKey, error) {
+	var jwks map[string]interface{}
+	if err := json.Unmarshal(body, &jwks); err != nil {
+		return nil, fmt.Errorf("parsing JWKS: %w", err)
+	}
+	return ExtractPublicKeysFromJWKS(jwks)
+}
+
+// fetchJWKSFromURL fetches and parses a JWKS from the given URL, using the
+// resilience fetcher for retry and stale-cache fallback.
 func (r *WhitelistRegistry) fetchJWKSFromURL(ctx context.Context, jwksURL string) ([]crypto.PublicKey, error) {
 	// Validate URL scheme
 	if !r.config.AllowHTTP && !strings.HasPrefix(jwksURL, "https://") {
 		return nil, fmt.Errorf("HTTPS required for JWKS fetch (got %s)", jwksURL)
 	}
 
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, jwksURL, nil)
+	result, _, err := r.jwksFetcher.Fetch(ctx, jwksURL)
 	if err != nil {
-		return nil, fmt.Errorf("creating request: %w", err)
+		return nil, fmt.Errorf("fetching JWKS from %s: %w", jwksURL, err)
 	}
-	req.Header.Set("Accept", "application/json")
-
-	resp, err := r.httpClient.Do(req)
-	if err != nil {
-		return nil, fmt.Errorf("fetching JWKS: %w", err)
-	}
-	defer func() { _ = resp.Body.Close() }()
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("JWKS fetch returned status %d from %s", resp.StatusCode, jwksURL)
-	}
-
-	body, err := registry.ReadLimitedBody(resp.Body)
-	if err != nil {
-		return nil, fmt.Errorf("reading response: %w", err)
-	}
-
-	var jwks map[string]interface{}
-	if err := json.Unmarshal(body, &jwks); err != nil {
-		return nil, fmt.Errorf("parsing JWKS: %w", err)
-	}
-
-	return ExtractPublicKeysFromJWKS(jwks)
+	return result, nil
 }
 
 // tryJWTVCIssuerMetadata attempts SD-JWT VC §5.3 JWT VC Issuer Metadata discovery.

--- a/pkg/registry/static/whitelist.go
+++ b/pkg/registry/static/whitelist.go
@@ -192,7 +192,9 @@ func NewWhitelistRegistry(opts ...WhitelistOption) *WhitelistRegistry {
 	}
 
 	// Create JWKS fetcher with retry (uses the configured HTTP client).
-	r.jwksFetcher = resilience.NewFetcher(r.httpClient, parseJWKSPublicKeys, resilience.FetcherConfig{})
+	r.jwksFetcher = resilience.NewFetcher(r.httpClient, parseJWKSPublicKeys, resilience.FetcherConfig{
+		MaxBodyBytes: int64(registry.GetMaxResponseBodyBytes()),
+	})
 
 	r.resolveConfig()
 
@@ -734,20 +736,20 @@ func (r *WhitelistRegistry) Refresh(ctx context.Context) error {
 	newKeyHashes := make(map[string]map[string]bool)
 
 	// Fetch JWKS for each entity
-	var errors []string
+	var fetchErrors []string
 	for entity := range entities {
-		keys, err := r.fetchEntityKeys(ctx, entity)
+		keys, stale, err := r.fetchEntityKeys(ctx, entity)
 		if err != nil {
 			r.logger.Warn("failed to fetch keys for entity",
 				"entity", entity,
 				"error", err)
-			errors = append(errors, fmt.Sprintf("%s: %s", entity, err))
+			fetchErrors = append(fetchErrors, fmt.Sprintf("%s: %s", entity, err))
 			// Preserve stale keys for this entity if available
-			if stale, ok := r.keyHashes[entity]; ok && len(stale) > 0 {
-				newKeyHashes[entity] = stale
+			if old, ok := r.keyHashes[entity]; ok && len(old) > 0 {
+				newKeyHashes[entity] = old
 				r.logger.Info("preserving stale keys for entity",
 					"entity", entity,
-					"stale_key_count", len(stale))
+					"stale_key_count", len(old))
 			}
 			continue
 		}
@@ -766,19 +768,25 @@ func (r *WhitelistRegistry) Refresh(ctx context.Context) error {
 
 		if len(keySet) > 0 {
 			newKeyHashes[entity] = keySet
-			r.logger.Info("loaded keys for entity",
-				"entity", entity,
-				"key_count", len(keySet))
+			if stale {
+				r.logger.Info("using stale-cached keys for entity",
+					"entity", entity,
+					"key_count", len(keySet))
+			} else {
+				r.logger.Info("loaded fresh keys for entity",
+					"entity", entity,
+					"key_count", len(keySet))
+			}
 		}
 	}
 
 	r.keyHashes = newKeyHashes
 	r.lastRefresh = time.Now()
 
-	if len(errors) > 0 {
+	if len(fetchErrors) > 0 {
 		// Still consider loaded if at least some entities have keys
 		r.keysLoaded = len(newKeyHashes) > 0
-		return fmt.Errorf("failed to fetch keys for %d entities", len(errors))
+		return fmt.Errorf("failed to fetch keys for %d entities", len(fetchErrors))
 	}
 
 	r.keysLoaded = true
@@ -806,18 +814,18 @@ func (r *WhitelistRegistry) countTotalKeys() int {
 //  4. OpenID4VCI Metadata (.well-known/openid-credential-issuer)
 //
 // Falls back to {entity}/.well-known/jwks.json if discovery yields nothing.
-func (r *WhitelistRegistry) fetchEntityKeys(ctx context.Context, entity string) ([]crypto.PublicKey, error) {
+func (r *WhitelistRegistry) fetchEntityKeys(ctx context.Context, entity string) ([]crypto.PublicKey, bool, error) {
 	if r.config.JWKSEndpointPattern != "" {
 		// Explicit pattern configured — use it directly (backward compat)
 		return r.fetchJWKSFromURL(ctx, r.buildJWKSURL(entity))
 	}
 
 	// 1. Try SD-JWT VC §5.3 (.well-known/jwt-vc-issuer) — may return inline JWKS
-	keys, err := r.tryJWTVCIssuerMetadata(ctx, entity)
+	keys, stale, err := r.tryJWTVCIssuerMetadata(ctx, entity)
 	if err == nil {
 		r.logger.Info("discovered keys via jwt-vc-issuer metadata",
-			"entity", entity, "key_count", len(keys))
-		return keys, nil
+			"entity", entity, "key_count", len(keys), "stale", stale)
+		return keys, stale, nil
 	}
 	r.logger.Debug("jwt-vc-issuer discovery failed", "entity", entity, "error", err)
 
@@ -845,45 +853,46 @@ func parseJWKSPublicKeys(body []byte) ([]crypto.PublicKey, error) {
 
 // fetchJWKSFromURL fetches and parses a JWKS from the given URL, using the
 // resilience fetcher for retry and stale-cache fallback.
-func (r *WhitelistRegistry) fetchJWKSFromURL(ctx context.Context, jwksURL string) ([]crypto.PublicKey, error) {
+// Returns the parsed keys, whether the result was stale (from cache), and any error.
+func (r *WhitelistRegistry) fetchJWKSFromURL(ctx context.Context, jwksURL string) ([]crypto.PublicKey, bool, error) {
 	// Validate URL scheme
 	if !r.config.AllowHTTP && !strings.HasPrefix(jwksURL, "https://") {
-		return nil, fmt.Errorf("HTTPS required for JWKS fetch (got %s)", jwksURL)
+		return nil, false, fmt.Errorf("HTTPS required for JWKS fetch (got %s)", jwksURL)
 	}
 
-	result, _, err := r.jwksFetcher.Fetch(ctx, jwksURL)
+	result, stale, err := r.jwksFetcher.Fetch(ctx, jwksURL)
 	if err != nil {
-		return nil, fmt.Errorf("fetching JWKS from %s: %w", jwksURL, err)
+		return nil, false, fmt.Errorf("fetching JWKS from %s: %w", jwksURL, err)
 	}
-	return result, nil
+	return result, stale, nil
 }
 
 // tryJWTVCIssuerMetadata attempts SD-JWT VC §5.3 JWT VC Issuer Metadata discovery.
 // The well-known URL is constructed per RFC 8615: the well-known string is inserted
 // between the host component and the path component of the entity URL.
 // The metadata may contain inline "jwks" or a "jwks_uri" reference.
-func (r *WhitelistRegistry) tryJWTVCIssuerMetadata(ctx context.Context, entity string) ([]crypto.PublicKey, error) {
+func (r *WhitelistRegistry) tryJWTVCIssuerMetadata(ctx context.Context, entity string) ([]crypto.PublicKey, bool, error) {
 	metadataURL := buildWellKnownURL(entity, "jwt-vc-issuer")
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, metadataURL, nil)
 	if err != nil {
-		return nil, fmt.Errorf("creating request: %w", err)
+		return nil, false, fmt.Errorf("creating request: %w", err)
 	}
 	req.Header.Set("Accept", "application/json")
 
 	resp, err := r.httpClient.Do(req)
 	if err != nil {
-		return nil, fmt.Errorf("fetching jwt-vc-issuer metadata: %w", err)
+		return nil, false, fmt.Errorf("fetching jwt-vc-issuer metadata: %w", err)
 	}
 	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("jwt-vc-issuer metadata returned status %d", resp.StatusCode)
+		return nil, false, fmt.Errorf("jwt-vc-issuer metadata returned status %d", resp.StatusCode)
 	}
 
 	body, err := registry.ReadLimitedBody(resp.Body)
 	if err != nil {
-		return nil, fmt.Errorf("reading jwt-vc-issuer metadata: %w", err)
+		return nil, false, fmt.Errorf("reading jwt-vc-issuer metadata: %w", err)
 	}
 
 	var metadata struct {
@@ -892,23 +901,24 @@ func (r *WhitelistRegistry) tryJWTVCIssuerMetadata(ctx context.Context, entity s
 		JWKS    map[string]interface{} `json:"jwks,omitempty"`
 	}
 	if err := json.Unmarshal(body, &metadata); err != nil {
-		return nil, fmt.Errorf("parsing jwt-vc-issuer metadata: %w", err)
+		return nil, false, fmt.Errorf("parsing jwt-vc-issuer metadata: %w", err)
 	}
 
 	// Prefer inline JWKS if present
 	if metadata.JWKS != nil {
-		return ExtractPublicKeysFromJWKS(metadata.JWKS)
+		keys, err := ExtractPublicKeysFromJWKS(metadata.JWKS)
+		return keys, false, err
 	}
 
 	// Fall back to jwks_uri
 	if metadata.JWKSURI != "" {
 		if !r.config.AllowHTTP && !strings.HasPrefix(metadata.JWKSURI, "https://") {
-			return nil, fmt.Errorf("jwks_uri must use HTTPS: %s", metadata.JWKSURI)
+			return nil, false, fmt.Errorf("jwks_uri must use HTTPS: %s", metadata.JWKSURI)
 		}
 		return r.fetchJWKSFromURL(ctx, metadata.JWKSURI)
 	}
 
-	return nil, fmt.Errorf("jwt-vc-issuer metadata has neither jwks nor jwks_uri")
+	return nil, false, fmt.Errorf("jwt-vc-issuer metadata has neither jwks nor jwks_uri")
 }
 
 // discoverJWKSURI attempts to discover the JWKS URI for an entity using standard

--- a/pkg/registry/static/whitelist_test.go
+++ b/pkg/registry/static/whitelist_test.go
@@ -1924,3 +1924,130 @@ func TestWhitelist_CredentialTypesInResponse(t *testing.T) {
 		}
 	})
 }
+
+// TestWhitelistRegistry_Refresh_StaleCacheOnFailure verifies that when a refresh
+// fails to fetch keys for some entities, previously cached keys are preserved
+// (stale-cache fallback) and the registry remains healthy.
+func TestWhitelistRegistry_Refresh_StaleCacheOnFailure(t *testing.T) {
+	key1, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	key2, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+
+	jwks1 := map[string]interface{}{
+		"keys": []interface{}{ecdsaPubKeyToJWK(&key1.PublicKey, "key1")},
+	}
+	jwks2 := map[string]interface{}{
+		"keys": []interface{}{ecdsaPubKeyToJWK(&key2.PublicKey, "key2")},
+	}
+
+	// entity2Fail controls whether entity2's JWKS endpoint returns an error.
+	entity2Fail := false
+	mux := http.NewServeMux()
+	mux.HandleFunc("/entity1/.well-known/jwks.json", func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(jwks1)
+	})
+	mux.HandleFunc("/entity2/.well-known/jwks.json", func(w http.ResponseWriter, r *http.Request) {
+		if entity2Fail {
+			http.Error(w, "Service Unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(jwks2)
+	})
+
+	server := httptest.NewServer(mux)
+	defer server.Close()
+
+	entity1URL := server.URL + "/entity1"
+	entity2URL := server.URL + "/entity2"
+
+	reg := NewWhitelistRegistry(WithWhitelistConfig(WhitelistConfig{
+		Lists: map[string][]string{
+			"all": {entity1URL, entity2URL},
+		},
+		Actions: map[string]string{
+			"issuer": "all",
+		},
+		AllowHTTP: true,
+	}))
+
+	// First refresh: both succeed.
+	if err := reg.Refresh(context.Background()); err != nil {
+		t.Fatalf("initial refresh failed: %v", err)
+	}
+	if !reg.Healthy() {
+		t.Fatal("registry should be healthy after successful refresh")
+	}
+
+	// Verify both entities' keys work.
+	for _, tc := range []struct {
+		name   string
+		entity string
+		key    *ecdsa.PublicKey
+	}{
+		{"entity1", entity1URL, &key1.PublicKey},
+		{"entity2", entity2URL, &key2.PublicKey},
+	} {
+		resp, err := reg.Evaluate(context.Background(), &authzen.EvaluationRequest{
+			Subject: authzen.Subject{ID: tc.entity},
+			Action:  &authzen.Action{Name: "issuer"},
+			Resource: authzen.Resource{
+				Type: "jwk",
+				Key:  []interface{}{ecdsaPubKeyToJWK(tc.key, "k")},
+			},
+		})
+		if err != nil {
+			t.Fatalf("%s: unexpected error: %v", tc.name, err)
+		}
+		if !resp.Decision {
+			t.Fatalf("%s: expected allow, got deny", tc.name)
+		}
+	}
+
+	// Second refresh: entity2 fails. The resilience fetcher returns stale cached
+	// data from the first fetch, so refresh should still succeed. Entity2's keys
+	// continue to work transparently.
+	entity2Fail = true
+	if err := reg.Refresh(context.Background()); err != nil {
+		// An error may occur if the stale cache has been invalidated;
+		// either way entity2 keys must still work below.
+		t.Logf("refresh with entity2 failing: %v (stale cache may or may not absorb)", err)
+	}
+
+	// Registry should still be healthy.
+	if !reg.Healthy() {
+		t.Fatal("registry should remain healthy with stale keys")
+	}
+
+	// entity2's key should still work (stale cache).
+	resp, err := reg.Evaluate(context.Background(), &authzen.EvaluationRequest{
+		Subject: authzen.Subject{ID: entity2URL},
+		Action:  &authzen.Action{Name: "issuer"},
+		Resource: authzen.Resource{
+			Type: "jwk",
+			Key:  []interface{}{ecdsaPubKeyToJWK(&key2.PublicKey, "k")},
+		},
+	})
+	if err != nil {
+		t.Fatalf("entity2 stale cache: unexpected error: %v", err)
+	}
+	if !resp.Decision {
+		t.Fatal("entity2 stale cache: expected allow (stale keys preserved), got deny")
+	}
+
+	// entity1 should still work (fresh keys).
+	resp, err = reg.Evaluate(context.Background(), &authzen.EvaluationRequest{
+		Subject: authzen.Subject{ID: entity1URL},
+		Action:  &authzen.Action{Name: "issuer"},
+		Resource: authzen.Resource{
+			Type: "jwk",
+			Key:  []interface{}{ecdsaPubKeyToJWK(&key1.PublicKey, "k")},
+		},
+	})
+	if err != nil {
+		t.Fatalf("entity1 fresh: unexpected error: %v", err)
+	}
+	if !resp.Decision {
+		t.Fatal("entity1 fresh: expected allow, got deny")
+	}
+}

--- a/pkg/registry/static/whitelist_test.go
+++ b/pkg/registry/static/whitelist_test.go
@@ -2005,13 +2005,11 @@ func TestWhitelistRegistry_Refresh_StaleCacheOnFailure(t *testing.T) {
 	}
 
 	// Second refresh: entity2 fails. The resilience fetcher returns stale cached
-	// data from the first fetch, so refresh should still succeed. Entity2's keys
-	// continue to work transparently.
+	// data from the first fetch, so refresh succeeds with stale-cached keys for
+	// entity2. Entity2's keys continue to work transparently.
 	entity2Fail = true
 	if err := reg.Refresh(context.Background()); err != nil {
-		// An error may occur if the stale cache has been invalidated;
-		// either way entity2 keys must still work below.
-		t.Logf("refresh with entity2 failing: %v (stale cache may or may not absorb)", err)
+		t.Fatalf("expected refresh to succeed (stale cache absorbs entity2 failure), got: %v", err)
 	}
 
 	// Registry should still be healthy.

--- a/pkg/resilience/fetcher.go
+++ b/pkg/resilience/fetcher.go
@@ -1,0 +1,227 @@
+// Package resilience provides retry and resilience utilities for HTTP fetch
+// operations used by trust registry implementations.
+//
+// The core abstraction is [Fetcher], which wraps an HTTP fetch function with:
+//   - Exponential backoff retry for transient failures (transport errors, 5xx)
+//   - Stale-cache fallback: on fetch failure, return the previous result if available
+//   - Configurable retry count, base delay, and cache TTL
+//
+// Registry implementations use Fetcher by providing a parse function that converts
+// an HTTP response body into a typed result. The Fetcher handles all retry,
+// caching, and error classification logic.
+package resilience
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"sync"
+	"time"
+)
+
+// TransportError wraps a network/transport-level error (DNS, TCP, TLS).
+type TransportError struct {
+	Err error
+}
+
+func (e *TransportError) Error() string { return e.Err.Error() }
+func (e *TransportError) Unwrap() error { return e.Err }
+
+// HTTPStatusError represents a non-200 HTTP response.
+type HTTPStatusError struct {
+	StatusCode int
+	URL        string
+}
+
+func (e *HTTPStatusError) Error() string {
+	return fmt.Sprintf("HTTP %d from %s", e.StatusCode, e.URL)
+}
+
+// IsRetryable reports whether err is a transient error worth retrying:
+// transport errors and 5xx HTTP responses.
+func IsRetryable(err error) bool {
+	var te *TransportError
+	if errors.As(err, &te) {
+		return true
+	}
+	var se *HTTPStatusError
+	if errors.As(err, &se) {
+		return se.StatusCode >= http.StatusInternalServerError
+	}
+	return false
+}
+
+// FetcherConfig configures a [Fetcher].
+type FetcherConfig struct {
+	// MaxRetries is the maximum number of fetch attempts for transient failures.
+	// Default: 3.
+	MaxRetries int
+
+	// RetryBaseDelay is the initial backoff duration; doubled after each attempt.
+	// Default: 500ms.
+	RetryBaseDelay time.Duration
+
+	// MaxBodyBytes limits the response body size. Default: 10MB.
+	MaxBodyBytes int64
+}
+
+func (c *FetcherConfig) defaults() {
+	if c.MaxRetries <= 0 {
+		c.MaxRetries = 3
+	}
+	if c.RetryBaseDelay <= 0 {
+		c.RetryBaseDelay = 500 * time.Millisecond
+	}
+	if c.MaxBodyBytes <= 0 {
+		c.MaxBodyBytes = 10 << 20 // 10 MB
+	}
+}
+
+// HTTPDoer is the minimal interface for executing HTTP requests.
+type HTTPDoer interface {
+	Do(req *http.Request) (*http.Response, error)
+}
+
+// cachedEntry holds a cached fetch result with its timestamp.
+type cachedEntry[T any] struct {
+	value     T
+	fetchedAt time.Time
+}
+
+// Fetcher performs HTTP fetches with retry and stale-cache fallback.
+// T is the parsed result type (e.g. *JWKS, []crypto.PublicKey).
+type Fetcher[T any] struct {
+	client HTTPDoer
+	config FetcherConfig
+	parse  func(body []byte) (T, error)
+
+	mu    sync.RWMutex
+	cache map[string]*cachedEntry[T]
+}
+
+// NewFetcher creates a Fetcher.
+//
+// client: HTTP client (e.g. SafeHTTPClient or *http.Client).
+// parse: converts the response body into the result type T.
+// config: retry/size settings (zero-value fields use defaults).
+func NewFetcher[T any](client HTTPDoer, parse func(body []byte) (T, error), config FetcherConfig) *Fetcher[T] {
+	config.defaults()
+	return &Fetcher[T]{
+		client: client,
+		config: config,
+		parse:  parse,
+		cache:  make(map[string]*cachedEntry[T]),
+	}
+}
+
+// Fetch retrieves and parses a resource from url.
+//
+// If the fetch succeeds, the result is cached and returned.
+// On transient failure, the fetch is retried with exponential backoff.
+// If all retries fail and a previously cached result exists for this url,
+// the stale cached value is returned (no error).
+// If no cached value exists, the last error is returned.
+func (f *Fetcher[T]) Fetch(ctx context.Context, url string) (T, bool, error) {
+	result, err := f.fetchWithRetry(ctx, url)
+	if err == nil {
+		f.mu.Lock()
+		f.cache[url] = &cachedEntry[T]{value: result, fetchedAt: time.Now()}
+		f.mu.Unlock()
+		return result, false, nil // fresh
+	}
+
+	// Fetch failed — try stale cache
+	f.mu.RLock()
+	entry := f.cache[url]
+	f.mu.RUnlock()
+
+	if entry != nil {
+		var zero T
+		_ = zero
+		return entry.value, true, nil // stale
+	}
+
+	return *new(T), false, err
+}
+
+// Invalidate removes a cached entry for the given URL.
+func (f *Fetcher[T]) Invalidate(url string) {
+	f.mu.Lock()
+	delete(f.cache, url)
+	f.mu.Unlock()
+}
+
+// InvalidateAll clears the entire cache.
+func (f *Fetcher[T]) InvalidateAll() {
+	f.mu.Lock()
+	f.cache = make(map[string]*cachedEntry[T])
+	f.mu.Unlock()
+}
+
+// Config returns a copy of the fetcher's configuration.
+func (f *Fetcher[T]) Config() FetcherConfig {
+	return f.config
+}
+
+// fetchWithRetry performs the HTTP fetch with exponential backoff retry.
+func (f *Fetcher[T]) fetchWithRetry(ctx context.Context, url string) (T, error) {
+	var lastErr error
+	backoff := f.config.RetryBaseDelay
+
+	for attempt := 0; attempt < f.config.MaxRetries; attempt++ {
+		if attempt > 0 {
+			select {
+			case <-ctx.Done():
+				return *new(T), ctx.Err()
+			case <-time.After(backoff):
+			}
+			backoff *= 2
+		}
+
+		result, err := f.doFetch(ctx, url)
+		if err == nil {
+			return result, nil
+		}
+		lastErr = err
+
+		if !IsRetryable(err) {
+			return *new(T), err
+		}
+	}
+
+	return *new(T), fmt.Errorf("fetch failed after %d attempts: %w", f.config.MaxRetries, lastErr)
+}
+
+// doFetch performs a single HTTP GET, reads the body, and parses it.
+func (f *Fetcher[T]) doFetch(ctx context.Context, url string) (T, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return *new(T), fmt.Errorf("creating request: %w", err)
+	}
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := f.client.Do(req)
+	if err != nil {
+		return *new(T), &TransportError{Err: err}
+	}
+	defer func() { _ = resp.Body.Close() }()
+
+	if resp.StatusCode != http.StatusOK {
+		return *new(T), &HTTPStatusError{StatusCode: resp.StatusCode, URL: url}
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, f.config.MaxBodyBytes))
+	if err != nil {
+		return *new(T), &TransportError{Err: fmt.Errorf("reading body: %w", err)}
+	}
+
+	result, err := f.parse(body)
+	if err != nil {
+		// Parse errors are not retryable
+		return *new(T), fmt.Errorf("parsing response from %s: %w", url, err)
+	}
+
+	return result, nil
+}

--- a/pkg/resilience/fetcher.go
+++ b/pkg/resilience/fetcher.go
@@ -55,21 +55,22 @@ func IsRetryable(err error) bool {
 
 // FetcherConfig configures a [Fetcher].
 type FetcherConfig struct {
-	// MaxRetries is the maximum number of fetch attempts for transient failures.
-	// Default: 3.
-	MaxRetries int
+	// MaxAttempts is the maximum number of fetch attempts (1 = no retry).
+	// Default: 3 (1 initial + 2 retries).
+	MaxAttempts int
 
 	// RetryBaseDelay is the initial backoff duration; doubled after each attempt.
 	// Default: 500ms.
 	RetryBaseDelay time.Duration
 
-	// MaxBodyBytes limits the response body size. Default: 10MB.
+	// MaxBodyBytes limits the response body size. Returns an error if the
+	// response exceeds this limit. Default: 10MB.
 	MaxBodyBytes int64
 }
 
 func (c *FetcherConfig) defaults() {
-	if c.MaxRetries <= 0 {
-		c.MaxRetries = 3
+	if c.MaxAttempts <= 0 {
+		c.MaxAttempts = 3
 	}
 	if c.RetryBaseDelay <= 0 {
 		c.RetryBaseDelay = 500 * time.Millisecond
@@ -138,8 +139,6 @@ func (f *Fetcher[T]) Fetch(ctx context.Context, url string) (T, bool, error) {
 	f.mu.RUnlock()
 
 	if entry != nil {
-		var zero T
-		_ = zero
 		return entry.value, true, nil // stale
 	}
 
@@ -170,7 +169,7 @@ func (f *Fetcher[T]) fetchWithRetry(ctx context.Context, url string) (T, error) 
 	var lastErr error
 	backoff := f.config.RetryBaseDelay
 
-	for attempt := 0; attempt < f.config.MaxRetries; attempt++ {
+	for attempt := 0; attempt < f.config.MaxAttempts; attempt++ {
 		if attempt > 0 {
 			select {
 			case <-ctx.Done():
@@ -191,7 +190,7 @@ func (f *Fetcher[T]) fetchWithRetry(ctx context.Context, url string) (T, error) 
 		}
 	}
 
-	return *new(T), fmt.Errorf("fetch failed after %d attempts: %w", f.config.MaxRetries, lastErr)
+	return *new(T), fmt.Errorf("fetch failed after %d attempts: %w", f.config.MaxAttempts, lastErr)
 }
 
 // doFetch performs a single HTTP GET, reads the body, and parses it.
@@ -212,9 +211,12 @@ func (f *Fetcher[T]) doFetch(ctx context.Context, url string) (T, error) {
 		return *new(T), &HTTPStatusError{StatusCode: resp.StatusCode, URL: url}
 	}
 
-	body, err := io.ReadAll(io.LimitReader(resp.Body, f.config.MaxBodyBytes))
+	body, err := io.ReadAll(io.LimitReader(resp.Body, f.config.MaxBodyBytes+1))
 	if err != nil {
 		return *new(T), &TransportError{Err: fmt.Errorf("reading body: %w", err)}
+	}
+	if int64(len(body)) > f.config.MaxBodyBytes {
+		return *new(T), fmt.Errorf("response body from %s exceeds maximum size of %d bytes", url, f.config.MaxBodyBytes)
 	}
 
 	result, err := f.parse(body)

--- a/pkg/resilience/fetcher_test.go
+++ b/pkg/resilience/fetcher_test.go
@@ -61,7 +61,7 @@ func TestFetcher_RetryOnTransientFailure(t *testing.T) {
 	defer server.Close()
 
 	f := NewFetcher(server.Client(), parseTestPayload, FetcherConfig{
-		MaxRetries:     3,
+		MaxAttempts:    3,
 		RetryBaseDelay: 1 * time.Millisecond,
 	})
 
@@ -89,7 +89,7 @@ func TestFetcher_NoRetryOn4xx(t *testing.T) {
 	defer server.Close()
 
 	f := NewFetcher(server.Client(), parseTestPayload, FetcherConfig{
-		MaxRetries:     3,
+		MaxAttempts:    3,
 		RetryBaseDelay: 1 * time.Millisecond,
 	})
 
@@ -116,7 +116,7 @@ func TestFetcher_StaleCacheOnFailure(t *testing.T) {
 	defer server.Close()
 
 	f := NewFetcher(server.Client(), parseTestPayload, FetcherConfig{
-		MaxRetries:     1,
+		MaxAttempts:    1,
 		RetryBaseDelay: 1 * time.Millisecond,
 	})
 
@@ -152,7 +152,7 @@ func TestFetcher_NoStaleCache_ReturnsError(t *testing.T) {
 	defer server.Close()
 
 	f := NewFetcher(server.Client(), parseTestPayload, FetcherConfig{
-		MaxRetries:     1,
+		MaxAttempts:    1,
 		RetryBaseDelay: 1 * time.Millisecond,
 	})
 
@@ -169,7 +169,7 @@ func TestFetcher_ContextCancellation(t *testing.T) {
 	defer server.Close()
 
 	f := NewFetcher(server.Client(), parseTestPayload, FetcherConfig{
-		MaxRetries:     5,
+		MaxAttempts:    5,
 		RetryBaseDelay: 100 * time.Millisecond,
 	})
 
@@ -192,7 +192,7 @@ func TestFetcher_ParseError_NoRetry(t *testing.T) {
 	defer server.Close()
 
 	f := NewFetcher(server.Client(), parseTestPayload, FetcherConfig{
-		MaxRetries:     3,
+		MaxAttempts:    3,
 		RetryBaseDelay: 1 * time.Millisecond,
 	})
 
@@ -219,7 +219,7 @@ func TestFetcher_InvalidateCache(t *testing.T) {
 	defer server.Close()
 
 	f := NewFetcher(server.Client(), parseTestPayload, FetcherConfig{
-		MaxRetries:     1,
+		MaxAttempts:    1,
 		RetryBaseDelay: 1 * time.Millisecond,
 	})
 

--- a/pkg/resilience/fetcher_test.go
+++ b/pkg/resilience/fetcher_test.go
@@ -1,0 +1,264 @@
+package resilience
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+// testPayload is a simple type for testing Fetcher.
+type testPayload struct {
+	Keys []string `json:"keys"`
+}
+
+func parseTestPayload(body []byte) (*testPayload, error) {
+	var p testPayload
+	if err := json.Unmarshal(body, &p); err != nil {
+		return nil, err
+	}
+	if len(p.Keys) == 0 {
+		return nil, fmt.Errorf("no keys")
+	}
+	return &p, nil
+}
+
+func TestFetcher_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"keys":["a","b"]}`)
+	}))
+	defer server.Close()
+
+	f := NewFetcher(server.Client(), parseTestPayload, FetcherConfig{})
+	result, stale, err := f.Fetch(context.Background(), server.URL)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if stale {
+		t.Error("expected fresh result, got stale")
+	}
+	if len(result.Keys) != 2 {
+		t.Errorf("expected 2 keys, got %d", len(result.Keys))
+	}
+}
+
+func TestFetcher_RetryOnTransientFailure(t *testing.T) {
+	var attempts int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&attempts, 1)
+		if n < 3 {
+			http.Error(w, "Service Unavailable", http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"keys":["ok"]}`)
+	}))
+	defer server.Close()
+
+	f := NewFetcher(server.Client(), parseTestPayload, FetcherConfig{
+		MaxRetries:     3,
+		RetryBaseDelay: 1 * time.Millisecond,
+	})
+
+	result, stale, err := f.Fetch(context.Background(), server.URL)
+	if err != nil {
+		t.Fatalf("expected success after retries, got: %v", err)
+	}
+	if stale {
+		t.Error("expected fresh result")
+	}
+	if result.Keys[0] != "ok" {
+		t.Errorf("unexpected key: %s", result.Keys[0])
+	}
+	if got := atomic.LoadInt32(&attempts); got != 3 {
+		t.Errorf("expected 3 attempts, got %d", got)
+	}
+}
+
+func TestFetcher_NoRetryOn4xx(t *testing.T) {
+	var attempts int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		http.Error(w, "Not Found", http.StatusNotFound)
+	}))
+	defer server.Close()
+
+	f := NewFetcher(server.Client(), parseTestPayload, FetcherConfig{
+		MaxRetries:     3,
+		RetryBaseDelay: 1 * time.Millisecond,
+	})
+
+	_, _, err := f.Fetch(context.Background(), server.URL)
+	if err == nil {
+		t.Fatal("expected error for 404")
+	}
+	if got := atomic.LoadInt32(&attempts); got != 1 {
+		t.Errorf("expected 1 attempt (no retry on 404), got %d", got)
+	}
+}
+
+func TestFetcher_StaleCacheOnFailure(t *testing.T) {
+	var requestCount int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&requestCount, 1)
+		if n == 1 {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"keys":["cached"]}`)
+			return
+		}
+		http.Error(w, "Service Unavailable", http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	f := NewFetcher(server.Client(), parseTestPayload, FetcherConfig{
+		MaxRetries:     1,
+		RetryBaseDelay: 1 * time.Millisecond,
+	})
+
+	// Warm the cache.
+	result1, stale1, err := f.Fetch(context.Background(), server.URL)
+	if err != nil {
+		t.Fatalf("initial fetch: %v", err)
+	}
+	if stale1 {
+		t.Error("initial should be fresh")
+	}
+	if result1.Keys[0] != "cached" {
+		t.Errorf("unexpected key: %s", result1.Keys[0])
+	}
+
+	// Second call: server fails, should get stale cache.
+	result2, stale2, err := f.Fetch(context.Background(), server.URL)
+	if err != nil {
+		t.Fatalf("expected stale fallback, got error: %v", err)
+	}
+	if !stale2 {
+		t.Error("expected stale result")
+	}
+	if result2.Keys[0] != "cached" {
+		t.Errorf("unexpected stale key: %s", result2.Keys[0])
+	}
+}
+
+func TestFetcher_NoStaleCache_ReturnsError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "Service Unavailable", http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	f := NewFetcher(server.Client(), parseTestPayload, FetcherConfig{
+		MaxRetries:     1,
+		RetryBaseDelay: 1 * time.Millisecond,
+	})
+
+	_, _, err := f.Fetch(context.Background(), server.URL)
+	if err == nil {
+		t.Fatal("expected error when no stale cache exists")
+	}
+}
+
+func TestFetcher_ContextCancellation(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "Service Unavailable", http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	f := NewFetcher(server.Client(), parseTestPayload, FetcherConfig{
+		MaxRetries:     5,
+		RetryBaseDelay: 100 * time.Millisecond,
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+	defer cancel()
+
+	_, _, err := f.Fetch(ctx, server.URL)
+	if err == nil {
+		t.Fatal("expected error on context cancellation")
+	}
+}
+
+func TestFetcher_ParseError_NoRetry(t *testing.T) {
+	var attempts int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt32(&attempts, 1)
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `not json`)
+	}))
+	defer server.Close()
+
+	f := NewFetcher(server.Client(), parseTestPayload, FetcherConfig{
+		MaxRetries:     3,
+		RetryBaseDelay: 1 * time.Millisecond,
+	})
+
+	_, _, err := f.Fetch(context.Background(), server.URL)
+	if err == nil {
+		t.Fatal("expected parse error")
+	}
+	if got := atomic.LoadInt32(&attempts); got != 1 {
+		t.Errorf("expected 1 attempt (no retry on parse error), got %d", got)
+	}
+}
+
+func TestFetcher_InvalidateCache(t *testing.T) {
+	var requestCount int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		n := atomic.AddInt32(&requestCount, 1)
+		if n == 1 {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"keys":["first"]}`)
+			return
+		}
+		http.Error(w, "Service Unavailable", http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	f := NewFetcher(server.Client(), parseTestPayload, FetcherConfig{
+		MaxRetries:     1,
+		RetryBaseDelay: 1 * time.Millisecond,
+	})
+
+	// Warm cache.
+	_, _, err := f.Fetch(context.Background(), server.URL)
+	if err != nil {
+		t.Fatalf("initial: %v", err)
+	}
+
+	// Invalidate.
+	f.Invalidate(server.URL)
+
+	// Now fetch fails with no stale cache.
+	_, _, err = f.Fetch(context.Background(), server.URL)
+	if err == nil {
+		t.Fatal("expected error after invalidation with failing server")
+	}
+}
+
+func TestIsRetryable(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{"transport error", &TransportError{Err: fmt.Errorf("connection refused")}, true},
+		{"500", &HTTPStatusError{StatusCode: 500, URL: "x"}, true},
+		{"503", &HTTPStatusError{StatusCode: 503, URL: "x"}, true},
+		{"404", &HTTPStatusError{StatusCode: 404, URL: "x"}, false},
+		{"400", &HTTPStatusError{StatusCode: 400, URL: "x"}, false},
+		{"wrapped transport", fmt.Errorf("outer: %w", &TransportError{Err: fmt.Errorf("inner")}), true},
+		{"generic error", fmt.Errorf("something"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsRetryable(tt.err); got != tt.expected {
+				t.Errorf("IsRetryable() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds a shared `pkg/resilience.Fetcher` library and integrates it into the `didjwks` and `whitelist` registries to improve resilience against transient JWKS fetch failures.

## Changes

### New: `pkg/resilience` — shared fetch resilience library

A generic `Fetcher[T]` that wraps HTTP fetch operations with:
- **Exponential backoff retry** for transient failures (transport errors, 5xx responses)
- **Per-URL stale-cache fallback**: on fetch failure, returns the previously cached result
- **Error classification**: only retries transient errors; 4xx and parse errors fail immediately
- Configurable retry count (default: 3), base delay (default: 500ms), and body size limit (default: 10MB)

The `Fetcher` is parameterized by result type, so registries provide a parse function and get retry + caching for free.

### `didjwks` registry — retry on JWKS fetch

- `fetchJWKS` now uses `resilience.Fetcher[*JWKS]` for automatic retry and per-URL caching
- New `MaxRetries` config field (default: 3)
- Most impactful registry for retry: resolves on-demand per request with no background refresh, so a single transient failure previously caused an immediate trust denial

### `whitelist` registry — stale-cache preservation on refresh

Two improvements:
1. `fetchJWKSFromURL` uses `resilience.Fetcher[[]crypto.PublicKey]` for retry on JWKS endpoint fetches
2. `Refresh()` **preserves stale key fingerprints** for entities whose JWKS fetch fails, instead of clearing all keys before fetching. The registry remains `Healthy()` as long as at least some entities have keys, preventing a single issuer outage from breaking all trust evaluation.

### Circuit breaker — already wired (no changes)

The existing `CircuitBreaker` in `pkg/registry/circuit_breaker.go` was already wired into all evaluation strategies in `strategies.go` (FirstMatch, AllRegistries, Sequential, BestMatch). No changes needed.

## Motivation

Mirrors the JWKS retry and circuit breaker patterns added to `go-wallet-backend` in PR #160, adapted for go-trust's different architecture:
- go-wallet-backend: single OIDC validator with JWKS cache
- go-trust: multiple registry backends, each with their own JWKS fetch patterns

## Tests

- 9 new tests in `pkg/resilience/` covering retry, no-retry on 4xx, stale cache, context cancellation, parse errors, cache invalidation, and error classification
- 1 new integration test in `pkg/registry/static/` verifying whitelist stale-cache preservation on partial refresh failure
- All 20 existing test packages pass