### PR TITLE
security: pin Go builder to 1.26.3-alpine (CVE scan remediation)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.26-alpine AS builder
+FROM golang:1.26.3-alpine AS builder
 
 WORKDIR /app
 


### PR DESCRIPTION
## Security Scan Remediation

Pin the Docker builder image from `golang:1.26-alpine` (floating minor) to `golang:1.26.3-alpine` to ensure Go 1.26.3 security fixes are included in builds.

### CVEs Addressed (6 High)
- **CVE-2026-33814**: HTTP/2 SETTINGS infinite loop (DoS) — **applicable**
- **CVE-2026-33811**: LookupCNAME buffer overflow — **applicable**  
- **CVE-2026-32280**: Certificate chain building DoS — applicable via Go upgrade
- **CVE-2026-32283**: TLS key update memory exhaustion — applicable via Go upgrade
- **CVE-2026-42501**: Module proxy validation flaw (build-time)
- **CVE-2026-42499, CVE-2026-39820**: Email parsing DoS (not applicable)
- **CVE-2026-39836**: net.Dial Windows panic (not applicable — Linux)

### Changes
- `Dockerfile`: `golang:1.26-alpine` → `golang:1.26.3-alpine`

go.mod already specifies `go 1.26.3`. This change ensures the builder image matches.

Ref: External security scan 2026-05-20