### PR TITLE
test: contract testing hardening and coverage improvements

### DIFF
--- a/.github/workflows/network-tests.yml
+++ b/.github/workflows/network-tests.yml
@@ -1,6 +1,10 @@
 name: Network Integration Tests
 
 on:
+  # Nightly run to catch upstream trust infrastructure changes
+  schedule:
+    - cron: '0 6 * * *'  # Daily at 06:00 UTC
+
   # Manual trigger from Actions tab (or gh CLI)
   workflow_dispatch:
     inputs:
@@ -17,9 +21,10 @@ jobs:
   network-tests:
     name: Network Integration Tests
     runs-on: ubuntu-latest
-    # Run if manually dispatched OR if the 'run-network-tests' label is present
+    # Run if manually dispatched, scheduled, OR if the 'run-network-tests' label is present
     if: >-
       github.event_name == 'workflow_dispatch' ||
+      github.event_name == 'schedule' ||
       github.event.label.name == 'run-network-tests'
     timeout-minutes: 15
 

--- a/pkg/authzen/fuzz_test.go
+++ b/pkg/authzen/fuzz_test.go
@@ -1,0 +1,111 @@
+package authzen
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// FuzzEvaluationRequestValidate fuzzes the Validate method with arbitrary JSON.
+// This catches panics, infinite loops, or unexpected crashes in the validation
+// and JSON unmarshaling pipeline.
+func FuzzEvaluationRequestValidate(f *testing.F) {
+	// Seed with representative valid and invalid shapes
+	seeds := []string{
+		// Valid x5c request
+		`{"subject":{"type":"key","id":"did:web:x"},"resource":{"type":"x5c","id":"did:web:x","key":["cert"]}}`,
+		// Valid jwk request
+		`{"subject":{"type":"key","id":"did:web:x"},"resource":{"type":"jwk","id":"did:web:x","key":[{"kty":"EC"}]}}`,
+		// Resolution-only
+		`{"subject":{"type":"key","id":"did:web:x"},"resource":{"id":"did:web:x"}}`,
+		// With action
+		`{"subject":{"type":"key","id":"x"},"resource":{"type":"x5c","id":"x","key":["c"]},"action":{"name":"issuer"}}`,
+		// With action parameters
+		`{"subject":{"type":"key","id":"x"},"resource":{"type":"x5c","id":"x","key":["c"]},"action":{"name":"issuer","parameters":{"credential_types":["pid"]}}}`,
+		// With context
+		`{"subject":{"type":"key","id":"x"},"resource":{"type":"x5c","id":"x","key":["c"]},"context":{"flow":"issuance"}}`,
+		// Empty
+		`{}`,
+		// Invalid subject type
+		`{"subject":{"type":"user","id":"alice"},"resource":{"type":"x5c","id":"alice","key":["c"]}}`,
+		// Mismatched IDs
+		`{"subject":{"type":"key","id":"a"},"resource":{"type":"x5c","id":"b","key":["c"]}}`,
+		// Null fields
+		`{"subject":{"type":"key","id":"x"},"resource":{"type":"x5c","id":"x","key":null}}`,
+		// URL subject
+		`{"subject":{"type":"url","id":"https://example.com"},"resource":{"id":"https://example.com"}}`,
+	}
+
+	for _, s := range seeds {
+		f.Add([]byte(s))
+	}
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		var req EvaluationRequest
+		if err := json.Unmarshal(data, &req); err != nil {
+			return // Invalid JSON is fine to skip
+		}
+
+		// Validate must not panic
+		_ = req.Validate()
+
+		// IsResolutionOnlyRequest must not panic
+		_ = req.IsResolutionOnlyRequest()
+
+		// Re-marshal must not panic
+		_, _ = json.Marshal(req)
+	})
+}
+
+// FuzzEvaluationResponseRoundTrip fuzzes response marshaling round-trips.
+func FuzzEvaluationResponseRoundTrip(f *testing.F) {
+	seeds := []string{
+		`{"decision":true}`,
+		`{"decision":false,"context":{"reason":{"error":"not found"}}}`,
+		`{"decision":true,"context":{"trust_metadata":{"id":"did:web:x"}}}`,
+		`{"decision":false}`,
+		`{}`,
+	}
+
+	for _, s := range seeds {
+		f.Add([]byte(s))
+	}
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		var resp EvaluationResponse
+		if err := json.Unmarshal(data, &resp); err != nil {
+			return
+		}
+
+		// Re-marshal must not panic
+		out, err := json.Marshal(resp)
+		if err != nil {
+			t.Fatalf("marshal failed for valid response: %v", err)
+		}
+
+		// Round-trip: unmarshal must succeed
+		var resp2 EvaluationResponse
+		if err := json.Unmarshal(out, &resp2); err != nil {
+			t.Fatalf("round-trip unmarshal failed: %v", err)
+		}
+	})
+}
+
+// FuzzPDPMetadataRoundTrip fuzzes PDPMetadata marshaling.
+func FuzzPDPMetadataRoundTrip(f *testing.F) {
+	seeds := []string{
+		`{"policy_decision_point":"https://pdp.example.com","access_evaluation_endpoint":"https://pdp.example.com/evaluation"}`,
+		`{}`,
+	}
+
+	for _, s := range seeds {
+		f.Add([]byte(s))
+	}
+
+	f.Fuzz(func(t *testing.T, data []byte) {
+		var meta PDPMetadata
+		if err := json.Unmarshal(data, &meta); err != nil {
+			return
+		}
+		_, _ = json.Marshal(meta)
+	})
+}

--- a/pkg/authzen/golden_test.go
+++ b/pkg/authzen/golden_test.go
@@ -10,13 +10,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// goldenVector defines a canonical wire-format fixture.
-type goldenVector struct {
-	Name     string          `json:"name"`
-	Request  json.RawMessage `json:"request,omitempty"`
-	Response json.RawMessage `json:"response,omitempty"`
-}
-
 // TestGoldenWireFormat ensures AuthZEN request/response JSON shapes are stable.
 // If the golden file does not exist it is created (first run).  On subsequent
 // runs the test fails when the serialised form drifts.
@@ -153,11 +146,7 @@ func TestGoldenWireFormat(t *testing.T) {
 
 			want, err := os.ReadFile(goldenPath)
 			if os.IsNotExist(err) {
-				// First run: create the golden file
-				require.NoError(t, os.MkdirAll(goldenDir, 0o755))
-				require.NoError(t, os.WriteFile(goldenPath, got, 0o644))
-				t.Logf("created golden file: %s", goldenPath)
-				return
+				t.Fatalf("golden file missing: %s — run with UPDATE_GOLDEN=1 to create", goldenPath)
 			}
 			require.NoError(t, err, "failed to read golden file %s", goldenPath)
 

--- a/pkg/authzen/golden_test.go
+++ b/pkg/authzen/golden_test.go
@@ -1,0 +1,277 @@
+package authzen
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// goldenVector defines a canonical wire-format fixture.
+type goldenVector struct {
+	Name     string          `json:"name"`
+	Request  json.RawMessage `json:"request,omitempty"`
+	Response json.RawMessage `json:"response,omitempty"`
+}
+
+// TestGoldenWireFormat ensures AuthZEN request/response JSON shapes are stable.
+// If the golden file does not exist it is created (first run).  On subsequent
+// runs the test fails when the serialised form drifts.
+func TestGoldenWireFormat(t *testing.T) {
+	vectors := []struct {
+		name string
+		obj  interface{}
+	}{
+		{
+			name: "full_x5c_request",
+			obj: EvaluationRequest{
+				Subject:  Subject{Type: "key", ID: "https://issuer.example.com"},
+				Resource: Resource{Type: "x5c", ID: "https://issuer.example.com", Key: []interface{}{"MIIBxxx"}},
+				Action:   &Action{Name: "credential-issuer"},
+			},
+		},
+		{
+			name: "full_jwk_request",
+			obj: EvaluationRequest{
+				Subject: Subject{Type: "key", ID: "did:web:example.com"},
+				Resource: Resource{
+					Type: "jwk",
+					ID:   "did:web:example.com",
+					Key: []interface{}{map[string]interface{}{
+						"kty": "EC",
+						"crv": "P-256",
+						"x":   "f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",
+						"y":   "x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0",
+					}},
+				},
+				Action: &Action{Name: "credential-verifier"},
+			},
+		},
+		{
+			name: "action_with_parameters",
+			obj: EvaluationRequest{
+				Subject:  Subject{Type: "key", ID: "https://issuer.example.com"},
+				Resource: Resource{Type: "x5c", ID: "https://issuer.example.com", Key: []interface{}{"MIIBxxx"}},
+				Action: &Action{
+					Name: "credential-issuer",
+					Parameters: map[string]interface{}{
+						"credential_types": []interface{}{"urn:eu.europa.ec.eudi:pid:1"},
+					},
+				},
+			},
+		},
+		{
+			name: "resolution_only_request",
+			obj: EvaluationRequest{
+				Subject:  Subject{Type: "key", ID: "did:web:example.com"},
+				Resource: Resource{ID: "did:web:example.com"},
+			},
+		},
+		{
+			name: "url_subject_request",
+			obj: EvaluationRequest{
+				Subject:  Subject{Type: "url", ID: "https://verifier.example.com"},
+				Resource: Resource{ID: "https://verifier.example.com"},
+			},
+		},
+		{
+			name: "minimal_request_no_action",
+			obj: EvaluationRequest{
+				Subject:  Subject{Type: "key", ID: "did:example:123"},
+				Resource: Resource{Type: "x5c", ID: "did:example:123", Key: []interface{}{"cert"}},
+			},
+		},
+		{
+			name: "request_with_context",
+			obj: EvaluationRequest{
+				Subject:  Subject{Type: "key", ID: "https://issuer.example.com"},
+				Resource: Resource{Type: "x5c", ID: "https://issuer.example.com", Key: []interface{}{"MIIBxxx"}},
+				Context:  map[string]interface{}{"tenant": "acme-corp"},
+			},
+		},
+		{
+			name: "decision_true_response",
+			obj: EvaluationResponse{
+				Decision: true,
+				Context: &EvaluationResponseContext{
+					Reason: map[string]interface{}{
+						"registry": "etsi_tsl",
+					},
+				},
+			},
+		},
+		{
+			name: "decision_false_response",
+			obj: EvaluationResponse{
+				Decision: false,
+				Context: &EvaluationResponseContext{
+					Reason: map[string]interface{}{
+						"error": "no matching trust anchor",
+					},
+				},
+			},
+		},
+		{
+			name: "response_with_trust_metadata",
+			obj: EvaluationResponse{
+				Decision: true,
+				Context: &EvaluationResponseContext{
+					TrustMetadata: map[string]interface{}{
+						"@context": "https://www.w3.org/ns/did/v1",
+						"id":       "did:web:example.com",
+					},
+				},
+			},
+		},
+		{
+			name: "pdp_metadata",
+			obj: PDPMetadata{
+				PolicyDecisionPoint:      "https://pdp.example.com",
+				AccessEvaluationEndpoint: "https://pdp.example.com/evaluation",
+			},
+		},
+	}
+
+	goldenDir := filepath.Join("testdata", "golden")
+
+	for _, v := range vectors {
+		t.Run(v.name, func(t *testing.T) {
+			got, err := json.MarshalIndent(v.obj, "", "  ")
+			require.NoError(t, err)
+
+			goldenPath := filepath.Join(goldenDir, v.name+".json")
+
+			if os.Getenv("UPDATE_GOLDEN") == "1" {
+				require.NoError(t, os.MkdirAll(goldenDir, 0o755))
+				require.NoError(t, os.WriteFile(goldenPath, got, 0o644))
+				t.Logf("updated golden file: %s", goldenPath)
+				return
+			}
+
+			want, err := os.ReadFile(goldenPath)
+			if os.IsNotExist(err) {
+				// First run: create the golden file
+				require.NoError(t, os.MkdirAll(goldenDir, 0o755))
+				require.NoError(t, os.WriteFile(goldenPath, got, 0o644))
+				t.Logf("created golden file: %s", goldenPath)
+				return
+			}
+			require.NoError(t, err, "failed to read golden file %s", goldenPath)
+
+			assert.JSONEq(t, string(want), string(got),
+				"wire format drift detected for %s — run with UPDATE_GOLDEN=1 to update", v.name)
+		})
+	}
+}
+
+// TestGoldenRoundTrip verifies that all golden vectors can be marshaled and
+// unmarshaled without loss. This catches silent field drops or type coercion.
+func TestGoldenRoundTrip(t *testing.T) {
+	t.Run("EvaluationRequest", func(t *testing.T) {
+		requests := []EvaluationRequest{
+			{
+				Subject:  Subject{Type: "key", ID: "did:web:example.com"},
+				Resource: Resource{Type: "jwk", ID: "did:web:example.com", Key: []interface{}{map[string]interface{}{"kty": "EC"}}},
+				Action:   &Action{Name: "issuer", Parameters: map[string]interface{}{"vct": []interface{}{"pid"}}},
+				Context:  map[string]interface{}{"flow": "issuance"},
+			},
+			{
+				Subject:  Subject{Type: "key", ID: "did:web:example.com"},
+				Resource: Resource{ID: "did:web:example.com"},
+			},
+		}
+
+		for i, req := range requests {
+			data, err := json.Marshal(req)
+			require.NoError(t, err, "marshal request %d", i)
+
+			var got EvaluationRequest
+			require.NoError(t, json.Unmarshal(data, &got), "unmarshal request %d", i)
+
+			// Re-marshal for stable comparison
+			data2, err := json.Marshal(got)
+			require.NoError(t, err)
+			assert.JSONEq(t, string(data), string(data2), "round-trip mismatch for request %d", i)
+		}
+	})
+
+	t.Run("EvaluationResponse", func(t *testing.T) {
+		responses := []EvaluationResponse{
+			{Decision: true},
+			{Decision: false, Context: &EvaluationResponseContext{
+				Reason:        map[string]interface{}{"error": "not found"},
+				TrustMetadata: map[string]interface{}{"id": "did:web:x"},
+			}},
+		}
+
+		for i, resp := range responses {
+			data, err := json.Marshal(resp)
+			require.NoError(t, err, "marshal response %d", i)
+
+			var got EvaluationResponse
+			require.NoError(t, json.Unmarshal(data, &got), "unmarshal response %d", i)
+
+			data2, err := json.Marshal(got)
+			require.NoError(t, err)
+			assert.JSONEq(t, string(data), string(data2), "round-trip mismatch for response %d", i)
+		}
+	})
+}
+
+// TestFieldPresence verifies that omitempty fields behave correctly.
+func TestFieldPresence(t *testing.T) {
+	t.Run("action omitted when nil", func(t *testing.T) {
+		req := EvaluationRequest{
+			Subject:  Subject{Type: "key", ID: "x"},
+			Resource: Resource{Type: "x5c", ID: "x", Key: []interface{}{"c"}},
+		}
+		data, err := json.Marshal(req)
+		require.NoError(t, err)
+		assert.NotContains(t, string(data), `"action"`)
+	})
+
+	t.Run("action present when set", func(t *testing.T) {
+		req := EvaluationRequest{
+			Subject:  Subject{Type: "key", ID: "x"},
+			Resource: Resource{Type: "x5c", ID: "x", Key: []interface{}{"c"}},
+			Action:   &Action{Name: "issuer"},
+		}
+		data, err := json.Marshal(req)
+		require.NoError(t, err)
+		assert.Contains(t, string(data), `"action"`)
+	})
+
+	t.Run("context omitted when nil", func(t *testing.T) {
+		req := EvaluationRequest{
+			Subject:  Subject{Type: "key", ID: "x"},
+			Resource: Resource{Type: "x5c", ID: "x", Key: []interface{}{"c"}},
+		}
+		data, err := json.Marshal(req)
+		require.NoError(t, err)
+		assert.NotContains(t, string(data), `"context"`)
+	})
+
+	t.Run("parameters omitted when nil", func(t *testing.T) {
+		action := Action{Name: "issuer"}
+		data, err := json.Marshal(action)
+		require.NoError(t, err)
+		assert.NotContains(t, string(data), `"parameters"`)
+	})
+
+	t.Run("response context omitted when nil", func(t *testing.T) {
+		resp := EvaluationResponse{Decision: true}
+		data, err := json.Marshal(resp)
+		require.NoError(t, err)
+		assert.NotContains(t, string(data), `"context"`)
+	})
+
+	t.Run("response decision false is explicit", func(t *testing.T) {
+		resp := EvaluationResponse{Decision: false}
+		data, err := json.Marshal(resp)
+		require.NoError(t, err)
+		assert.Contains(t, string(data), `"decision":false`)
+	})
+}

--- a/pkg/authzen/testdata/golden/action_with_parameters.json
+++ b/pkg/authzen/testdata/golden/action_with_parameters.json
@@ -1,0 +1,21 @@
+{
+  "subject": {
+    "type": "key",
+    "id": "https://issuer.example.com"
+  },
+  "resource": {
+    "type": "x5c",
+    "id": "https://issuer.example.com",
+    "key": [
+      "MIIBxxx"
+    ]
+  },
+  "action": {
+    "name": "credential-issuer",
+    "parameters": {
+      "credential_types": [
+        "urn:eu.europa.ec.eudi:pid:1"
+      ]
+    }
+  }
+}

--- a/pkg/authzen/testdata/golden/decision_false_response.json
+++ b/pkg/authzen/testdata/golden/decision_false_response.json
@@ -1,0 +1,8 @@
+{
+  "decision": false,
+  "context": {
+    "reason": {
+      "error": "no matching trust anchor"
+    }
+  }
+}

--- a/pkg/authzen/testdata/golden/decision_true_response.json
+++ b/pkg/authzen/testdata/golden/decision_true_response.json
@@ -1,0 +1,8 @@
+{
+  "decision": true,
+  "context": {
+    "reason": {
+      "registry": "etsi_tsl"
+    }
+  }
+}

--- a/pkg/authzen/testdata/golden/full_jwk_request.json
+++ b/pkg/authzen/testdata/golden/full_jwk_request.json
@@ -1,0 +1,21 @@
+{
+  "subject": {
+    "type": "key",
+    "id": "did:web:example.com"
+  },
+  "resource": {
+    "type": "jwk",
+    "id": "did:web:example.com",
+    "key": [
+      {
+        "crv": "P-256",
+        "kty": "EC",
+        "x": "f83OJ3D2xF1Bg8vub9tLe1gHMzV76e8Tus9uPHvRVEU",
+        "y": "x_FEzRu9m36HLN_tue659LNpXW6pCyStikYjKIWI5a0"
+      }
+    ]
+  },
+  "action": {
+    "name": "credential-verifier"
+  }
+}

--- a/pkg/authzen/testdata/golden/full_x5c_request.json
+++ b/pkg/authzen/testdata/golden/full_x5c_request.json
@@ -1,0 +1,16 @@
+{
+  "subject": {
+    "type": "key",
+    "id": "https://issuer.example.com"
+  },
+  "resource": {
+    "type": "x5c",
+    "id": "https://issuer.example.com",
+    "key": [
+      "MIIBxxx"
+    ]
+  },
+  "action": {
+    "name": "credential-issuer"
+  }
+}

--- a/pkg/authzen/testdata/golden/minimal_request_no_action.json
+++ b/pkg/authzen/testdata/golden/minimal_request_no_action.json
@@ -1,0 +1,13 @@
+{
+  "subject": {
+    "type": "key",
+    "id": "did:example:123"
+  },
+  "resource": {
+    "type": "x5c",
+    "id": "did:example:123",
+    "key": [
+      "cert"
+    ]
+  }
+}

--- a/pkg/authzen/testdata/golden/pdp_metadata.json
+++ b/pkg/authzen/testdata/golden/pdp_metadata.json
@@ -1,0 +1,4 @@
+{
+  "policy_decision_point": "https://pdp.example.com",
+  "access_evaluation_endpoint": "https://pdp.example.com/evaluation"
+}

--- a/pkg/authzen/testdata/golden/request_with_context.json
+++ b/pkg/authzen/testdata/golden/request_with_context.json
@@ -1,0 +1,16 @@
+{
+  "subject": {
+    "type": "key",
+    "id": "https://issuer.example.com"
+  },
+  "resource": {
+    "type": "x5c",
+    "id": "https://issuer.example.com",
+    "key": [
+      "MIIBxxx"
+    ]
+  },
+  "context": {
+    "tenant": "acme-corp"
+  }
+}

--- a/pkg/authzen/testdata/golden/resolution_only_request.json
+++ b/pkg/authzen/testdata/golden/resolution_only_request.json
@@ -1,0 +1,11 @@
+{
+  "subject": {
+    "type": "key",
+    "id": "did:web:example.com"
+  },
+  "resource": {
+    "type": "",
+    "id": "did:web:example.com",
+    "key": null
+  }
+}

--- a/pkg/authzen/testdata/golden/response_with_trust_metadata.json
+++ b/pkg/authzen/testdata/golden/response_with_trust_metadata.json
@@ -1,0 +1,9 @@
+{
+  "decision": true,
+  "context": {
+    "trust_metadata": {
+      "@context": "https://www.w3.org/ns/did/v1",
+      "id": "did:web:example.com"
+    }
+  }
+}

--- a/pkg/authzen/testdata/golden/url_subject_request.json
+++ b/pkg/authzen/testdata/golden/url_subject_request.json
@@ -1,0 +1,11 @@
+{
+  "subject": {
+    "type": "url",
+    "id": "https://verifier.example.com"
+  },
+  "resource": {
+    "type": "",
+    "id": "https://verifier.example.com",
+    "key": null
+  }
+}

--- a/pkg/registry/coverage_boost_test.go
+++ b/pkg/registry/coverage_boost_test.go
@@ -24,7 +24,7 @@ import (
 // Circuit breaker: half-open and edge cases
 // ---------------------------------------------------------------------------
 
-func TestCircuitBreaker_HalfOpenTransition(t *testing.T) {
+func TestCircuitBreaker_AllowsAttemptAfterResetTimeout(t *testing.T) {
 	cb := NewCircuitBreaker(2, 10*time.Millisecond)
 
 	// Drive to open
@@ -33,17 +33,18 @@ func TestCircuitBreaker_HalfOpenTransition(t *testing.T) {
 	assert.Equal(t, CircuitOpen, cb.GetState())
 	assert.False(t, cb.CanAttempt())
 
-	// Wait for reset timeout
-	time.Sleep(15 * time.Millisecond)
-	assert.True(t, cb.CanAttempt(), "should allow attempt after reset timeout")
+	// Wait for reset timeout (use generous margin to avoid flakiness)
+	require.Eventually(t, func() bool { return cb.CanAttempt() },
+		500*time.Millisecond, 5*time.Millisecond,
+		"should allow attempt after reset timeout")
 
-	// One more failure from half-open goes straight to open
+	// One more failure goes straight back to open
 	cb.RecordFailure()
 	assert.Equal(t, CircuitOpen, cb.GetState())
 
 	// Wait again, then succeed → should close
-	time.Sleep(15 * time.Millisecond)
-	assert.True(t, cb.CanAttempt())
+	require.Eventually(t, func() bool { return cb.CanAttempt() },
+		500*time.Millisecond, 5*time.Millisecond)
 	cb.RecordSuccess()
 	assert.Equal(t, CircuitClosed, cb.GetState())
 	assert.Equal(t, 0, cb.GetFailureCount())

--- a/pkg/registry/coverage_boost_test.go
+++ b/pkg/registry/coverage_boost_test.go
@@ -1,0 +1,495 @@
+package registry
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"errors"
+	"math/big"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sirosfoundation/go-trust/pkg/authzen"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// Circuit breaker: half-open and edge cases
+// ---------------------------------------------------------------------------
+
+func TestCircuitBreaker_HalfOpenTransition(t *testing.T) {
+	cb := NewCircuitBreaker(2, 10*time.Millisecond)
+
+	// Drive to open
+	cb.RecordFailure()
+	cb.RecordFailure()
+	assert.Equal(t, CircuitOpen, cb.GetState())
+	assert.False(t, cb.CanAttempt())
+
+	// Wait for reset timeout
+	time.Sleep(15 * time.Millisecond)
+	assert.True(t, cb.CanAttempt(), "should allow attempt after reset timeout")
+
+	// One more failure from half-open goes straight to open
+	cb.RecordFailure()
+	assert.Equal(t, CircuitOpen, cb.GetState())
+
+	// Wait again, then succeed → should close
+	time.Sleep(15 * time.Millisecond)
+	assert.True(t, cb.CanAttempt())
+	cb.RecordSuccess()
+	assert.Equal(t, CircuitClosed, cb.GetState())
+	assert.Equal(t, 0, cb.GetFailureCount())
+}
+
+func TestCircuitBreaker_ManualReset(t *testing.T) {
+	cb := NewCircuitBreaker(1, time.Hour)
+	cb.RecordFailure()
+	assert.Equal(t, CircuitOpen, cb.GetState())
+
+	cb.Reset()
+	assert.Equal(t, CircuitClosed, cb.GetState())
+	assert.Equal(t, 0, cb.GetFailureCount())
+	assert.True(t, cb.CanAttempt())
+}
+
+// ---------------------------------------------------------------------------
+// NormalizeSubjectID
+// ---------------------------------------------------------------------------
+
+func TestNormalizeSubjectID_Coverage(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"x509_san_dns:example.com", "https://example.com"},
+		{"x509_san_uri:https://example.com", "https://example.com"},
+		{"https://example.com", "https://example.com"},
+		{"did:web:example.com", "did:web:example.com"},
+	}
+	for _, tt := range tests {
+		assert.Equal(t, tt.want, NormalizeSubjectID(tt.input), tt.input)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// extractDecisionReason coverage
+// ---------------------------------------------------------------------------
+
+func TestExtractDecisionReason(t *testing.T) {
+	tests := []struct {
+		name string
+		resp *authzen.EvaluationResponse
+		want string
+	}{
+		{"nil context", &authzen.EvaluationResponse{Decision: true}, ""},
+		{"nil reason", &authzen.EvaluationResponse{Decision: true, Context: &authzen.EvaluationResponseContext{}}, ""},
+		{"admin reason", &authzen.EvaluationResponse{Decision: false, Context: &authzen.EvaluationResponseContext{
+			Reason: map[string]interface{}{"admin": "detailed info"},
+		}}, "detailed info"},
+		{"allow with user reason", &authzen.EvaluationResponse{Decision: true, Context: &authzen.EvaluationResponseContext{
+			Reason: map[string]interface{}{"user": "trusted via whitelist"},
+		}}, "trusted via whitelist"},
+		{"allow with error fallback", &authzen.EvaluationResponse{Decision: true, Context: &authzen.EvaluationResponseContext{
+			Reason: map[string]interface{}{"error": "some error"},
+		}}, "some error"},
+		{"deny with error", &authzen.EvaluationResponse{Decision: false, Context: &authzen.EvaluationResponseContext{
+			Reason: map[string]interface{}{"error": "not found"},
+		}}, "not found"},
+		{"deny with user fallback", &authzen.EvaluationResponse{Decision: false, Context: &authzen.EvaluationResponseContext{
+			Reason: map[string]interface{}{"user": "denied"},
+		}}, "denied"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.want, extractDecisionReason(tt.resp))
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Strategy edge cases: AllRegistries with mixed results
+// ---------------------------------------------------------------------------
+
+func TestManager_AllRegistries_MixedResults(t *testing.T) {
+	mgr := NewRegistryManager(AllRegistries, 5*time.Second)
+	mgr.Register(&MockRegistry{name: "approve", decision: true, types: []string{"x5c"}})
+	mgr.Register(&MockRegistry{name: "deny", decision: false, types: []string{"x5c"}})
+
+	resp, err := mgr.Evaluate(context.Background(), &authzen.EvaluationRequest{
+		Subject:  authzen.Subject{Type: "key", ID: "test"},
+		Resource: authzen.Resource{Type: "x5c", ID: "test", Key: []interface{}{"cert"}},
+	})
+	require.NoError(t, err)
+	// AllRegistries returns true if ANY registry approves
+	assert.True(t, resp.Decision)
+}
+
+func TestManager_AllRegistries_AllApprove(t *testing.T) {
+	mgr := NewRegistryManager(AllRegistries, 5*time.Second)
+	mgr.Register(&MockRegistry{name: "reg-1", decision: true, types: []string{"x5c"}})
+	mgr.Register(&MockRegistry{name: "reg-2", decision: true, types: []string{"x5c"}})
+
+	resp, err := mgr.Evaluate(context.Background(), &authzen.EvaluationRequest{
+		Subject:  authzen.Subject{Type: "key", ID: "test"},
+		Resource: authzen.Resource{Type: "x5c", ID: "test", Key: []interface{}{"cert"}},
+	})
+	require.NoError(t, err)
+	assert.True(t, resp.Decision)
+}
+
+func TestManager_Sequential_FirstDeniesSecondApproves(t *testing.T) {
+	mgr := NewRegistryManager(Sequential, 5*time.Second)
+	mgr.Register(&MockRegistry{name: "deny-first", decision: false, types: []string{"x5c"}})
+	mgr.Register(&MockRegistry{name: "approve-second", decision: true, types: []string{"x5c"}})
+
+	resp, err := mgr.Evaluate(context.Background(), &authzen.EvaluationRequest{
+		Subject:  authzen.Subject{Type: "key", ID: "test"},
+		Resource: authzen.Resource{Type: "x5c", ID: "test", Key: []interface{}{"cert"}},
+	})
+	require.NoError(t, err)
+	// Sequential stops on first match; deny-first returns false, so it continues to approve-second
+	assert.True(t, resp.Decision)
+}
+
+func TestManager_BestMatch_MultipleApprovals(t *testing.T) {
+	mgr := NewRegistryManager(BestMatch, 5*time.Second)
+	mgr.Register(&MockRegistry{name: "reg-a", decision: true, types: []string{"x5c"}})
+	mgr.Register(&MockRegistry{name: "reg-b", decision: true, types: []string{"x5c"}})
+
+	resp, err := mgr.Evaluate(context.Background(), &authzen.EvaluationRequest{
+		Subject:  authzen.Subject{Type: "key", ID: "test"},
+		Resource: authzen.Resource{Type: "x5c", ID: "test", Key: []interface{}{"cert"}},
+	})
+	require.NoError(t, err)
+	assert.True(t, resp.Decision)
+}
+
+// ---------------------------------------------------------------------------
+// Policy-aware registry filtering
+// ---------------------------------------------------------------------------
+
+func TestManager_PolicyFilteredRegistries(t *testing.T) {
+	mgr := NewRegistryManager(FirstMatch, 5*time.Second)
+	mgr.Register(&MockRegistry{name: "allowed-reg", decision: true, types: []string{"x5c"}})
+	mgr.Register(&MockRegistry{name: "blocked-reg", decision: true, types: []string{"x5c"}})
+
+	pm := NewPolicyManager()
+	pm.RegisterPolicy(&Policy{
+		Name:       "issuer",
+		Registries: []string{"allowed-reg"},
+	})
+	mgr.SetPolicyManager(pm)
+
+	resp, err := mgr.Evaluate(context.Background(), &authzen.EvaluationRequest{
+		Subject:  authzen.Subject{Type: "key", ID: "test"},
+		Resource: authzen.Resource{Type: "x5c", ID: "test", Key: []interface{}{"cert"}},
+		Action:   &authzen.Action{Name: "issuer"},
+	})
+	require.NoError(t, err)
+	assert.True(t, resp.Decision)
+	// Response should come from allowed-reg only
+	if resp.Context != nil && resp.Context.Reason != nil {
+		assert.Equal(t, "allowed-reg", resp.Context.Reason["registry"])
+	}
+}
+
+func TestManager_PolicyAllowedKeyTypesRejection(t *testing.T) {
+	mgr := NewRegistryManager(FirstMatch, 5*time.Second)
+	mgr.Register(&MockRegistry{name: "reg", decision: true, types: []string{"*"}})
+
+	pm := NewPolicyManager()
+	pm.RegisterPolicy(&Policy{
+		Name: "issuer",
+		Constraints: PolicyConstraints{
+			AllowedKeyTypes: []string{"x5c"},
+		},
+	})
+	mgr.SetPolicyManager(pm)
+
+	// JWK not allowed by policy
+	resp, err := mgr.Evaluate(context.Background(), &authzen.EvaluationRequest{
+		Subject:  authzen.Subject{Type: "key", ID: "test"},
+		Resource: authzen.Resource{Type: "jwk", ID: "test", Key: []interface{}{map[string]interface{}{"kty": "EC"}}},
+		Action:   &authzen.Action{Name: "issuer"},
+	})
+	require.NoError(t, err)
+	assert.False(t, resp.Decision)
+	assert.Contains(t, resp.Context.Reason["error"], "resource type not allowed by policy")
+}
+
+// ---------------------------------------------------------------------------
+// No applicable registries
+// ---------------------------------------------------------------------------
+
+func TestManager_NoApplicableRegistries(t *testing.T) {
+	mgr := NewRegistryManager(FirstMatch, 5*time.Second)
+	mgr.Register(&MockRegistry{name: "jwk-only", decision: true, types: []string{"jwk"}})
+
+	resp, err := mgr.Evaluate(context.Background(), &authzen.EvaluationRequest{
+		Subject:  authzen.Subject{Type: "key", ID: "test"},
+		Resource: authzen.Resource{Type: "x5c", ID: "test", Key: []interface{}{"cert"}},
+	})
+	require.NoError(t, err)
+	assert.False(t, resp.Decision)
+}
+
+// ---------------------------------------------------------------------------
+// Registry error during evaluation
+// ---------------------------------------------------------------------------
+
+func TestManager_RegistryError(t *testing.T) {
+	mgr := NewRegistryManager(FirstMatch, 5*time.Second)
+	mgr.Register(&MockRegistry{name: "failing", decision: false, types: []string{"x5c"}, err: errors.New("connection refused")})
+
+	resp, err := mgr.Evaluate(context.Background(), &authzen.EvaluationRequest{
+		Subject:  authzen.Subject{Type: "key", ID: "test"},
+		Resource: authzen.Resource{Type: "x5c", ID: "test", Key: []interface{}{"cert"}},
+	})
+	require.NoError(t, err)
+	assert.False(t, resp.Decision)
+}
+
+// ---------------------------------------------------------------------------
+// Resolution-only request routing
+// ---------------------------------------------------------------------------
+
+func TestManager_ResolutionOnlyRouting(t *testing.T) {
+	mgr := NewRegistryManager(FirstMatch, 5*time.Second)
+	mgr.Register(&MockRegistry{
+		name:                   "resolver",
+		decision:               true,
+		types:                  []string{"jwk"},
+		supportsResolutionOnly: true,
+		trustMetadata:          map[string]interface{}{"id": "did:web:x"},
+	})
+	mgr.Register(&MockRegistry{name: "non-resolver", decision: true, types: []string{"x5c"}})
+
+	// Resolution-only: no resource type or key
+	resp, err := mgr.Evaluate(context.Background(), &authzen.EvaluationRequest{
+		Subject:  authzen.Subject{Type: "key", ID: "did:web:x"},
+		Resource: authzen.Resource{ID: "did:web:x"},
+	})
+	require.NoError(t, err)
+	assert.True(t, resp.Decision)
+}
+
+// ---------------------------------------------------------------------------
+// JWKsMatch utility
+// ---------------------------------------------------------------------------
+
+func TestJWKsMatch(t *testing.T) {
+	tests := []struct {
+		name  string
+		jwk1  map[string]interface{}
+		jwk2  map[string]interface{}
+		match bool
+	}{
+		{"EC match", map[string]interface{}{"kty": "EC", "crv": "P-256", "x": "a", "y": "b"}, map[string]interface{}{"kty": "EC", "crv": "P-256", "x": "a", "y": "b"}, true},
+		{"EC different x", map[string]interface{}{"kty": "EC", "crv": "P-256", "x": "a", "y": "b"}, map[string]interface{}{"kty": "EC", "crv": "P-256", "x": "c", "y": "b"}, false},
+		{"OKP match", map[string]interface{}{"kty": "OKP", "crv": "Ed25519", "x": "a"}, map[string]interface{}{"kty": "OKP", "crv": "Ed25519", "x": "a"}, true},
+		{"OKP different", map[string]interface{}{"kty": "OKP", "crv": "Ed25519", "x": "a"}, map[string]interface{}{"kty": "OKP", "crv": "Ed25519", "x": "b"}, false},
+		{"RSA match", map[string]interface{}{"kty": "RSA", "n": "n1", "e": "e1"}, map[string]interface{}{"kty": "RSA", "n": "n1", "e": "e1"}, true},
+		{"RSA different", map[string]interface{}{"kty": "RSA", "n": "n1", "e": "e1"}, map[string]interface{}{"kty": "RSA", "n": "n2", "e": "e1"}, false},
+		{"different kty", map[string]interface{}{"kty": "EC"}, map[string]interface{}{"kty": "RSA"}, false},
+		{"unknown kty", map[string]interface{}{"kty": "unknown"}, map[string]interface{}{"kty": "unknown"}, false},
+		{"missing kty", map[string]interface{}{}, map[string]interface{}{}, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.match, JWKsMatch(tt.jwk1, tt.jwk2))
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// HTTP utility functions
+// ---------------------------------------------------------------------------
+
+func TestHTTPUtil_SetAndGetMaxResponseBodyBytes(t *testing.T) {
+	original := GetMaxResponseBodyBytes()
+	defer SetMaxResponseBodyBytes(original) // restore
+
+	SetMaxResponseBodyBytes(1024)
+	assert.Equal(t, 1024, GetMaxResponseBodyBytes())
+
+	SetMaxResponseBodyBytes(0) // should reset to default
+	assert.Equal(t, DefaultMaxResponseBodyBytes, GetMaxResponseBodyBytes())
+
+	SetMaxResponseBodyBytes(-1) // should reset to default
+	assert.Equal(t, DefaultMaxResponseBodyBytes, GetMaxResponseBodyBytes())
+}
+
+func TestReadLimitedBody(t *testing.T) {
+	original := GetMaxResponseBodyBytes()
+	defer SetMaxResponseBodyBytes(original)
+
+	SetMaxResponseBodyBytes(10)
+
+	// Under limit
+	data, err := ReadLimitedBody(strings.NewReader("hello"))
+	require.NoError(t, err)
+	assert.Equal(t, "hello", string(data))
+
+	// At limit
+	data, err = ReadLimitedBody(strings.NewReader("0123456789"))
+	require.NoError(t, err)
+	assert.Len(t, data, 10)
+
+	// Over limit
+	_, err = ReadLimitedBody(strings.NewReader("01234567890"))
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds maximum size")
+}
+
+func TestLimitedReader(t *testing.T) {
+	original := GetMaxResponseBodyBytes()
+	defer SetMaxResponseBodyBytes(original)
+
+	SetMaxResponseBodyBytes(5)
+	r := LimitedReader(strings.NewReader("abcdefghij"))
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	// LimitedReader allows limit+1 bytes to detect overflow
+	assert.LessOrEqual(t, buf.Len(), 6)
+}
+
+// ---------------------------------------------------------------------------
+// ParseCertificate / ParseCertificatesPEM
+// ---------------------------------------------------------------------------
+
+func TestParseCertificate_NilExtensions(t *testing.T) {
+	_, err := ParseCertificate([]byte("not-a-cert"), nil)
+	assert.Error(t, err)
+}
+
+func TestParseCertificatesPEM_NilExtensions(t *testing.T) {
+	// Valid PEM with invalid DER body → should skip gracefully
+	pem := []byte("-----BEGIN CERTIFICATE-----\nnotvalid\n-----END CERTIFICATE-----\n")
+	certs, err := ParseCertificatesPEM(pem, nil)
+	require.NoError(t, err)
+	assert.Empty(t, certs)
+}
+
+func TestParseCertificatesPEM_ValidSelfSigned(t *testing.T) {
+	// Generate a real self-signed cert at test time
+	template := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test"},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(time.Hour),
+		BasicConstraintsValid: true,
+	}
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	require.NoError(t, err)
+	pemBlock := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+
+	certs, err := ParseCertificatesPEM(pemBlock, nil)
+	require.NoError(t, err)
+	assert.Len(t, certs, 1)
+}
+
+// ---------------------------------------------------------------------------
+// PolicyContext helper coverage
+// ---------------------------------------------------------------------------
+
+func TestPolicyContext_Getters(t *testing.T) {
+	// nil policy
+	pc := &PolicyContext{}
+	assert.Nil(t, pc.GetOIDFedEntityTypes())
+	assert.Nil(t, pc.GetETSIServiceTypes())
+	assert.Nil(t, pc.GetDIDRequiredServices())
+	assert.Nil(t, pc.GetDIDAllowedDomains())
+	assert.Nil(t, pc.GetMDOCIACAIssuerAllowlist())
+	assert.False(t, pc.HasETSIConstraints())
+	assert.False(t, pc.HasDIDConstraints())
+	assert.False(t, pc.HasMDOCIACAConstraints())
+	assert.False(t, pc.RequiresVerifiableHistory())
+
+	// policy with OIDFed
+	pc = &PolicyContext{Policy: &Policy{
+		OIDFed: &OIDFedPolicyConstraints{
+			EntityTypes:        []string{"openid_relying_party"},
+			RequiredTrustMarks: []string{"tm1"},
+		},
+	}}
+	assert.Equal(t, []string{"openid_relying_party"}, pc.GetOIDFedEntityTypes())
+	assert.Equal(t, []string{"tm1"}, pc.GetOIDFedTrustMarks())
+
+	// policy with ETSI
+	pc = &PolicyContext{Policy: &Policy{
+		ETSI: &ETSIPolicyConstraints{ServiceTypes: []string{"QCert"}},
+	}}
+	assert.True(t, pc.HasETSIConstraints())
+	assert.Equal(t, []string{"QCert"}, pc.GetETSIServiceTypes())
+
+	// policy with DID
+	pc = &PolicyContext{Policy: &Policy{
+		DID: &DIDPolicyConstraints{
+			AllowedDomains:           []string{"example.com"},
+			RequiredServices:         []string{"LinkedDomains"},
+			RequireVerifiableHistory: true,
+		},
+	}}
+	assert.True(t, pc.HasDIDConstraints())
+	assert.Equal(t, []string{"example.com"}, pc.GetDIDAllowedDomains())
+	assert.Equal(t, []string{"LinkedDomains"}, pc.GetDIDRequiredServices())
+	assert.True(t, pc.RequiresVerifiableHistory())
+
+	// policy with MDOCIACA
+	pc = &PolicyContext{Policy: &Policy{
+		MDOCIACA: &MDOCIACAPolicyConstraints{IssuerAllowlist: []string{"SE"}},
+	}}
+	assert.True(t, pc.HasMDOCIACAConstraints())
+	assert.Equal(t, []string{"SE"}, pc.GetMDOCIACAIssuerAllowlist())
+}
+
+// ---------------------------------------------------------------------------
+// ListRegistries
+// ---------------------------------------------------------------------------
+
+func TestManager_ListRegistries(t *testing.T) {
+	mgr := NewRegistryManager(FirstMatch, 5*time.Second)
+	mgr.Register(&MockRegistry{name: "reg-a", decision: true, types: []string{"x5c"}})
+	mgr.Register(&MockRegistry{name: "reg-b", decision: true, types: []string{"jwk"}, supportsResolutionOnly: true})
+
+	infos := mgr.ListRegistries()
+	require.Len(t, infos, 2)
+	assert.Equal(t, "reg-a", infos[0].Name)
+	assert.Equal(t, []string{"x5c"}, infos[0].ResourceTypes)
+	assert.False(t, infos[0].ResolutionOnly)
+	assert.Equal(t, "reg-b", infos[1].Name)
+	assert.True(t, infos[1].ResolutionOnly)
+}
+
+// ---------------------------------------------------------------------------
+// Refresh
+// ---------------------------------------------------------------------------
+
+func TestManager_Refresh_Errors(t *testing.T) {
+	mgr := NewRegistryManager(FirstMatch, 5*time.Second)
+	mgr.Register(&MockRegistry{name: "ok", decision: true, types: []string{"x5c"}})
+	mgr.Register(&MockRegistry{name: "fail", decision: true, types: []string{"x5c"}, refreshErr: errors.New("timeout")})
+
+	err := mgr.Refresh(context.Background())
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "timeout")
+}
+
+func TestManager_Refresh_AllOK(t *testing.T) {
+	mgr := NewRegistryManager(FirstMatch, 5*time.Second)
+	mgr.Register(&MockRegistry{name: "ok1", decision: true, types: []string{"x5c"}})
+	mgr.Register(&MockRegistry{name: "ok2", decision: true, types: []string{"x5c"}})
+
+	err := mgr.Refresh(context.Background())
+	assert.NoError(t, err)
+}

--- a/pkg/registry/didwebvh/evaluate_test.go
+++ b/pkg/registry/didwebvh/evaluate_test.go
@@ -1,0 +1,353 @@
+package didwebvh
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/sirosfoundation/go-trust/pkg/authzen"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// Evaluate edge cases — these exercise paths at 38.1% coverage
+// ---------------------------------------------------------------------------
+
+func TestEvaluate_NonWebVH_Subject(t *testing.T) {
+	r, err := NewDIDWebVHRegistry(Config{})
+	require.NoError(t, err)
+
+	resp, err := r.Evaluate(context.Background(), &authzen.EvaluationRequest{
+		Subject:  authzen.Subject{Type: "key", ID: "did:web:example.com"},
+		Resource: authzen.Resource{Type: "jwk", ID: "did:web:example.com", Key: []interface{}{map[string]interface{}{"kty": "EC"}}},
+	})
+	require.NoError(t, err)
+	assert.False(t, resp.Decision)
+	assert.Contains(t, resp.Context.Reason["error"], "must be a did:webvh identifier")
+}
+
+func TestEvaluate_HTTPFetchError(t *testing.T) {
+	// Server that always returns 404
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	// Extract host from test server URL (e.g., "127.0.0.1:PORT")
+	host := strings.TrimPrefix(srv.URL, "http://")
+
+	// Percent-encode port colon for did:webvh
+	hostEncoded := strings.Replace(host, ":", "%3A", 1)
+
+	scid := "QmWtQnHnZnZnZnZnZnZnZnZnZnZnZnZnZnZnZnZnZnZnZnZ"
+	did := fmt.Sprintf("did:webvh:%s:%s", scid, hostEncoded)
+
+	r, err := NewDIDWebVHRegistry(Config{AllowHTTP: true, AllowPrivateIPs: true})
+	require.NoError(t, err)
+
+	resp, err := r.Evaluate(context.Background(), &authzen.EvaluationRequest{
+		Subject:  authzen.Subject{Type: "key", ID: did},
+		Resource: authzen.Resource{Type: "jwk", ID: did, Key: []interface{}{map[string]interface{}{"kty": "EC"}}},
+	})
+	require.NoError(t, err)
+	assert.False(t, resp.Decision)
+	assert.Contains(t, resp.Context.Reason["error"], "failed to resolve DID")
+}
+
+func TestEvaluate_EmptyDIDLog(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/jsonl")
+		w.WriteHeader(http.StatusOK)
+		// Empty body
+	}))
+	defer srv.Close()
+
+	host := strings.TrimPrefix(srv.URL, "http://")
+	hostEncoded := strings.Replace(host, ":", "%3A", 1)
+	scid := "QmWtQnHnZnZnZnZnZnZnZnZnZnZnZnZnZnZnZnZnZnZnZnZ"
+	did := fmt.Sprintf("did:webvh:%s:%s", scid, hostEncoded)
+
+	r, err := NewDIDWebVHRegistry(Config{AllowHTTP: true, AllowPrivateIPs: true})
+	require.NoError(t, err)
+
+	resp, err := r.Evaluate(context.Background(), &authzen.EvaluationRequest{
+		Subject:  authzen.Subject{Type: "key", ID: did},
+		Resource: authzen.Resource{Type: "jwk", ID: did, Key: []interface{}{map[string]interface{}{"kty": "EC"}}},
+	})
+	require.NoError(t, err)
+	assert.False(t, resp.Decision)
+	assert.Contains(t, resp.Context.Reason["error"], "failed to resolve DID")
+}
+
+func TestEvaluate_InvalidDIDLogJSON(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/jsonl")
+		w.WriteHeader(http.StatusOK)
+		fmt.Fprintln(w, "not valid json at all")
+	}))
+	defer srv.Close()
+
+	host := strings.TrimPrefix(srv.URL, "http://")
+	hostEncoded := strings.Replace(host, ":", "%3A", 1)
+	scid := "QmWtQnHnZnZnZnZnZnZnZnZnZnZnZnZnZnZnZnZnZnZnZnZ"
+	did := fmt.Sprintf("did:webvh:%s:%s", scid, hostEncoded)
+
+	r, err := NewDIDWebVHRegistry(Config{AllowHTTP: true, AllowPrivateIPs: true})
+	require.NoError(t, err)
+
+	resp, err := r.Evaluate(context.Background(), &authzen.EvaluationRequest{
+		Subject:  authzen.Subject{Type: "key", ID: did},
+		Resource: authzen.Resource{Type: "jwk", ID: did, Key: []interface{}{map[string]interface{}{"kty": "EC"}}},
+	})
+	require.NoError(t, err)
+	assert.False(t, resp.Decision)
+}
+
+func TestEvaluate_ContextTimeout(t *testing.T) {
+	// Slow server
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		time.Sleep(2 * time.Second)
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	host := strings.TrimPrefix(srv.URL, "http://")
+	hostEncoded := strings.Replace(host, ":", "%3A", 1)
+	scid := "QmWtQnHnZnZnZnZnZnZnZnZnZnZnZnZnZnZnZnZnZnZnZnZ"
+	did := fmt.Sprintf("did:webvh:%s:%s", scid, hostEncoded)
+
+	r, err := NewDIDWebVHRegistry(Config{AllowHTTP: true, AllowPrivateIPs: true, Timeout: 100 * time.Millisecond})
+	require.NoError(t, err)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+
+	resp, err := r.Evaluate(ctx, &authzen.EvaluationRequest{
+		Subject:  authzen.Subject{Type: "key", ID: did},
+		Resource: authzen.Resource{Type: "jwk", ID: did, Key: []interface{}{map[string]interface{}{"kty": "EC"}}},
+	})
+	require.NoError(t, err)
+	assert.False(t, resp.Decision)
+}
+
+func TestEvaluate_DIDWithFragment(t *testing.T) {
+	// The Evaluate method should strip fragments from subject.id
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	host := strings.TrimPrefix(srv.URL, "http://")
+	hostEncoded := strings.Replace(host, ":", "%3A", 1)
+	scid := "QmWtQnHnZnZnZnZnZnZnZnZnZnZnZnZnZnZnZnZnZnZnZnZ"
+	did := fmt.Sprintf("did:webvh:%s:%s#key-1", scid, hostEncoded)
+
+	r, err := NewDIDWebVHRegistry(Config{AllowHTTP: true, AllowPrivateIPs: true})
+	require.NoError(t, err)
+
+	resp, err := r.Evaluate(context.Background(), &authzen.EvaluationRequest{
+		Subject:  authzen.Subject{Type: "key", ID: did},
+		Resource: authzen.Resource{Type: "jwk", ID: did, Key: []interface{}{map[string]interface{}{"kty": "EC"}}},
+	})
+	require.NoError(t, err)
+	assert.False(t, resp.Decision)
+	// Should have attempted resolution (error about DID resolution, not about identifier format)
+	assert.Contains(t, resp.Context.Reason["error"], "failed to resolve DID")
+}
+
+// ---------------------------------------------------------------------------
+// processDIDLog edge cases
+// ---------------------------------------------------------------------------
+
+func TestProcessDIDLog_MissingSCID(t *testing.T) {
+	r, _ := NewDIDWebVHRegistry(Config{})
+
+	// Entry with no SCID in parameters
+	logLine := `{"versionId":"1-abc","versionTime":"2024-01-01T00:00:00Z","parameters":{},"state":{"id":"did:webvh:QmTest:example.com"}}`
+
+	_, _, err := r.processDIDLog(strings.NewReader(logLine), "QmTest", "did:webvh:QmTest:example.com")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "missing SCID")
+}
+
+func TestProcessDIDLog_SCIDMismatch(t *testing.T) {
+	r, _ := NewDIDWebVHRegistry(Config{})
+
+	logLine := `{"versionId":"1-abc","versionTime":"2024-01-01T00:00:00Z","parameters":{"scid":"QmWrongWrongWrongWrongWrongWrongWrongWrongWrongWrong"},"state":{"id":"did:webvh:QmTest:example.com"}}`
+
+	_, _, err := r.processDIDLog(strings.NewReader(logLine), "QmTestTestTestTestTestTestTestTestTestTestTestTest", "did:webvh:QmTest:example.com")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "SCID mismatch")
+}
+
+func TestProcessDIDLog_InvalidVersionPrefix(t *testing.T) {
+	r, _ := NewDIDWebVHRegistry(Config{})
+
+	// Version should start with "1-" for first entry, but we give "2-"
+	logLine := `{"versionId":"2-abc","versionTime":"2024-01-01T00:00:00Z","parameters":{"scid":"QmTest"},"state":{"id":"did:webvh:QmTest:example.com"}}`
+
+	_, _, err := r.processDIDLog(strings.NewReader(logLine), "QmTest", "did:webvh:QmTest:example.com")
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid versionId")
+}
+
+// ---------------------------------------------------------------------------
+// matchJWK
+// ---------------------------------------------------------------------------
+
+func TestMatchJWK(t *testing.T) {
+	r, _ := NewDIDWebVHRegistry(Config{})
+
+	tests := []struct {
+		name    string
+		reqKey  []interface{}
+		didDoc  *DIDDocument
+		match   bool
+		wantErr bool
+	}{
+		{
+			name:   "matching EC keys",
+			reqKey: []interface{}{map[string]interface{}{"kty": "EC", "crv": "P-256", "x": "abc", "y": "def"}},
+			didDoc: &DIDDocument{
+				VerificationMethod: []VerificationMethod{{
+					ID:   "#key-1",
+					Type: "JsonWebKey2020",
+					PublicKeyJwk: map[string]interface{}{"kty": "EC", "crv": "P-256", "x": "abc", "y": "def"},
+				}},
+			},
+			match: true,
+		},
+		{
+			name:   "non-matching keys",
+			reqKey: []interface{}{map[string]interface{}{"kty": "EC", "crv": "P-256", "x": "abc", "y": "def"}},
+			didDoc: &DIDDocument{
+				VerificationMethod: []VerificationMethod{{
+					ID:   "#key-1",
+					Type: "JsonWebKey2020",
+					PublicKeyJwk: map[string]interface{}{"kty": "EC", "crv": "P-256", "x": "xyz", "y": "def"},
+				}},
+			},
+			match: false,
+		},
+		{
+			name:    "empty request key",
+			reqKey:  []interface{}{},
+			didDoc:  &DIDDocument{},
+			match:   false,
+			wantErr: true,
+		},
+		{
+			name:    "invalid JWK format",
+			reqKey:  []interface{}{"not-a-map"},
+			didDoc:  &DIDDocument{},
+			match:   false,
+			wantErr: true,
+		},
+		{
+			name:   "verification method without JWK",
+			reqKey: []interface{}{map[string]interface{}{"kty": "EC"}},
+			didDoc: &DIDDocument{
+				VerificationMethod: []VerificationMethod{{
+					ID:                 "#key-1",
+					Type:               "Ed25519VerificationKey2020",
+					PublicKeyMultibase: "z6Mk...",
+				}},
+			},
+			match: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			matched, _, err := r.matchJWK(tt.reqKey, tt.didDoc)
+			if tt.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+			assert.Equal(t, tt.match, matched)
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// buildResolutionOnlyResponse
+// ---------------------------------------------------------------------------
+
+func TestBuildResolutionOnlyResponse(t *testing.T) {
+	r, _ := NewDIDWebVHRegistry(Config{})
+
+	didDoc := &DIDDocument{
+		ID: "did:webvh:QmTest:example.com",
+		VerificationMethod: []VerificationMethod{
+			{ID: "did:webvh:QmTest:example.com#key-1", Type: "Ed25519VerificationKey2020"},
+		},
+	}
+	metadata := &DIDMetadata{
+		SCID:      "QmTest",
+		VersionID: "1-abc",
+	}
+
+	resp := r.buildResolutionOnlyResponse(didDoc, metadata, time.Now())
+	assert.True(t, resp.Decision)
+	assert.NotNil(t, resp.Context)
+	assert.Equal(t, true, resp.Context.Reason["resolution_only"])
+	assert.Equal(t, true, resp.Context.Reason["verifiable_history"])
+	assert.NotNil(t, resp.Context.TrustMetadata)
+}
+
+// ---------------------------------------------------------------------------
+// didDocumentToTrustMetadata
+// ---------------------------------------------------------------------------
+
+func TestDidDocumentToTrustMetadata(t *testing.T) {
+	r, _ := NewDIDWebVHRegistry(Config{})
+
+	didDoc := &DIDDocument{
+		Context: "https://www.w3.org/ns/did/v1",
+		ID:      "did:webvh:QmTest:example.com",
+		VerificationMethod: []VerificationMethod{
+			{
+				ID:         "did:webvh:QmTest:example.com#key-1",
+				Type:       "Ed25519VerificationKey2020",
+				Controller: "did:webvh:QmTest:example.com",
+			},
+		},
+	}
+	metadata := &DIDMetadata{
+		SCID:        "QmTest",
+		VersionID:   "2-xyz",
+		VersionTime: "2024-06-01T00:00:00Z",
+		Created:     "2024-01-01T00:00:00Z",
+		Updated:     "2024-06-01T00:00:00Z",
+	}
+
+	trustMeta := r.didDocumentToTrustMetadata(didDoc, metadata)
+	assert.Equal(t, "did:webvh:QmTest:example.com", trustMeta["id"])
+	assert.NotNil(t, trustMeta["verificationMethod"])
+	assert.NotNil(t, trustMeta["didResolutionMetadata"])
+}
+
+// ---------------------------------------------------------------------------
+// Info / SupportedResourceTypes / SupportsResolutionOnly / Healthy / Refresh
+// ---------------------------------------------------------------------------
+
+func TestRegistryMetadata(t *testing.T) {
+	r, err := NewDIDWebVHRegistry(Config{Description: "Test VH"})
+	require.NoError(t, err)
+
+	info := r.Info()
+	assert.Equal(t, "didwebvh-registry", info.Name)
+	assert.Equal(t, "did:webvh", info.Type)
+	assert.Equal(t, "Test VH", info.Description)
+
+	assert.Equal(t, []string{"jwk"}, r.SupportedResourceTypes())
+	assert.True(t, r.SupportsResolutionOnly())
+	assert.True(t, r.Healthy())
+	assert.NoError(t, r.Refresh(context.Background()))
+}

--- a/pkg/testserver/contract_test.go
+++ b/pkg/testserver/contract_test.go
@@ -1,0 +1,193 @@
+package testserver
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/sirosfoundation/go-trust/pkg/authzen"
+	"github.com/sirosfoundation/go-trust/pkg/authzenclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestContract_DiscoverThenEvaluate exercises the full consumer workflow:
+// discover PDP metadata → evaluate trust → check response shape.
+// This is the primary pattern used by go-wallet-backend and vc consumers.
+func TestContract_DiscoverThenEvaluate(t *testing.T) {
+	srv := New(WithAcceptAll())
+	defer srv.Close()
+
+	ctx := context.Background()
+
+	// Step 1: Discover
+	client, err := authzenclient.Discover(ctx, srv.URL())
+	require.NoError(t, err)
+	require.NotNil(t, client.Metadata)
+	assert.NotEmpty(t, client.Metadata.AccessEvaluationEndpoint)
+	assert.NotEmpty(t, client.Metadata.PolicyDecisionPoint)
+
+	// Step 2: Evaluate x5c
+	resp, err := client.EvaluateRaw(ctx, &authzen.EvaluationRequest{
+		Subject:  authzen.Subject{Type: "key", ID: "https://issuer.example.com"},
+		Resource: authzen.Resource{Type: "x5c", ID: "https://issuer.example.com", Key: []interface{}{"MIIBxxx"}},
+		Action:   &authzen.Action{Name: "credential-issuer"},
+	})
+	require.NoError(t, err)
+	assert.True(t, resp.Decision)
+
+	// Step 3: Evaluate jwk
+	resp, err = client.EvaluateRaw(ctx, &authzen.EvaluationRequest{
+		Subject: authzen.Subject{Type: "key", ID: "did:web:example.com"},
+		Resource: authzen.Resource{
+			Type: "jwk",
+			ID:   "did:web:example.com",
+			Key:  []interface{}{map[string]interface{}{"kty": "EC", "crv": "P-256"}},
+		},
+	})
+	require.NoError(t, err)
+	assert.True(t, resp.Decision)
+}
+
+// TestContract_DecisionFuncCapturesRequest verifies that the DecisionFunc
+// receives the exact AuthZEN request shape consumers send.
+func TestContract_DecisionFuncCapturesRequest(t *testing.T) {
+	var captured atomic.Value
+
+	srv := New(WithDecisionFunc(func(req *authzen.EvaluationRequest) (*authzen.EvaluationResponse, error) {
+		captured.Store(req)
+		return &authzen.EvaluationResponse{Decision: true}, nil
+	}))
+	defer srv.Close()
+
+	client := authzenclient.New(srv.URL())
+	ctx := context.Background()
+
+	sent := &authzen.EvaluationRequest{
+		Subject:  authzen.Subject{Type: "key", ID: "https://issuer.example.com"},
+		Resource: authzen.Resource{Type: "x5c", ID: "https://issuer.example.com", Key: []interface{}{"MIIBcert"}},
+		Action: &authzen.Action{
+			Name:       "credential-issuer",
+			Parameters: map[string]interface{}{"credential_types": []interface{}{"urn:eu.europa.ec.eudi:pid:1"}},
+		},
+	}
+
+	resp, err := client.EvaluateRaw(ctx, sent)
+	require.NoError(t, err)
+	assert.True(t, resp.Decision)
+
+	got := captured.Load().(*authzen.EvaluationRequest)
+	require.NotNil(t, got)
+	assert.Equal(t, sent.Subject.Type, got.Subject.Type)
+	assert.Equal(t, sent.Subject.ID, got.Subject.ID)
+	assert.Equal(t, sent.Resource.Type, got.Resource.Type)
+	assert.Equal(t, sent.Action.Name, got.Action.Name)
+	assert.NotNil(t, got.Action.Parameters)
+}
+
+// TestContract_ResolutionOnly verifies that resolution-only requests
+// (no resource.type/key) are handled correctly.
+func TestContract_ResolutionOnly(t *testing.T) {
+	srv := New(WithDecisionFunc(func(req *authzen.EvaluationRequest) (*authzen.EvaluationResponse, error) {
+		return &authzen.EvaluationResponse{
+			Decision: true,
+			Context: &authzen.EvaluationResponseContext{
+				TrustMetadata: map[string]interface{}{
+					"id": req.Subject.ID,
+				},
+			},
+		}, nil
+	}))
+	defer srv.Close()
+
+	client := authzenclient.New(srv.URL())
+	resp, err := client.Resolve(context.Background(), "did:web:example.com")
+	require.NoError(t, err)
+	assert.True(t, resp.Decision)
+	assert.NotNil(t, resp.Context)
+	assert.NotNil(t, resp.Context.TrustMetadata)
+}
+
+// TestContract_ConcurrentEvaluations verifies thread safety under concurrent load.
+func TestContract_ConcurrentEvaluations(t *testing.T) {
+	var counter atomic.Int64
+
+	srv := New(WithDecisionFunc(func(req *authzen.EvaluationRequest) (*authzen.EvaluationResponse, error) {
+		counter.Add(1)
+		return &authzen.EvaluationResponse{Decision: true}, nil
+	}))
+	defer srv.Close()
+
+	client := authzenclient.New(srv.URL())
+	ctx := context.Background()
+
+	const numGoroutines = 20
+	var wg sync.WaitGroup
+	errs := make(chan error, numGoroutines)
+
+	for i := 0; i < numGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			resp, err := client.EvaluateRaw(ctx, &authzen.EvaluationRequest{
+				Subject:  authzen.Subject{Type: "key", ID: "test"},
+				Resource: authzen.Resource{Type: "x5c", ID: "test", Key: []interface{}{"cert"}},
+			})
+			if err != nil {
+				errs <- err
+				return
+			}
+			if !resp.Decision {
+				errs <- assert.AnError
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		t.Errorf("concurrent evaluation failed: %v", err)
+	}
+	assert.Equal(t, int64(numGoroutines), counter.Load())
+}
+
+// TestContract_InvalidRequest verifies the server returns a structured
+// error response (not HTTP error) for invalid AuthZEN requests.
+func TestContract_InvalidRequest(t *testing.T) {
+	srv := New(WithAcceptAll())
+	defer srv.Close()
+
+	client := authzenclient.New(srv.URL())
+	ctx := context.Background()
+
+	// Invalid subject type
+	resp, err := client.EvaluateRaw(ctx, &authzen.EvaluationRequest{
+		Subject:  authzen.Subject{Type: "user", ID: "alice"},
+		Resource: authzen.Resource{Type: "x5c", ID: "alice", Key: []interface{}{"cert"}},
+	})
+	require.NoError(t, err, "server should return a valid JSON response, not an HTTP error")
+	assert.False(t, resp.Decision)
+}
+
+// TestContract_WithMultipleRegistries tests the server with multiple registries
+// configured, mimicking a production-like setup.
+func TestContract_WithMultipleRegistries(t *testing.T) {
+	srv := New(
+		WithMockRegistry("etsi-tsl", false, []string{"x5c"}),
+		WithMockRegistry("oidfed", true, []string{"jwk", "x5c"}),
+	)
+	defer srv.Close()
+
+	client := authzenclient.New(srv.URL())
+	ctx := context.Background()
+
+	// JWK request — only oidfed supports it, should get decision=true
+	resp, err := client.EvaluateRaw(ctx, &authzen.EvaluationRequest{
+		Subject:  authzen.Subject{Type: "key", ID: "did:web:x"},
+		Resource: authzen.Resource{Type: "jwk", ID: "did:web:x", Key: []interface{}{map[string]interface{}{"kty": "EC"}}},
+	})
+	require.NoError(t, err)
+	assert.True(t, resp.Decision, "oidfed registry should approve the jwk request")
+}

--- a/pkg/testserver/contract_test.go
+++ b/pkg/testserver/contract_test.go
@@ -77,8 +77,10 @@ func TestContract_DecisionFuncCapturesRequest(t *testing.T) {
 	require.NoError(t, err)
 	assert.True(t, resp.Decision)
 
-	got := captured.Load().(*authzen.EvaluationRequest)
-	require.NotNil(t, got)
+	loaded := captured.Load()
+	require.NotNil(t, loaded, "decision callback should have been invoked")
+	got, ok := loaded.(*authzen.EvaluationRequest)
+	require.True(t, ok, "captured value should be *EvaluationRequest")
 	assert.Equal(t, sent.Subject.Type, got.Subject.Type)
 	assert.Equal(t, sent.Subject.ID, got.Subject.ID)
 	assert.Equal(t, sent.Resource.Type, got.Resource.Type)

--- a/tests/contract/consumer_test.go
+++ b/tests/contract/consumer_test.go
@@ -1,0 +1,247 @@
+// Package contract tests go-trust's public API surface from the perspective
+// of its consumers (go-wallet-backend, vc).  These tests exercise the patterns
+// that consumer code actually uses, acting as a regression gate against
+// accidental contract breakage.
+package contract
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+
+	"github.com/sirosfoundation/go-trust/pkg/authzen"
+	"github.com/sirosfoundation/go-trust/pkg/authzenclient"
+	"github.com/sirosfoundation/go-trust/pkg/testserver"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ---------------------------------------------------------------------------
+// Pattern 1: go-wallet-backend — AuthZEN evaluator via testserver
+// go-wallet-backend/pkg/trust/authzen/integration_test.go
+// ---------------------------------------------------------------------------
+
+func TestConsumer_WalletBackend_X5CIssuance(t *testing.T) {
+	srv := testserver.New(testserver.WithAcceptAll())
+	defer srv.Close()
+
+	client := authzenclient.New(srv.URL())
+	resp, err := client.EvaluateRaw(context.Background(), &authzen.EvaluationRequest{
+		Subject:  authzen.Subject{Type: "key", ID: "https://issuer.example.com"},
+		Resource: authzen.Resource{Type: "x5c", ID: "https://issuer.example.com", Key: []interface{}{"MIIBxxx"}},
+		Action:   &authzen.Action{Name: "credential-issuer"},
+	})
+	require.NoError(t, err)
+	assert.True(t, resp.Decision)
+}
+
+func TestConsumer_WalletBackend_JWKVerification(t *testing.T) {
+	srv := testserver.New(testserver.WithAcceptAll())
+	defer srv.Close()
+
+	client := authzenclient.New(srv.URL())
+	resp, err := client.EvaluateRaw(context.Background(), &authzen.EvaluationRequest{
+		Subject: authzen.Subject{Type: "key", ID: "did:web:verifier.example.com"},
+		Resource: authzen.Resource{
+			Type: "jwk",
+			ID:   "did:web:verifier.example.com",
+			Key:  []interface{}{map[string]interface{}{"kty": "EC", "crv": "P-256", "x": "f83OJ", "y": "x_FEz"}},
+		},
+		Action: &authzen.Action{Name: "credential-verifier"},
+	})
+	require.NoError(t, err)
+	assert.True(t, resp.Decision)
+}
+
+func TestConsumer_WalletBackend_DecisionCallback(t *testing.T) {
+	// go-wallet-backend uses DecisionFunc to capture and validate request shapes
+	var captured struct {
+		mu  sync.Mutex
+		req *authzen.EvaluationRequest
+	}
+
+	srv := testserver.New(testserver.WithDecisionFunc(func(req *authzen.EvaluationRequest) (*authzen.EvaluationResponse, error) {
+		captured.mu.Lock()
+		captured.req = req
+		captured.mu.Unlock()
+		return &authzen.EvaluationResponse{Decision: true}, nil
+	}))
+	defer srv.Close()
+
+	client := authzenclient.New(srv.URL())
+	_, err := client.EvaluateRaw(context.Background(), &authzen.EvaluationRequest{
+		Subject:  authzen.Subject{Type: "key", ID: "https://issuer.example.com"},
+		Resource: authzen.Resource{Type: "x5c", ID: "https://issuer.example.com", Key: []interface{}{"MIIBcert"}},
+		Action: &authzen.Action{
+			Name:       "credential-issuer",
+			Parameters: map[string]interface{}{"credential_types": []interface{}{"urn:eu.europa.ec.eudi:pid:1"}},
+		},
+	})
+	require.NoError(t, err)
+
+	captured.mu.Lock()
+	got := captured.req
+	captured.mu.Unlock()
+
+	require.NotNil(t, got)
+	assert.Equal(t, "key", got.Subject.Type)
+	assert.Equal(t, "x5c", got.Resource.Type)
+	assert.Equal(t, "credential-issuer", got.Action.Name)
+	assert.NotNil(t, got.Action.Parameters)
+}
+
+// ---------------------------------------------------------------------------
+// Pattern 2: vc — GoTrustResolver resolution-only
+// vc/pkg/keyresolver/gotrust_adapter.go
+// ---------------------------------------------------------------------------
+
+func TestConsumer_VC_ResolutionOnly(t *testing.T) {
+	srv := testserver.New(testserver.WithDecisionFunc(func(req *authzen.EvaluationRequest) (*authzen.EvaluationResponse, error) {
+		return &authzen.EvaluationResponse{
+			Decision: true,
+			Context: &authzen.EvaluationResponseContext{
+				TrustMetadata: map[string]interface{}{
+					"@context": "https://www.w3.org/ns/did/v1",
+					"id":       req.Subject.ID,
+					"verificationMethod": []interface{}{
+						map[string]interface{}{
+							"id":                 req.Subject.ID + "#key-1",
+							"type":               "JsonWebKey2020",
+							"publicKeyJwk":       map[string]interface{}{"kty": "EC", "crv": "P-256"},
+						},
+					},
+				},
+			},
+		}, nil
+	}))
+	defer srv.Close()
+
+	client := authzenclient.New(srv.URL())
+	resp, err := client.Resolve(context.Background(), "did:web:example.com")
+	require.NoError(t, err)
+	assert.True(t, resp.Decision)
+	require.NotNil(t, resp.Context)
+	require.NotNil(t, resp.Context.TrustMetadata)
+
+	// Verify the metadata structure is preserved
+	meta, ok := resp.Context.TrustMetadata.(map[string]interface{})
+	require.True(t, ok, "trust_metadata should be a map")
+	assert.Equal(t, "did:web:example.com", meta["id"])
+	assert.NotNil(t, meta["verificationMethod"])
+}
+
+// ---------------------------------------------------------------------------
+// Pattern 3: vc — GoTrustEvaluator with discovery
+// vc/pkg/trust/gotrust.go
+// ---------------------------------------------------------------------------
+
+func TestConsumer_VC_DiscoveryAndEvaluate(t *testing.T) {
+	srv := testserver.New(testserver.WithAcceptAll())
+	defer srv.Close()
+
+	// vc uses Discover() to find the PDP
+	client, err := authzenclient.Discover(context.Background(), srv.URL())
+	require.NoError(t, err)
+	require.NotNil(t, client.Metadata)
+
+	// Then evaluates x5c cert chains
+	resp, err := client.EvaluateRaw(context.Background(), &authzen.EvaluationRequest{
+		Subject:  authzen.Subject{Type: "key", ID: "https://issuer.example.com"},
+		Resource: authzen.Resource{Type: "x5c", ID: "https://issuer.example.com", Key: []interface{}{"MIIBxxx"}},
+	})
+	require.NoError(t, err)
+	assert.True(t, resp.Decision)
+}
+
+// ---------------------------------------------------------------------------
+// Pattern 4: Wire format stability — consumer JSON shapes
+// ---------------------------------------------------------------------------
+
+func TestConsumer_WireFormat_RequestJSON(t *testing.T) {
+	// Verify the exact JSON keys consumers rely on
+	req := &authzen.EvaluationRequest{
+		Subject:  authzen.Subject{Type: "key", ID: "https://issuer.example.com"},
+		Resource: authzen.Resource{Type: "x5c", ID: "https://issuer.example.com", Key: []interface{}{"MIIBxxx"}},
+		Action:   &authzen.Action{Name: "credential-issuer"},
+	}
+
+	data, err := json.Marshal(req)
+	require.NoError(t, err)
+
+	var raw map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &raw))
+
+	// These are the keys consumers depend on
+	assert.Contains(t, raw, "subject")
+	assert.Contains(t, raw, "resource")
+	assert.Contains(t, raw, "action")
+
+	subject := raw["subject"].(map[string]interface{})
+	assert.Equal(t, "key", subject["type"])
+	assert.Equal(t, "https://issuer.example.com", subject["id"])
+
+	resource := raw["resource"].(map[string]interface{})
+	assert.Equal(t, "x5c", resource["type"])
+	assert.NotNil(t, resource["key"])
+
+	action := raw["action"].(map[string]interface{})
+	assert.Equal(t, "credential-issuer", action["name"])
+}
+
+func TestConsumer_WireFormat_ResponseJSON(t *testing.T) {
+	resp := &authzen.EvaluationResponse{
+		Decision: true,
+		Context: &authzen.EvaluationResponseContext{
+			Reason:        map[string]interface{}{"registry": "etsi_tsl"},
+			TrustMetadata: map[string]interface{}{"id": "did:web:x"},
+		},
+	}
+
+	data, err := json.Marshal(resp)
+	require.NoError(t, err)
+
+	var raw map[string]interface{}
+	require.NoError(t, json.Unmarshal(data, &raw))
+
+	assert.Equal(t, true, raw["decision"])
+	ctx := raw["context"].(map[string]interface{})
+	assert.NotNil(t, ctx["reason"])
+	assert.NotNil(t, ctx["trust_metadata"])
+}
+
+// ---------------------------------------------------------------------------
+// Pattern 5: PDPMetadata discovery contract
+// ---------------------------------------------------------------------------
+
+func TestConsumer_PDPMetadata_Fields(t *testing.T) {
+	srv := testserver.New(testserver.WithAcceptAll())
+	defer srv.Close()
+
+	client, err := authzenclient.Discover(context.Background(), srv.URL())
+	require.NoError(t, err)
+
+	meta := client.Metadata
+	require.NotNil(t, meta)
+
+	// These fields MUST be present per AuthZEN spec
+	assert.NotEmpty(t, meta.PolicyDecisionPoint, "policy_decision_point is required")
+	assert.NotEmpty(t, meta.AccessEvaluationEndpoint, "access_evaluation_endpoint is required")
+}
+
+// ---------------------------------------------------------------------------
+// Pattern 6: Reject-all server (go-wallet-backend negative tests)
+// ---------------------------------------------------------------------------
+
+func TestConsumer_RejectAll(t *testing.T) {
+	srv := testserver.New(testserver.WithRejectAll())
+	defer srv.Close()
+
+	client := authzenclient.New(srv.URL())
+	resp, err := client.EvaluateRaw(context.Background(), &authzen.EvaluationRequest{
+		Subject:  authzen.Subject{Type: "key", ID: "https://issuer.example.com"},
+		Resource: authzen.Resource{Type: "x5c", ID: "https://issuer.example.com", Key: []interface{}{"MIIBxxx"}},
+	})
+	require.NoError(t, err)
+	assert.False(t, resp.Decision)
+}

--- a/tests/contract/consumer_test.go
+++ b/tests/contract/consumer_test.go
@@ -173,19 +173,22 @@ func TestConsumer_WireFormat_RequestJSON(t *testing.T) {
 	require.NoError(t, json.Unmarshal(data, &raw))
 
 	// These are the keys consumers depend on
-	assert.Contains(t, raw, "subject")
-	assert.Contains(t, raw, "resource")
-	assert.Contains(t, raw, "action")
+	require.Contains(t, raw, "subject")
+	require.Contains(t, raw, "resource")
+	require.Contains(t, raw, "action")
 
-	subject := raw["subject"].(map[string]interface{})
+	subject, ok := raw["subject"].(map[string]interface{})
+	require.True(t, ok, "subject should be a map")
 	assert.Equal(t, "key", subject["type"])
 	assert.Equal(t, "https://issuer.example.com", subject["id"])
 
-	resource := raw["resource"].(map[string]interface{})
+	resource, ok := raw["resource"].(map[string]interface{})
+	require.True(t, ok, "resource should be a map")
 	assert.Equal(t, "x5c", resource["type"])
 	assert.NotNil(t, resource["key"])
 
-	action := raw["action"].(map[string]interface{})
+	action, ok := raw["action"].(map[string]interface{})
+	require.True(t, ok, "action should be a map")
 	assert.Equal(t, "credential-issuer", action["name"])
 }
 
@@ -205,7 +208,9 @@ func TestConsumer_WireFormat_ResponseJSON(t *testing.T) {
 	require.NoError(t, json.Unmarshal(data, &raw))
 
 	assert.Equal(t, true, raw["decision"])
-	ctx := raw["context"].(map[string]interface{})
+	require.Contains(t, raw, "context")
+	ctx, ok := raw["context"].(map[string]interface{})
+	require.True(t, ok, "context should be a map")
 	assert.NotNil(t, ctx["reason"])
 	assert.NotNil(t, ctx["trust_metadata"])
 }


### PR DESCRIPTION
## Summary

Comprehensive testing improvements across 7 areas to harden contract stability and boost coverage.

### Changes

1. **Wire-format golden tests** (`pkg/authzen/golden_test.go`)
   - 11 golden vectors ensuring authzen serialization stability
   - Round-trip and field-presence tests
   - Update via `UPDATE_GOLDEN=1 go test`

2. **Fuzz testing** (`pkg/authzen/fuzz_test.go`)
   - 3 fuzz targets: EvaluationRequest validation, Response round-trip, PDPMetadata round-trip

3. **Testserver contract tests** (`pkg/testserver/contract_test.go`)
   - 6 tests covering discover-then-evaluate, decision callbacks, resolution-only, concurrency, invalid requests, multi-registry

4. **Consumer-driven contract tests** (`tests/contract/consumer_test.go`)
   - 9 tests mimicking real usage from go-wallet-backend (X5C issuance, JWK verification, callbacks) and vc (resolution-only, discovery+evaluate)
   - Wire-format compatibility tests for request/response JSON

5. **Registry coverage boost** (`pkg/registry/coverage_boost_test.go`)
   - Coverage: 68.8% → 76.5%
   - Circuit breaker half-open transition, AllRegistries/Sequential/BestMatch strategies, policy filtering, JWK matching, HTTP utils

6. **didwebvh fixture tests** (`pkg/registry/didwebvh/evaluate_test.go`)
   - Coverage: 65.5% → 75.9%
   - Evaluate edge cases (non-webvh subject, HTTP errors, empty/invalid DID log, timeout, fragments)
   - matchJWK (100%), buildResolutionOnlyResponse (100%), processDIDLog edge cases, didDocumentToTrustMetadata

7. **Nightly network test cron** (`.github/workflows/network-tests.yml`)
   - Daily schedule at 06:00 UTC to catch upstream trust infrastructure changes (expired certs, changed entity configs)

### Test Results

All tests pass: `SKIP_NETWORK_TESTS=1 go test ./...`