### PR TITLE
fix: replace read-all with specific permissions in scorecard workflow

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -7,13 +7,17 @@ on:
   schedule:
     - cron: "0 4 * * 1"
 
-permissions: read-all
+permissions:
+  contents: read
+  actions: read
 
 jobs:
   analysis:
     name: Scorecard analysis
     runs-on: ubuntu-latest
     permissions:
+      contents: read
+      actions: read
       security-events: write
       id-token: write
     steps:


### PR DESCRIPTION
SonarCloud flags `permissions: read-all` as a security hotspot.

Replaces with explicit minimal permissions:
- `contents: read` — checkout repo
- `actions: read` — Scorecard reads workflow files for scoring
- Job-level adds `security-events: write` + `id-token: write` (unchanged)