### PR TITLE
ci: use govulncheck-action instead of go install

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
-      - name: Install govulncheck
-        run: go install golang.org/x/vuln/cmd/govulncheck@v1.1.4
       - name: Run govulncheck
-        run: govulncheck ./...
+        uses: golang/govulncheck-action@v1
+        with:
+          go-version-file: go.mod


### PR DESCRIPTION
Replace unpinned `go install govulncheck@v1.1.4` with `golang/govulncheck-action@v1` for deterministic, version-locked vulnerability scanning.

Fixes SonarCloud MAJOR: dependency versions not predictable.