### PR TITLE
ci: migrate Docker workflow to org reusable workflow + bump Go 1.26.4

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -2,65 +2,17 @@ name: Build and Publish Docker Image
 
 on:
   push:
-    branches:
-      - main
-    tags:
-      - 'v*'
+    branches: [main]
+    tags: ['v[0-9]+.[0-9]+.[0-9]+*']
   pull_request:
-    branches:
-      - main
-
-env:
-  REGISTRY: ghcr.io
-  IMAGE_NAME: sirosfoundation/go-trust
+    branches: [main]
 
 jobs:
-  build-and-push:
-    runs-on: ubuntu-latest
+  docker:
+    uses: sirosfoundation/.github/.github/workflows/docker-build-push.yml@main
     permissions:
       contents: read
       packages: write
-
-    steps:
-      - name: Checkout repository
-        uses: actions/checkout@v6
-
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v4
-
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
-
-      - name: Log in to Container Registry
-        if: github.event_name != 'pull_request'
-        uses: docker/login-action@v4
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Extract metadata (tags, labels) for Docker
-        id: meta
-        uses: docker/metadata-action@v6
-        with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
-          tags: |
-            type=ref,event=branch
-            type=ref,event=pr
-            type=semver,pattern={{version}}
-            type=semver,pattern={{major}}.{{minor}}
-            type=semver,pattern={{major}}
-            type=sha,prefix=
-            type=raw,value=latest,enable={{is_default_branch}}
-
-      - name: Build and push Docker image
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      security-events: write
+    with:
+      image-name: sirosfoundation/go-trust

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.26.3-alpine AS builder
+FROM golang:1.26.4-alpine AS builder
 
 WORKDIR /app
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sirosfoundation/go-trust
 
-go 1.26.3
+go 1.26.4
 
 replace github.com/moov-io/signedxml v1.2.3 => github.com/sirosfoundation/signedxml v1.4.0-siros1
 


### PR DESCRIPTION
## What

Replaces the 66-line local Docker workflow with the 18-line reusable workflow caller from `sirosfoundation/.github`.

### Changes

- **docker-publish.yml**: Uses `sirosfoundation/.github/.github/workflows/docker-build-push.yml@main`
  - Adds Trivy CVE scanning (results in Security tab)
  - Adds VEX support for CVE filtering
  - Adds PR image push support (same tag policy)
- **Dockerfile**: Bumps Go builder from `1.26.3` → `1.26.4`
- **go.mod**: Bumps Go from `1.26.3` → `1.26.4`

### Go 1.26.4 security fixes

This image was the only one in the org with CRITICAL/HIGH CVEs — all from Go stdlib 1.26.3:

- CVE-2026-42504 (HIGH): MIME header decoding DoS
- CVE-2026-27145 (MEDIUM): x509 VerifyHostname bypass
- CVE-2026-42507 (MEDIUM): net/textproto error information leak

Related: sirosfoundation/.github#20