### PR TITLE
fix: normalize environment variable naming prefix to GT_

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ gt \
 | `--log-format` | Log format: text, json | `text` |
 | `--config` | Configuration file (YAML) | - |
 
-Environment variable: `GO_TRUST_EXTERNAL_URL` for external URL.
+Environment variable: `GT_EXTERNAL_URL` for external URL.
 
 ## API Endpoints
 

--- a/cmd/gt/main.go
+++ b/cmd/gt/main.go
@@ -76,7 +76,7 @@ func usage() {
 	fmt.Fprintln(os.Stderr, "  --host         API server hostname (default: 127.0.0.1)")
 	fmt.Fprintln(os.Stderr, "  --port         API server port (default: 6001)")
 	fmt.Fprintln(os.Stderr, "  --external-url External URL for PDP discovery (e.g., https://pdp.example.com)")
-	fmt.Fprintln(os.Stderr, "                 Can also be set via GO_TRUST_EXTERNAL_URL environment variable")
+	fmt.Fprintln(os.Stderr, "                 Can also be set via GT_EXTERNAL_URL environment variable")
 	fmt.Fprintln(os.Stderr, "\nETSI TSL Registry Options:")
 	fmt.Fprintln(os.Stderr, "  --etsi-cert-bundle   Path to PEM file with trusted CA certificates")
 	fmt.Fprintln(os.Stderr, "  --etsi-tsl-files     Comma-separated list of local TSL XML files")
@@ -332,7 +332,7 @@ func main() {
 	// Set BaseURL for .well-known discovery
 	baseURL := *externalURL
 	if baseURL == "" {
-		baseURL = os.Getenv("GO_TRUST_EXTERNAL_URL")
+		baseURL = os.Getenv("GT_EXTERNAL_URL")
 	}
 	if baseURL == "" {
 		baseURL = fmt.Sprintf("http://%s:%s", *host, *port)

--- a/example/kubernetes.yaml
+++ b/example/kubernetes.yaml
@@ -57,7 +57,7 @@ spec:
           containerPort: 6001
           protocol: TCP
         env:
-        - name: GO_TRUST_EXTERNAL_URL
+        - name: GT_EXTERNAL_URL
           value: "https://pdp.example.com"
         livenessProbe:
           httpGet:

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -200,9 +200,9 @@ func RegisterAPIRoutes(r *gin.Engine, serverCtx *ServerContext) {
 	r.GET("/info", InfoHandler(serverCtx))
 
 	// Test-mode shutdown endpoint
-	// This endpoint is only registered when GO_TRUST_TEST_MODE environment variable is set
+	// This endpoint is only registered when GT_TEST_MODE environment variable is set
 	// It allows integration tests to gracefully shutdown the server
-	if os.Getenv("GO_TRUST_TEST_MODE") == "1" {
+	if os.Getenv("GT_TEST_MODE") == "1" {
 		r.POST("/test/shutdown", TestShutdownHandler(serverCtx))
 		serverCtx.Logger.Warn("Test mode enabled: /test/shutdown endpoint is available")
 	}

--- a/pkg/registry/lote/published_lote_test.go
+++ b/pkg/registry/lote/published_lote_test.go
@@ -27,8 +27,8 @@ const (
 
 func skipIfOffline(t *testing.T) {
 	t.Helper()
-	if os.Getenv("GO_TRUST_INTEGRATION") == "" {
-		t.Skip("set GO_TRUST_INTEGRATION to a non-empty value to run live integration tests")
+	if os.Getenv("GT_INTEGRATION") == "" {
+		t.Skip("set GT_INTEGRATION to a non-empty value to run live integration tests")
 	}
 	client := &http.Client{Timeout: 10 * time.Second}
 	resp, err := client.Head(loteURL)


### PR DESCRIPTION
"GO_TRUST" is used as an env prefix in some places. Use "GT_" instead as it is used elsewhere:

https://github.com/sirosfoundation/go-trust/blob/7449fd449d733dff92b951220ac4ca90baf03c1a/example/docker-compose.yaml#L15-L19