### PR TITLE
feat: close RFC003 conformance gaps (Phases 1–5)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -157,6 +157,6 @@ jobs:
     - name: golangci-lint
       uses: golangci/golangci-lint-action@v9
       with:
-        version: v2.10.0
+        version: v2.12.2
         args: --timeout=5m --tests=false
         verify: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.26.4-alpine AS builder
+FROM golang:1.26.5-alpine AS builder
 
 WORKDIR /app
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/sirosfoundation/go-trust
 
-go 1.26.4
+go 1.26.5
 
 replace github.com/moov-io/signedxml v1.2.3 => github.com/sirosfoundation/signedxml v1.4.0-siros1
 

--- a/pkg/registry/lote/jws_verify.go
+++ b/pkg/registry/lote/jws_verify.go
@@ -1,9 +1,11 @@
 // Package lote — LoTE JWS signature verification per ETSI TS 119 615.
 //
-// verifyLoTESignature verifies the JWS envelope of a LoTE JWT document when a
-// non-nil trust anchor pool is provided. The LoTE document MUST be a compact
-// JWS (header.payload.signature) or a JSON serialisation with a protected
-// header that carries the signer certificate chain in the x5c header parameter.
+// VerifyLoTESignature verifies the JWS envelope of a LoTE JWT document when a
+// non-nil trust anchor pool is provided. Two JWS serializations are supported:
+//   - Compact serialization: "<header>.<payload>.<signature>"
+//   - Flattened JSON serialization: {"protected":"…","payload":"…","signature":"…"}
+//
+// General JSON serialization (multiple signatures array) is NOT supported.
 //
 // If the trust anchor pool is nil the function returns nil (verification skipped).
 // This preserves backwards compatibility for callers that use NilTrustAnchorProvider.
@@ -142,7 +144,9 @@ func verifyJWSSignature(alg string, pub crypto.PublicKey, signingInput, sig []by
 		h := jwsHash(alg)
 		hh := h.New()
 		hh.Write(signingInput)
-		return rsa.VerifyPSS(rsaKey, h, hh.Sum(nil), sig, nil)
+		// RFC 7518 §3.5 requires salt length = hash length for PS256/384/512.
+		pssOpts := &rsa.PSSOptions{SaltLength: rsa.PSSSaltLengthEqualsHash, Hash: h}
+		return rsa.VerifyPSS(rsaKey, h, hh.Sum(nil), sig, pssOpts)
 
 	case "ES256", "ES384", "ES512":
 		ecKey, ok := pub.(*ecdsa.PublicKey)

--- a/pkg/registry/lote/jws_verify.go
+++ b/pkg/registry/lote/jws_verify.go
@@ -1,0 +1,230 @@
+// Package lote — LoTE JWS signature verification per ETSI TS 119 615.
+//
+// verifyLoTESignature verifies the JWS envelope of a LoTE JWT document when a
+// non-nil trust anchor pool is provided. The LoTE document MUST be a compact
+// JWS (header.payload.signature) or a JSON serialisation with a protected
+// header that carries the signer certificate chain in the x5c header parameter.
+//
+// If the trust anchor pool is nil the function returns nil (verification skipped).
+// This preserves backwards compatibility for callers that use NilTrustAnchorProvider.
+//
+// References:
+//   - ETSI TS 119 615 v1.1.1 — Trust Anchor validation procedures
+//   - ETSI TS 119 612 v2.1.1 — Trusted List format (JSON)
+//   - RFC 7515 — JSON Web Signature
+package lote
+
+import (
+	"context"
+	"crypto"
+	"crypto/ecdsa"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/sha512"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"hash"
+	"io"
+	"math/big"
+	"net/http"
+	"os"
+	"strings"
+	"time"
+)
+
+// VerifyLoTESignature verifies the JWS signature of a raw LoTE payload.
+//
+// raw is the raw bytes fetched from the LoTE endpoint (compact JWT or JSON).
+// roots is the CertPool to anchor the signer certificate chain; nil means skip.
+// now is the verification time (normally time.Now(), injected for testing).
+//
+// On success the signer leaf certificate is returned so callers can log it.
+// Returns (nil, nil) when roots is nil (verification skipped).
+func VerifyLoTESignature(ctx context.Context, raw []byte, roots *x509.CertPool, now time.Time) (*x509.Certificate, error) {
+	if roots == nil {
+		return nil, nil
+	}
+
+	token := strings.TrimSpace(string(raw))
+
+	var headerB64, payloadB64, sigB64 string
+	if parts := strings.Split(token, "."); len(parts) == 3 {
+		// Compact JWS
+		headerB64, payloadB64, sigB64 = parts[0], parts[1], parts[2]
+	} else {
+		// Try JSON serialisation: {"protected":"…","payload":"…","signature":"…"}
+		var flat struct {
+			Protected string `json:"protected"`
+			Payload   string `json:"payload"`
+			Signature string `json:"signature"`
+		}
+		if err := json.Unmarshal(raw, &flat); err != nil {
+			return nil, fmt.Errorf("lote: cannot parse as compact JWT or JSON JWS: %w", err)
+		}
+		headerB64 = flat.Protected
+		payloadB64 = flat.Payload
+		sigB64 = flat.Signature
+	}
+
+	// Decode header
+	headerBytes, err := base64.RawURLEncoding.DecodeString(headerB64)
+	if err != nil {
+		return nil, fmt.Errorf("lote: decoding JWS header: %w", err)
+	}
+	var header struct {
+		Alg string   `json:"alg"`
+		X5C []string `json:"x5c"`
+	}
+	if err := json.Unmarshal(headerBytes, &header); err != nil {
+		return nil, fmt.Errorf("lote: parsing JWS header: %w", err)
+	}
+	if len(header.X5C) == 0 {
+		return nil, fmt.Errorf("lote: JWS header missing x5c certificate chain required by ETSI TS 119 615")
+	}
+
+	// Parse x5c chain
+	leaf, intermediates, err := parseX5CChainRaw(header.X5C)
+	if err != nil {
+		return nil, fmt.Errorf("lote: parsing x5c from JWS header: %w", err)
+	}
+
+	// Verify signer certificate against trust anchors
+	verifyOpts := x509.VerifyOptions{
+		Roots:         roots,
+		Intermediates: intermediates,
+		CurrentTime:   now,
+		KeyUsages:     []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
+	}
+	if _, err := leaf.Verify(verifyOpts); err != nil {
+		return nil, fmt.Errorf("lote: signer certificate chain validation failed: %w", err)
+	}
+
+	// Verify JWS signature
+	signingInput := headerB64 + "." + payloadB64
+	sigBytes, err := base64.RawURLEncoding.DecodeString(sigB64)
+	if err != nil {
+		return nil, fmt.Errorf("lote: decoding JWS signature: %w", err)
+	}
+	if err := verifyJWSSignature(header.Alg, leaf.PublicKey, []byte(signingInput), sigBytes); err != nil {
+		return nil, fmt.Errorf("lote: JWS signature verification failed: %w", err)
+	}
+
+	return leaf, nil
+}
+
+// verifyJWSSignature checks a JWS signature given the algorithm name, public key,
+// signing input (ASCII bytes of "header.payload"), and raw signature bytes.
+func verifyJWSSignature(alg string, pub crypto.PublicKey, signingInput, sig []byte) error {
+	switch alg {
+	case "RS256", "RS384", "RS512":
+		rsaKey, ok := pub.(*rsa.PublicKey)
+		if !ok {
+			return fmt.Errorf("algorithm %s requires RSA public key", alg)
+		}
+		h, hash := algHash(alg)
+		digest := h.Sum(nil)
+		_ = digest
+		hh := hash.New()
+		hh.Write(signingInput)
+		return rsa.VerifyPKCS1v15(rsaKey, hash, hh.Sum(nil), sig)
+
+	case "PS256", "PS384", "PS512":
+		rsaKey, ok := pub.(*rsa.PublicKey)
+		if !ok {
+			return fmt.Errorf("algorithm %s requires RSA public key", alg)
+		}
+		_, hash := algHash(alg)
+		hh := hash.New()
+		hh.Write(signingInput)
+		return rsa.VerifyPSS(rsaKey, hash, hh.Sum(nil), sig, nil)
+
+	case "ES256", "ES384", "ES512":
+		ecKey, ok := pub.(*ecdsa.PublicKey)
+		if !ok {
+			return fmt.Errorf("algorithm %s requires ECDSA public key", alg)
+		}
+		_, hash := algHash(alg)
+		hh := hash.New()
+		hh.Write(signingInput)
+		digest := hh.Sum(nil)
+		// ECDSA JWS signature is r || s (fixed-size big-endian)
+		keyBytes := (ecKey.Curve.Params().BitSize + 7) / 8
+		if len(sig) != 2*keyBytes {
+			return fmt.Errorf("ECDSA signature has unexpected length %d (want %d)", len(sig), 2*keyBytes)
+		}
+		r := new(big.Int).SetBytes(sig[:keyBytes])
+		s := new(big.Int).SetBytes(sig[keyBytes:])
+		if !ecdsa.Verify(ecKey, digest, r, s) {
+			return fmt.Errorf("ECDSA signature invalid")
+		}
+		return nil
+
+	default:
+		return fmt.Errorf("unsupported JWS algorithm %q", alg)
+	}
+}
+
+// algHash maps a JWA algorithm name to a zeroed hash.Hash and its crypto.Hash ID.
+func algHash(alg string) (hash.Hash, crypto.Hash) {
+	switch alg {
+	case "RS256", "PS256", "ES256":
+		return sha256.New(), crypto.SHA256
+	case "RS384", "PS384", "ES384":
+		return sha512.New384(), crypto.SHA384
+	default: // RS512, PS512, ES512
+		return sha512.New(), crypto.SHA512
+	}
+}
+
+// parseX5CChainRaw parses a base64-encoded DER x5c array into leaf and
+// intermediates. Returns an error when the array is empty or parsing fails.
+func parseX5CChainRaw(x5c []string) (*x509.Certificate, *x509.CertPool, error) {
+	if len(x5c) == 0 {
+		return nil, nil, fmt.Errorf("x5c is empty")
+	}
+	intermediates := x509.NewCertPool()
+	var leaf *x509.Certificate
+	for i, b64 := range x5c {
+		der, err := base64.StdEncoding.DecodeString(b64)
+		if err != nil {
+			// Some implementations use raw URL encoding
+			der, err = base64.RawStdEncoding.DecodeString(b64)
+			if err != nil {
+				return nil, nil, fmt.Errorf("x5c[%d]: base64 decode failed: %w", i, err)
+			}
+		}
+		cert, err := x509.ParseCertificate(der)
+		if err != nil {
+			return nil, nil, fmt.Errorf("x5c[%d]: parse certificate: %w", i, err)
+		}
+		if i == 0 {
+			leaf = cert
+		} else {
+			intermediates.AddCert(cert)
+		}
+	}
+	return leaf, intermediates, nil
+}
+
+// fetchRawSource fetches the raw bytes from a URL or local file path.
+// Used to obtain the original JWS payload for signature verification before
+// the parsed LoTE is accepted.
+func fetchRawSource(src string, timeout time.Duration) ([]byte, error) {
+	if strings.HasPrefix(src, "http://") || strings.HasPrefix(src, "https://") {
+		client := &http.Client{Timeout: timeout}
+		resp, err := client.Get(src) //nolint:noctx // timeout set on client
+		if err != nil {
+			return nil, fmt.Errorf("HTTP GET %s: %w", src, err)
+		}
+		defer resp.Body.Close()
+		if resp.StatusCode != http.StatusOK {
+			return nil, fmt.Errorf("HTTP GET %s returned status %d", src, resp.StatusCode)
+		}
+		return io.ReadAll(io.LimitReader(resp.Body, 10<<20)) // 10 MiB safety limit
+	}
+	// Local file
+	path := strings.TrimPrefix(src, "file://")
+	return os.ReadFile(path)
+}

--- a/pkg/registry/lote/jws_verify.go
+++ b/pkg/registry/lote/jws_verify.go
@@ -218,7 +218,7 @@ func fetchRawSource(src string, timeout time.Duration) ([]byte, error) {
 		if err != nil {
 			return nil, fmt.Errorf("HTTP GET %s: %w", src, err)
 		}
-		defer resp.Body.Close()
+		defer func() { _ = resp.Body.Close() }()
 		if resp.StatusCode != http.StatusOK {
 			return nil, fmt.Errorf("HTTP GET %s returned status %d", src, resp.StatusCode)
 		}

--- a/pkg/registry/lote/jws_verify.go
+++ b/pkg/registry/lote/jws_verify.go
@@ -19,19 +19,20 @@ import (
 	"crypto"
 	"crypto/ecdsa"
 	"crypto/rsa"
-	"crypto/sha256"
-	"crypto/sha512"
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"hash"
 	"io"
 	"math/big"
 	"net/http"
 	"os"
 	"strings"
 	"time"
+
+	// Import hash implementations so crypto.SHA256 etc. are available via .New().
+	_ "crypto/sha256"
+	_ "crypto/sha512"
 )
 
 // VerifyLoTESignature verifies the JWS signature of a raw LoTE payload.
@@ -123,33 +124,36 @@ func verifyJWSSignature(alg string, pub crypto.PublicKey, signingInput, sig []by
 		if !ok {
 			return fmt.Errorf("algorithm %s requires RSA public key", alg)
 		}
-		h, hash := algHash(alg)
-		digest := h.Sum(nil)
-		_ = digest
-		hh := hash.New()
+		h := jwsHash(alg)
+		hh := h.New()
 		hh.Write(signingInput)
-		return rsa.VerifyPKCS1v15(rsaKey, hash, hh.Sum(nil), sig)
+		// RS256/384/512 use PKCS#1 v1.5 signature scheme per RFC 7518 §3.3.
+		// This is a signature verification operation (not encryption); PKCS#1 v1.5
+		// is a valid and widely-deployed JWS algorithm. RSA-PSS (PS256/384/512) is
+		// preferred for new deployments but RS* must be supported for interoperability
+		// with existing LoTE signers.
+		return rsa.VerifyPKCS1v15(rsaKey, h, hh.Sum(nil), sig) //nolint:gosec
 
 	case "PS256", "PS384", "PS512":
 		rsaKey, ok := pub.(*rsa.PublicKey)
 		if !ok {
 			return fmt.Errorf("algorithm %s requires RSA public key", alg)
 		}
-		_, hash := algHash(alg)
-		hh := hash.New()
+		h := jwsHash(alg)
+		hh := h.New()
 		hh.Write(signingInput)
-		return rsa.VerifyPSS(rsaKey, hash, hh.Sum(nil), sig, nil)
+		return rsa.VerifyPSS(rsaKey, h, hh.Sum(nil), sig, nil)
 
 	case "ES256", "ES384", "ES512":
 		ecKey, ok := pub.(*ecdsa.PublicKey)
 		if !ok {
 			return fmt.Errorf("algorithm %s requires ECDSA public key", alg)
 		}
-		_, hash := algHash(alg)
-		hh := hash.New()
+		h := jwsHash(alg)
+		hh := h.New()
 		hh.Write(signingInput)
 		digest := hh.Sum(nil)
-		// ECDSA JWS signature is r || s (fixed-size big-endian)
+		// ECDSA JWS signature is r || s (fixed-size big-endian) per RFC 7518 §3.4.
 		keyBytes := (ecKey.Curve.Params().BitSize + 7) / 8
 		if len(sig) != 2*keyBytes {
 			return fmt.Errorf("ECDSA signature has unexpected length %d (want %d)", len(sig), 2*keyBytes)
@@ -166,15 +170,15 @@ func verifyJWSSignature(alg string, pub crypto.PublicKey, signingInput, sig []by
 	}
 }
 
-// algHash maps a JWA algorithm name to a zeroed hash.Hash and its crypto.Hash ID.
-func algHash(alg string) (hash.Hash, crypto.Hash) {
+// jwsHash maps a JWA algorithm name to its crypto.Hash identifier (RFC 7518 §3).
+func jwsHash(alg string) crypto.Hash {
 	switch alg {
 	case "RS256", "PS256", "ES256":
-		return sha256.New(), crypto.SHA256
+		return crypto.SHA256
 	case "RS384", "PS384", "ES384":
-		return sha512.New384(), crypto.SHA384
+		return crypto.SHA384
 	default: // RS512, PS512, ES512
-		return sha512.New(), crypto.SHA512
+		return crypto.SHA512
 	}
 }
 

--- a/pkg/registry/lote/registry.go
+++ b/pkg/registry/lote/registry.go
@@ -243,8 +243,14 @@ func (r *Registry) Evaluate(ctx context.Context, req *authzen.EvaluationRequest)
 		// when issuer resolution fails and a register client is configured, attempt
 		// a register lookup before denying. A successful register response is treated
 		// as equivalent to "registered but not yet notified in LoTE".
+		// Release the RLock before the (potentially blocking) network call to avoid
+		// stalling concurrent refreshes or other evaluations under the writer lock.
 		if r.config.RegisterClient != nil {
-			if regEnt, regErr := r.config.RegisterClient.LookupRP(ctx, subjectID); regErr == nil && regEnt != nil && regEnt.IsValid() {
+			regClient := r.config.RegisterClient
+			r.mu.RUnlock()
+			regEnt, regErr := regClient.LookupRP(ctx, subjectID)
+			r.mu.RLock()
+			if regErr == nil && regEnt != nil && regEnt.IsValid() {
 				reason := map[string]interface{}{
 					"admin":               fmt.Sprintf("entity %q resolved via National Register fallback (not in LoTE)", subjectID),
 					"registration_status": string(regEnt.RegistrationStatus),
@@ -649,6 +655,15 @@ func (r *Registry) refresh() error {
 					slog.String("source", src),
 					slog.String("signer", signerCert.Subject.CommonName))
 			}
+			// Parse from the same raw bytes that were verified to eliminate the
+			// TOCTOU race: a second fetch via FetchLoTE could return different
+			// content between signature verification and index building.
+			lote, err := etsi119602.ParseLoTE(raw)
+			if err != nil {
+				return fmt.Errorf("failed to parse verified LoTE from %s: %w", src, err)
+			}
+			lotes = append(lotes, lote)
+			continue
 		}
 		lote, err := etsi119602.FetchLoTE(src, opts)
 		if err != nil {

--- a/pkg/registry/lote/registry.go
+++ b/pkg/registry/lote/registry.go
@@ -56,6 +56,22 @@ type Config struct {
 	// CryptoExt provides extensible certificate parsing for non-standard curves
 	// (e.g. brainpool). If nil, standard x509.ParseCertificate is used.
 	CryptoExt *cryptoutil.Extensions
+
+	// TrustAnchorProvider supplies root certificates used to anchor the LoTE
+	// signer certificate chain for JWS signature verification per ETSI TS 119 615.
+	// When nil (or when the provider returns a nil pool), signature verification
+	// is skipped — suitable for test environments or deployments where the source
+	// is trusted through other means (HTTPS, controlled distribution).
+	// For APTITUDE/EUDI production use, inject an implementation that fetches
+	// roots from the OJEU or a pinned bundle.
+	TrustAnchorProvider LoTETrustAnchorProvider
+
+	// RegisterClient is an optional National Register client used as a fallback
+	// when WRPAC/WRPRC issuer resolution fails (AUTHZ-WRPAC-01-FAIL per RFC003).
+	// When nil, no register fallback is attempted and the request is denied.
+	// Inject a real implementation pointing at the national common REST API
+	// (GET /wrp) for production APTITUDE/EUDI deployments.
+	RegisterClient rpcert.NationalRegisterClient
 }
 
 // Registry is a TrustRegistry backed by ETSI TS 119 602 LoTE documents.
@@ -202,7 +218,7 @@ func (r *Registry) Stop() {
 
 // --- TrustRegistry interface ---
 
-func (r *Registry) Evaluate(_ context.Context, req *authzen.EvaluationRequest) (*authzen.EvaluationResponse, error) {
+func (r *Registry) Evaluate(ctx context.Context, req *authzen.EvaluationRequest) (*authzen.EvaluationResponse, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
@@ -221,6 +237,26 @@ func (r *Registry) Evaluate(_ context.Context, req *authzen.EvaluationRequest) (
 		if req.Resource.Type == "x5c" && r.index.globalCertPool != nil {
 			if resp := r.validateX5CChainCA(req, credentialTypes); resp != nil {
 				return resp, nil
+			}
+		}
+		// National Register fallback (RFC003 AUTHZ-WRPAC-01-FAIL / AUTHZ-WRPRC-01-FAIL):
+		// when issuer resolution fails and a register client is configured, attempt
+		// a register lookup before denying. A successful register response is treated
+		// as equivalent to "registered but not yet notified in LoTE".
+		if r.config.RegisterClient != nil {
+			if regEnt, regErr := r.config.RegisterClient.LookupRP(ctx, subjectID); regErr == nil && regEnt != nil && regEnt.IsValid() {
+				reason := map[string]interface{}{
+					"admin":               fmt.Sprintf("entity %q resolved via National Register fallback (not in LoTE)", subjectID),
+					"registration_status": string(regEnt.RegistrationStatus),
+				}
+				addCredentialTypesToReason(reason, credentialTypes)
+				return &authzen.EvaluationResponse{
+					Decision: true,
+					Context: &authzen.EvaluationResponseContext{
+						Reason:        reason,
+						TrustMetadata: regEnt,
+					},
+				}, nil
 			}
 		}
 		reason := map[string]interface{}{
@@ -585,8 +621,35 @@ func (r *Registry) refresh() error {
 		Timeout: r.config.FetchTimeout,
 	}
 
+	// Resolve trust anchors once per refresh (may be nil → skip sig verification).
+	var taPool *x509.CertPool
+	if r.config.TrustAnchorProvider != nil {
+		var taErr error
+		taPool, taErr = r.config.TrustAnchorProvider.TrustAnchors(context.Background())
+		if taErr != nil {
+			return fmt.Errorf("lote: resolving trust anchors: %w", taErr)
+		}
+	}
+
 	// Load direct LoTE sources (JSON or XML, auto-detected).
 	for _, src := range r.config.Sources {
+		// When a TrustAnchorProvider is configured, fetch raw bytes first so we
+		// can verify the JWS signature before accepting the parsed content.
+		if taPool != nil {
+			raw, rawErr := fetchRawSource(src, r.config.FetchTimeout)
+			if rawErr != nil {
+				return fmt.Errorf("failed to fetch raw LoTE from %s: %w", src, rawErr)
+			}
+			signerCert, sigErr := VerifyLoTESignature(context.Background(), raw, taPool, time.Now())
+			if sigErr != nil {
+				return fmt.Errorf("LoTE signature verification failed for %s: %w", src, sigErr)
+			}
+			if signerCert != nil && r.config.Logger != nil {
+				r.config.Logger.Info("LoTE JWS signature verified",
+					slog.String("source", src),
+					slog.String("signer", signerCert.Subject.CommonName))
+			}
+		}
 		lote, err := etsi119602.FetchLoTE(src, opts)
 		if err != nil {
 			return fmt.Errorf("failed to fetch LoTE from %s: %w", src, err)

--- a/pkg/registry/lote/rfc003_test.go
+++ b/pkg/registry/lote/rfc003_test.go
@@ -1,0 +1,377 @@
+package lote
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"math/big"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sirosfoundation/g119612/pkg/etsi119602"
+	"github.com/sirosfoundation/go-trust/pkg/authzen"
+	"github.com/sirosfoundation/go-trust/pkg/registry/rpcert"
+)
+
+// ─── key / cert helpers ─────────────────────────────────────────────────────
+
+func newECKey(t *testing.T) *ecdsa.PrivateKey {
+	t.Helper()
+	k, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	return k
+}
+
+func selfSignedCert(t *testing.T, key *ecdsa.PrivateKey, cn string, notAfter time.Time) *x509.Certificate {
+	t.Helper()
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(42),
+		Subject:      pkix.Name{CommonName: cn},
+		NotBefore:    time.Now().Add(-time.Minute),
+		NotAfter:     notAfter,
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+	cert, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	return cert
+}
+
+// compactJWS builds an ES256 compact JWS with an x5c header carrying signerCert.
+func compactJWS(t *testing.T, signerKey *ecdsa.PrivateKey, signerCert *x509.Certificate, payload []byte) string {
+	t.Helper()
+	headerJSON, err := json.Marshal(map[string]interface{}{
+		"alg": "ES256",
+		"x5c": []string{base64.StdEncoding.EncodeToString(signerCert.Raw)},
+	})
+	require.NoError(t, err)
+
+	hB64 := base64.RawURLEncoding.EncodeToString(headerJSON)
+	pB64 := base64.RawURLEncoding.EncodeToString(payload)
+	signingInput := hB64 + "." + pB64
+
+	digest := sha256.Sum256([]byte(signingInput))
+	r, s, err := ecdsa.Sign(rand.Reader, signerKey, digest[:])
+	require.NoError(t, err)
+
+	n := (signerKey.Curve.Params().BitSize + 7) / 8
+	sig := make([]byte, 2*n)
+	r.FillBytes(sig[:n])
+	s.FillBytes(sig[n:])
+
+	return hB64 + "." + pB64 + "." + base64.RawURLEncoding.EncodeToString(sig)
+}
+
+// tamperedJWS replaces the payload in a compact JWS without re-signing.
+func tamperedJWS(token, newPayload string) string {
+	parts := splitDots(token)
+	parts[1] = base64.RawURLEncoding.EncodeToString([]byte(newPayload))
+	return parts[0] + "." + parts[1] + "." + parts[2]
+}
+
+func splitDots(s string) [3]string {
+	var out [3]string
+	first := indexByte(s, '.')
+	last := lastIndexByte(s, '.')
+	out[0] = s[:first]
+	out[1] = s[first+1 : last]
+	out[2] = s[last+1:]
+	return out
+}
+
+func indexByte(s string, c byte) int {
+	for i := range s {
+		if s[i] == c {
+			return i
+		}
+	}
+	return -1
+}
+
+func lastIndexByte(s string, c byte) int {
+	for i := len(s) - 1; i >= 0; i-- {
+		if s[i] == c {
+			return i
+		}
+	}
+	return -1
+}
+
+// ─── VerifyLoTESignature ────────────────────────────────────────────────────
+
+func TestVerifyLoTESignature_NilRootsSkips(t *testing.T) {
+	cert, err := VerifyLoTESignature(context.Background(), []byte("anything"), nil, time.Now())
+	require.NoError(t, err)
+	assert.Nil(t, cert, "nil roots must skip verification and return nil")
+}
+
+func TestVerifyLoTESignature_MissingX5C(t *testing.T) {
+	roots := x509.NewCertPool()
+	hJSON, _ := json.Marshal(map[string]interface{}{"alg": "ES256"}) // no x5c
+	h := base64.RawURLEncoding.EncodeToString(hJSON)
+	p := base64.RawURLEncoding.EncodeToString([]byte("{}"))
+	s := base64.RawURLEncoding.EncodeToString([]byte("sig"))
+	_, err := VerifyLoTESignature(context.Background(), []byte(h+"."+p+"."+s), roots, time.Now())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "x5c")
+}
+
+func TestVerifyLoTESignature_ValidSignature(t *testing.T) {
+	key := newECKey(t)
+	cert := selfSignedCert(t, key, "LoTE Signer", time.Now().Add(time.Hour))
+	token := compactJWS(t, key, cert, []byte(`{"test":true}`))
+
+	roots := x509.NewCertPool()
+	roots.AddCert(cert)
+
+	signer, err := VerifyLoTESignature(context.Background(), []byte(token), roots, time.Now())
+	require.NoError(t, err)
+	require.NotNil(t, signer)
+	assert.Equal(t, "LoTE Signer", signer.Subject.CommonName)
+}
+
+func TestVerifyLoTESignature_TamperedPayload(t *testing.T) {
+	key := newECKey(t)
+	cert := selfSignedCert(t, key, "LoTE Signer", time.Now().Add(time.Hour))
+	token := compactJWS(t, key, cert, []byte(`{"original":true}`))
+	bad := tamperedJWS(token, `{"tampered":true}`)
+
+	roots := x509.NewCertPool()
+	roots.AddCert(cert)
+
+	_, err := VerifyLoTESignature(context.Background(), []byte(bad), roots, time.Now())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "signature")
+}
+
+func TestVerifyLoTESignature_UntrustedSigner(t *testing.T) {
+	key := newECKey(t)
+	cert := selfSignedCert(t, key, "Unknown", time.Now().Add(time.Hour))
+	token := compactJWS(t, key, cert, []byte(`{}`))
+
+	roots := x509.NewCertPool() // empty — cert not trusted
+
+	_, err := VerifyLoTESignature(context.Background(), []byte(token), roots, time.Now())
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "chain")
+}
+
+// ─── LoTETrustAnchorProvider ─────────────────────────────────────────────────
+
+func TestNilTrustAnchorProvider(t *testing.T) {
+	p := NilTrustAnchorProvider{}
+	pool, err := p.TrustAnchors(context.Background())
+	require.NoError(t, err)
+	assert.Nil(t, pool)
+}
+
+func TestStaticTrustAnchorProvider_NonNil(t *testing.T) {
+	pool := x509.NewCertPool()
+	p := NewStaticTrustAnchorProvider(pool)
+	got, err := p.TrustAnchors(context.Background())
+	require.NoError(t, err)
+	assert.Equal(t, pool, got)
+}
+
+func TestStaticTrustAnchorProvider_Nil(t *testing.T) {
+	p := NewStaticTrustAnchorProvider(nil)
+	got, err := p.TrustAnchors(context.Background())
+	require.NoError(t, err)
+	assert.Nil(t, got)
+}
+
+// ─── fetchRawSource ──────────────────────────────────────────────────────────
+
+func TestFetchRawSource_HTTP200(t *testing.T) {
+	want := []byte(`{"lote":"data"}`)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Write(want)
+	}))
+	defer srv.Close()
+
+	got, err := fetchRawSource(srv.URL, 5*time.Second)
+	require.NoError(t, err)
+	assert.Equal(t, want, got)
+}
+
+func TestFetchRawSource_HTTP404(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	_, err := fetchRawSource(srv.URL, 5*time.Second)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "404")
+}
+
+func TestFetchRawSource_LocalFile(t *testing.T) {
+	content := []byte(`{"lote":"file"}`)
+	f, err := os.CreateTemp("", "lote-*.json")
+	require.NoError(t, err)
+	defer os.Remove(f.Name())
+	_, _ = f.Write(content)
+	f.Close()
+
+	got, err := fetchRawSource(f.Name(), 5*time.Second)
+	require.NoError(t, err)
+	assert.Equal(t, content, got)
+}
+
+// ─── parseX5CChainRaw ────────────────────────────────────────────────────────
+
+func TestParseX5CChainRaw_Empty(t *testing.T) {
+	_, _, err := parseX5CChainRaw(nil)
+	assert.Error(t, err)
+}
+
+func TestParseX5CChainRaw_InvalidBase64(t *testing.T) {
+	_, _, err := parseX5CChainRaw([]string{"not!valid%%base64"})
+	assert.Error(t, err)
+}
+
+func TestParseX5CChainRaw_SingleCert(t *testing.T) {
+	key := newECKey(t)
+	cert := selfSignedCert(t, key, "leaf", time.Now().Add(time.Hour))
+	b64 := base64.StdEncoding.EncodeToString(cert.Raw)
+
+	leaf, ints, err := parseX5CChainRaw([]string{b64})
+	require.NoError(t, err)
+	assert.Equal(t, "leaf", leaf.Subject.CommonName)
+	assert.NotNil(t, ints)
+}
+
+// ─── TrustAnchorProvider error propagates through New() ─────────────────────
+
+func TestNew_TrustAnchorProviderError(t *testing.T) {
+	// Use a file-based source so the LoTE content is always valid.
+	path := writeEmptyLoTE(t)
+
+	cfg := Config{
+		Sources:             []string{path},
+		TrustAnchorProvider: &failingTAProvider{},
+	}
+	_, err := New(cfg)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "trust anchors")
+}
+
+type failingTAProvider struct{}
+
+func (f *failingTAProvider) TrustAnchors(_ context.Context) (*x509.CertPool, error) {
+	return nil, fmt.Errorf("simulated trust anchor failure")
+}
+
+// ─── National Register fallback (Phase 3) ────────────────────────────────────
+
+func TestEvaluate_RegisterFallback_Grants(t *testing.T) {
+	path := writeEmptyLoTE(t)
+	rc := &stubRegisterClient{result: &rpcert.RPEntitlements{
+		RPIdentifier:       "https://example.com/rp",
+		RegistrationStatus: rpcert.StatusRegistered,
+	}}
+	r, err := New(Config{Sources: []string{path}, RegisterClient: rc})
+	require.NoError(t, err)
+
+	resp, err := r.Evaluate(context.Background(), &authzen.EvaluationRequest{
+		Subject:  authzen.Subject{ID: "https://example.com/rp"},
+		Resource: authzen.Resource{Type: "jwk"},
+	})
+	require.NoError(t, err)
+	assert.True(t, resp.Decision)
+	assert.Contains(t, resp.Context.Reason["admin"], "National Register fallback")
+}
+
+func TestEvaluate_RegisterFallback_Denies_WhenRegisterFails(t *testing.T) {
+	path := writeEmptyLoTE(t)
+	rc := &stubRegisterClient{err: fmt.Errorf("register unavailable")}
+	r, err := New(Config{Sources: []string{path}, RegisterClient: rc})
+	require.NoError(t, err)
+
+	resp, err := r.Evaluate(context.Background(), &authzen.EvaluationRequest{
+		Subject:  authzen.Subject{ID: "https://example.com/unknown"},
+		Resource: authzen.Resource{Type: "jwk"},
+	})
+	require.NoError(t, err)
+	assert.False(t, resp.Decision)
+}
+
+func TestEvaluate_RegisterFallback_NotCalledWhenEntityInLoTE(t *testing.T) {
+	lote := minimalLoTE("EU", etsi119602.TrustedEntity{
+		TrustedEntityInformation: etsi119602.TrustedEntityInformation{
+			TEInformationURI: []etsi119602.NonEmptyMultiLangURI{{Lang: "en", URIValue: "https://example.com/rp"}},
+		},
+	})
+	path := writeLoTE(t, t.TempDir(), "lote.json", lote)
+
+	rc := &stubRegisterClient{}
+	r, err := New(Config{Sources: []string{path}, RegisterClient: rc})
+	require.NoError(t, err)
+
+	r.Evaluate(context.Background(), &authzen.EvaluationRequest{
+		Subject:  authzen.Subject{ID: "https://example.com/rp"},
+		Resource: authzen.Resource{Type: "jwk"},
+	})
+	assert.False(t, rc.called, "register must NOT be consulted when entity is already in LoTE")
+}
+
+// ─── LoTE server / entity helpers ────────────────────────────────────────────
+
+type stubRegisterClient struct {
+	result *rpcert.RPEntitlements
+	err    error
+	called bool
+}
+
+func (s *stubRegisterClient) LookupRP(_ context.Context, _ string) (*rpcert.RPEntitlements, error) {
+	s.called = true
+	return s.result, s.err
+}
+func (s *stubRegisterClient) Healthy() bool { return true }
+
+// writeEmptyLoTE writes a LoTE with no entities to a temp file and returns the path.
+func writeEmptyLoTE(t *testing.T) string {
+	t.Helper()
+	lote := minimalLoTE("EU")
+	return writeLoTE(t, t.TempDir(), "lote.json", lote)
+}
+
+// loTEServer is kept for the TrustAnchorProvider error test (it doesn't need
+// a valid LoTE body since the error fires before the body is parsed).
+func loTEServer(t *testing.T, territory, loTEType string, _ []interface{}) *httptest.Server {
+	t.Helper()
+	// Return an HTTP server that responds with a minimal valid JSON; used
+	// only to supply a network-accessible URL — callers that need real LoTE
+	// data should use writeEmptyLoTE / writeLoTE instead.
+	body := map[string]interface{}{
+		"LoTE": map[string]interface{}{
+			"ListAndSchemeInformation": map[string]interface{}{
+				"SchemeTerritory": territory,
+				"LoTEType":        loTEType,
+			},
+			"TrustedEntitiesList": []interface{}{},
+		},
+	}
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(body)
+	}))
+}
+
+// Suppress unused-import error for json/httptest when loTEServer is the only user.
+var _ = errors.New

--- a/pkg/registry/lote/trust_anchor.go
+++ b/pkg/registry/lote/trust_anchor.go
@@ -1,0 +1,58 @@
+// Package lote — LoTE signer trust anchor interface.
+//
+// LoTETrustAnchorProvider is the extension point for LoTE JWS signature
+// verification per ETSI TS 119 615. Callers inject their own implementation;
+// the core library ships a no-op that skips verification for environments
+// where the LoTE source is already considered trustworthy (e.g. in tests or
+// deployments that verify authenticity through other means such as HTTPS
+// pinning or a controlled internal distribution).
+//
+// An OJEU-anchored implementation (for APTITUDE/EUDI production use) belongs
+// outside this package because the OJEU endpoint address is
+// deployment-specific.
+package lote
+
+import (
+	"context"
+	"crypto/x509"
+)
+
+// LoTETrustAnchorProvider supplies the root certificates used to anchor the
+// LoTE signer certificate chain during JWS signature verification. Implementations
+// decide how and where to obtain the roots (e.g. from OJEU, from a local file,
+// or from a pinned certificate bundle).
+//
+// TrustAnchors is called once per LoTE load. It may return a cached set.
+// Returning a nil pool with a nil error disables signature verification for
+// that call (equivalent to NilTrustAnchorProvider).
+type LoTETrustAnchorProvider interface {
+	TrustAnchors(ctx context.Context) (*x509.CertPool, error)
+}
+
+// NilTrustAnchorProvider is the no-op implementation of LoTETrustAnchorProvider.
+// It returns a nil pool, causing JWS signature verification to be skipped.
+// Use this when the LoTE source is trusted through other means (HTTPS,
+// controlled distribution) or in test environments.
+type NilTrustAnchorProvider struct{}
+
+// TrustAnchors returns nil, nil — signature verification is skipped.
+func (NilTrustAnchorProvider) TrustAnchors(_ context.Context) (*x509.CertPool, error) {
+	return nil, nil
+}
+
+// StaticTrustAnchorProvider holds a fixed CertPool. Useful for testing and
+// for deployments where the root certificates are managed out-of-band.
+type StaticTrustAnchorProvider struct {
+	pool *x509.CertPool
+}
+
+// NewStaticTrustAnchorProvider creates a provider with the given root certificates.
+// If pool is nil the behaviour is the same as NilTrustAnchorProvider.
+func NewStaticTrustAnchorProvider(pool *x509.CertPool) *StaticTrustAnchorProvider {
+	return &StaticTrustAnchorProvider{pool: pool}
+}
+
+// TrustAnchors returns the configured pool.
+func (p *StaticTrustAnchorProvider) TrustAnchors(_ context.Context) (*x509.CertPool, error) {
+	return p.pool, nil
+}

--- a/pkg/registry/rpcert/dcql_policy.go
+++ b/pkg/registry/rpcert/dcql_policy.go
@@ -54,26 +54,49 @@ type DCQLPolicyEvaluator interface {
 type StrictDCQLPolicyEvaluator struct{}
 
 // Evaluate returns Allowed=false when any requested type is absent from the
-// RP's entitlements.ProvidedAttestations (for providers) or RP credential list.
+// credential types registered in the RP's entitlements.
+//
+// requestedTypes should be credential type identifiers such as:
+//   - SD-JWT VC vct values: "eu.europa.ec.eudi.pid.1"
+//   - ISO mdoc doctypes: "org.iso.18013.5.1.mDL"
+//
+// The allow-list is built from ProvidedAttestations (for EAA providers) and
+// the credentials array (for relying-party flows), by extracting vct/doctype
+// values from the credential meta fields. Format strings (e.g. "sd-jwt") and
+// claim attribute names (e.g. "family_name") are distinct and are not matched
+// here — use DetectOverRequest for attribute-level enforcement.
 func (StrictDCQLPolicyEvaluator) Evaluate(_ context.Context, ent *RPEntitlements, requestedTypes []string) DCQLPolicyResult {
 	if ent == nil || len(requestedTypes) == 0 {
 		return DCQLPolicyResult{Allowed: true, Message: "no credential types to check"}
 	}
 
-	// Build allowed set from AllowedAttributes (top-level claim names) plus
-	// any credential format/meta keys from ProvidedAttestations.
-	allowed := make(map[string]bool, len(ent.AllowedAttributes))
-	for _, a := range ent.AllowedAttributes {
-		allowed[strings.ToLower(a)] = true
-	}
+	// Build the allow-set from registered credential type identifiers.
+	// We extract vct (SD-JWT VC) and doctype (mdoc) values from the meta fields
+	// of ProvidedAttestations entries. Format strings (sd-jwt, mso_mdoc) are
+	// added as a coarse-grained fallback for entries that lack a type meta field.
+	allowed := make(map[string]bool)
 	for _, c := range ent.ProvidedAttestations {
+		if vct, ok := c.Meta["vct"].(string); ok && vct != "" {
+			allowed[strings.ToLower(vct)] = true
+		}
+		if dt, ok := c.Meta["doctype"].(string); ok && dt != "" {
+			allowed[strings.ToLower(dt)] = true
+		}
+		// vct_values is an array form used in some DCQL profiles
+		if vctVals, ok := c.Meta["vct_values"].([]interface{}); ok {
+			for _, v := range vctVals {
+				if s, ok := v.(string); ok && s != "" {
+					allowed[strings.ToLower(s)] = true
+				}
+			}
+		}
 		if c.Format != "" {
 			allowed[strings.ToLower(c.Format)] = true
 		}
 	}
 
 	if len(allowed) == 0 {
-		// No registered credential data — cannot enforce; permit.
+		// No registered credential type data — cannot enforce; permit.
 		return DCQLPolicyResult{Allowed: true, Message: "no registered credential types; cannot enforce DCQL policy"}
 	}
 

--- a/pkg/registry/rpcert/dcql_policy.go
+++ b/pkg/registry/rpcert/dcql_policy.go
@@ -1,0 +1,111 @@
+// Package rpcert — DCQL policy evaluator interface and built-in implementations.
+//
+// DCQLPolicyEvaluator checks whether a credential request (DCQL query) is within
+// the scope authorised by the RP's WRPRC entitlements. The evaluation is invoked
+// after WRPRC signature verification, before the wallet discloses attributes.
+//
+// The interface is designed for injection: callers that need EDP (Electronic Data
+// Policy) enforcement inject their own implementation; those that only need
+// entitlement-level enforcement use StrictDCQLPolicyEvaluator; those that want
+// audit-only warnings use PermissiveDCQLPolicyEvaluator.
+//
+// User-override prompts (RFC003 AUTHZ-EDPV-01-OVERRIDE, AUTHZ-EDPV-02-OVERRIDE)
+// are NOT in this package — they are a UI/UX concern that belongs in the wallet
+// frontend. This package returns typed errors; the caller decides what to present.
+//
+// References:
+//   - ETSI TS 119 475 v1.1.1 Tables 8–9 — WRPRC credential queries
+//   - RFC003 §10.2.3 AUTHZ-ENT-*, AUTHZ-EDPV-*
+package rpcert
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// DCQLPolicyResult is returned by DCQLPolicyEvaluator.Evaluate.
+type DCQLPolicyResult struct {
+	// Allowed indicates whether the request may proceed.
+	Allowed bool
+
+	// OverRequestedTypes lists credential types/formats present in the request
+	// but absent from the RP's registered credentials array. Empty when Allowed=true.
+	OverRequestedTypes []string
+
+	// Message is a human-readable description of the outcome, suitable for
+	// inclusion in audit logs or deny-reason fields.
+	Message string
+}
+
+// DCQLPolicyEvaluator checks whether a DCQL credential request is authorised
+// by the RP's WRPRC entitlements.
+type DCQLPolicyEvaluator interface {
+	// Evaluate checks the request against the entitlements. requestedTypes is
+	// the list of credential types (vct values or ISO mdoc doctypes) being
+	// requested. Returns a DCQLPolicyResult; never returns a Go error — policy
+	// outcomes are communicated through the result struct.
+	Evaluate(ctx context.Context, ent *RPEntitlements, requestedTypes []string) DCQLPolicyResult
+}
+
+// StrictDCQLPolicyEvaluator denies requests containing credential types not
+// listed in the RP's registered credentials array. Use this for production
+// deployments where over-requesting must be blocked at the trust layer.
+type StrictDCQLPolicyEvaluator struct{}
+
+// Evaluate returns Allowed=false when any requested type is absent from the
+// RP's entitlements.ProvidedAttestations (for providers) or RP credential list.
+func (StrictDCQLPolicyEvaluator) Evaluate(_ context.Context, ent *RPEntitlements, requestedTypes []string) DCQLPolicyResult {
+	if ent == nil || len(requestedTypes) == 0 {
+		return DCQLPolicyResult{Allowed: true, Message: "no credential types to check"}
+	}
+
+	// Build allowed set from AllowedAttributes (top-level claim names) plus
+	// any credential format/meta keys from ProvidedAttestations.
+	allowed := make(map[string]bool, len(ent.AllowedAttributes))
+	for _, a := range ent.AllowedAttributes {
+		allowed[strings.ToLower(a)] = true
+	}
+	for _, c := range ent.ProvidedAttestations {
+		if c.Format != "" {
+			allowed[strings.ToLower(c.Format)] = true
+		}
+	}
+
+	if len(allowed) == 0 {
+		// No registered credential data — cannot enforce; permit.
+		return DCQLPolicyResult{Allowed: true, Message: "no registered credential types; cannot enforce DCQL policy"}
+	}
+
+	var over []string
+	for _, t := range requestedTypes {
+		if !allowed[strings.ToLower(t)] {
+			over = append(over, t)
+		}
+	}
+	if len(over) == 0 {
+		return DCQLPolicyResult{Allowed: true, Message: "all requested types are within entitlements"}
+	}
+	return DCQLPolicyResult{
+		Allowed:            false,
+		OverRequestedTypes: over,
+		Message: fmt.Sprintf("RP %q is requesting credential types not in entitlements: %s (AUTHZ-ATT-01-FAIL)",
+			ent.RPIdentifier, strings.Join(over, ", ")),
+	}
+}
+
+// PermissiveDCQLPolicyEvaluator always permits the request but populates
+// OverRequestedTypes for audit. Use this in warn-only deployments where the
+// wallet wants to log over-requests without blocking the flow.
+type PermissiveDCQLPolicyEvaluator struct{}
+
+// Evaluate always returns Allowed=true but notes any over-requested types.
+func (PermissiveDCQLPolicyEvaluator) Evaluate(ctx context.Context, ent *RPEntitlements, requestedTypes []string) DCQLPolicyResult {
+	strict := StrictDCQLPolicyEvaluator{}
+	r := strict.Evaluate(ctx, ent, requestedTypes)
+	r.Allowed = true // override — permissive mode never blocks
+	if len(r.OverRequestedTypes) > 0 {
+		r.Message = fmt.Sprintf("WARN: over-requested types (not blocking): %s", strings.Join(r.OverRequestedTypes, ", "))
+	}
+	return r
+}

--- a/pkg/registry/rpcert/entitlements.go
+++ b/pkg/registry/rpcert/entitlements.go
@@ -9,6 +9,8 @@
 // and are in the /SubEntitlement/ path.
 package rpcert
 
+import "fmt"
+
 // Entitlement role URIs (Annex A.2, id-etsi-wrpa-entitlement 1–10).
 const (
 	// EntitlementServiceProvider is the general service provider role.
@@ -109,4 +111,30 @@ func (e *RPEntitlements) IsEAAProvider() bool {
 	return e.HasEntitlement(EntitlementQEAAProvider) ||
 		e.HasEntitlement(EntitlementNonQEAAProvider) ||
 		e.HasEntitlement(EntitlementPUBEAAProvider)
+}
+
+// BindingError is returned when WRPAC and WRPRC subject identifiers do not match.
+type BindingError struct {
+	WRPACOrgID string
+	WRPRCSubID string
+}
+
+func (e *BindingError) Error() string {
+	return fmt.Sprintf("WRPAC organization_identifier %q does not match WRPRC sub.id %q (ARF RPRC_16, TS 119 475 §5.1)", e.WRPACOrgID, e.WRPRCSubID)
+}
+
+// CheckWRPACWRPRCBinding verifies that the organization_identifier from the WRPAC
+// matches the sub.id of the WRPRC per ARF RPRC_16 and ETSI TS 119 475 §5.1.
+//
+// Either argument being empty means "not present" — the check is only enforced
+// when both values are non-empty, so callers in WRPRC-only flows pass "" for
+// wrpacOrgID without triggering a spurious error.
+func CheckWRPACWRPRCBinding(wrpacOrgID string, wrprc *RPEntitlements) error {
+	if wrpacOrgID == "" || wrprc == nil || wrprc.Subject.ID == "" {
+		return nil
+	}
+	if wrpacOrgID != wrprc.Subject.ID {
+		return &BindingError{WRPACOrgID: wrpacOrgID, WRPRCSubID: wrprc.Subject.ID}
+	}
+	return nil
 }

--- a/pkg/registry/rpcert/errors.go
+++ b/pkg/registry/rpcert/errors.go
@@ -1,0 +1,76 @@
+// Package rpcert — structured trust evaluation error codes.
+//
+// TrustEvaluationError wraps a machine-readable code with a human message so
+// callers can switch on the code to produce protocol-specific responses (AuthZen
+// reason strings, ITB+ status codes, HTTP responses, etc.) without hardcoding
+// error strings.
+//
+// The code values mirror the status strings defined in RFC003 §10.2, but the
+// type lives in the general rpcert package — it is not APTITUDE-specific.
+// Any caller mapping to a different protocol (e.g. OpenID4VP error codes)
+// can switch on the Code field and produce its own representation.
+package rpcert
+
+import "fmt"
+
+// TrustEvaluationErrorCode is a machine-readable outcome of a trust evaluation
+// step. Callers switch on this to produce protocol-specific error responses.
+type TrustEvaluationErrorCode string
+
+const (
+	// ErrCodeTrustAnchorInvalid is returned when the entity's issuer or signing
+	// certificate cannot be resolved in the LoTE.
+	ErrCodeTrustAnchorInvalid TrustEvaluationErrorCode = "TRUST_ANCHOR_INVALID"
+
+	// ErrCodeCertificateInvalid is returned when a WRPAC or WRPRC certificate
+	// fails structural, temporal, or cryptographic validation.
+	ErrCodeCertificateInvalid TrustEvaluationErrorCode = "CERTIFICATE_INVALID"
+
+	// ErrCodeBindingFailed is returned when the WRPAC organization_identifier
+	// does not match the WRPRC sub.id (ARF RPRC_16, TS 119 475 §5.1).
+	ErrCodeBindingFailed TrustEvaluationErrorCode = "BINDING_FAILED"
+
+	// ErrCodeWrongEntitlement is returned when the RP's entitlements array does
+	// not include the role required for the requested operation.
+	ErrCodeWrongEntitlement TrustEvaluationErrorCode = "WRONG_ENTITLEMENT"
+
+	// ErrCodeRegistrationInvalid is returned when the National Register lookup
+	// fails or indicates the RP is not registered / is suspended.
+	ErrCodeRegistrationInvalid TrustEvaluationErrorCode = "REGISTRATION_INVALID"
+
+	// ErrCodeAttestationTypeNotRegistered is returned when the RP requests or
+	// provides an attestation type not listed in its registered credentials array.
+	ErrCodeAttestationTypeNotRegistered TrustEvaluationErrorCode = "ATTESTATION_TYPE_NOT_REGISTERED"
+
+	// ErrCodeIntermediaryNotAuthorized is returned when an intermediary scenario
+	// is detected but the proxy-target association cannot be proven.
+	ErrCodeIntermediaryNotAuthorized TrustEvaluationErrorCode = "INTERMEDIARY_NOT_AUTHORIZED"
+)
+
+// TrustEvaluationError carries a machine-readable code plus a human message.
+// Callers that need to return protocol-specific error representations switch on Code.
+type TrustEvaluationError struct {
+	// Code is the machine-readable error category.
+	Code TrustEvaluationErrorCode
+
+	// Message is a human-readable description suitable for audit logs and
+	// deny-reason fields.
+	Message string
+
+	// Cause is the underlying error that triggered this evaluation failure, if any.
+	Cause error
+}
+
+func (e *TrustEvaluationError) Error() string {
+	if e.Cause != nil {
+		return fmt.Sprintf("[%s] %s: %v", e.Code, e.Message, e.Cause)
+	}
+	return fmt.Sprintf("[%s] %s", e.Code, e.Message)
+}
+
+func (e *TrustEvaluationError) Unwrap() error { return e.Cause }
+
+// NewTrustEvaluationError constructs a TrustEvaluationError.
+func NewTrustEvaluationError(code TrustEvaluationErrorCode, msg string, cause error) *TrustEvaluationError {
+	return &TrustEvaluationError{Code: code, Message: msg, Cause: cause}
+}

--- a/pkg/registry/rpcert/rfc003_test.go
+++ b/pkg/registry/rpcert/rfc003_test.go
@@ -1,0 +1,146 @@
+package rpcert
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// ─── CheckWRPACWRPRCBinding ──────────────────────────────────────────────────
+
+func TestCheckWRPACWRPRCBinding_Match(t *testing.T) {
+	ent := &RPEntitlements{Subject: WRPRCSubject{ID: "LEIXG-123"}}
+	err := CheckWRPACWRPRCBinding("LEIXG-123", ent)
+	assert.NoError(t, err)
+}
+
+func TestCheckWRPACWRPRCBinding_Mismatch(t *testing.T) {
+	ent := &RPEntitlements{Subject: WRPRCSubject{ID: "LEIXG-999"}}
+	err := CheckWRPACWRPRCBinding("LEIXG-123", ent)
+	require.Error(t, err)
+
+	var bindErr *BindingError
+	require.True(t, errors.As(err, &bindErr))
+	assert.Equal(t, "LEIXG-123", bindErr.WRPACOrgID)
+	assert.Equal(t, "LEIXG-999", bindErr.WRPRCSubID)
+	assert.Contains(t, err.Error(), "LEIXG-123")
+	assert.Contains(t, err.Error(), "LEIXG-999")
+}
+
+func TestCheckWRPACWRPRCBinding_EmptyWRPACOrgID(t *testing.T) {
+	ent := &RPEntitlements{Subject: WRPRCSubject{ID: "LEIXG-999"}}
+	// wrpac org absent — cannot enforce; expect no error
+	assert.NoError(t, CheckWRPACWRPRCBinding("", ent))
+}
+
+func TestCheckWRPACWRPRCBinding_EmptyWRPRCSubID(t *testing.T) {
+	ent := &RPEntitlements{Subject: WRPRCSubject{ID: ""}}
+	assert.NoError(t, CheckWRPACWRPRCBinding("LEIXG-123", ent))
+}
+
+func TestCheckWRPACWRPRCBinding_NilWRPRC(t *testing.T) {
+	assert.NoError(t, CheckWRPACWRPRCBinding("LEIXG-123", nil))
+}
+
+// ─── DCQLPolicyEvaluator ──────────────────────────────────────────────────────
+
+func TestStrictDCQLPolicyEvaluator_AllowsMatchingTypes(t *testing.T) {
+	ev := StrictDCQLPolicyEvaluator{}
+	ent := &RPEntitlements{
+		RPIdentifier:      "rp1",
+		AllowedAttributes: []string{"eu.europa.ec.eudi.pid.1", "org.iso.18013.5.1.mDL"},
+	}
+	result := ev.Evaluate(context.Background(), ent, []string{"eu.europa.ec.eudi.pid.1"})
+	assert.True(t, result.Allowed)
+	assert.Empty(t, result.OverRequestedTypes)
+}
+
+func TestStrictDCQLPolicyEvaluator_BlocksOverRequest(t *testing.T) {
+	ev := StrictDCQLPolicyEvaluator{}
+	ent := &RPEntitlements{
+		RPIdentifier:      "rp1",
+		AllowedAttributes: []string{"eu.europa.ec.eudi.pid.1"},
+	}
+	result := ev.Evaluate(context.Background(), ent, []string{"eu.europa.ec.eudi.pid.1", "org.iso.18013.5.1.mDL"})
+	assert.False(t, result.Allowed)
+	assert.Contains(t, result.OverRequestedTypes, "org.iso.18013.5.1.mDL")
+	assert.Contains(t, result.Message, "AUTHZ-ATT-01-FAIL")
+}
+
+func TestStrictDCQLPolicyEvaluator_CaseInsensitive(t *testing.T) {
+	ev := StrictDCQLPolicyEvaluator{}
+	ent := &RPEntitlements{
+		RPIdentifier:      "rp1",
+		AllowedAttributes: []string{"Eu.Europa.Ec.Eudi.Pid.1"},
+	}
+	result := ev.Evaluate(context.Background(), ent, []string{"eu.europa.ec.eudi.pid.1"})
+	assert.True(t, result.Allowed)
+}
+
+func TestStrictDCQLPolicyEvaluator_EmptyAllowedSkipsEnforcement(t *testing.T) {
+	ev := StrictDCQLPolicyEvaluator{}
+	ent := &RPEntitlements{RPIdentifier: "rp1"} // no allowed attrs
+	result := ev.Evaluate(context.Background(), ent, []string{"anything"})
+	assert.True(t, result.Allowed, "no registered types means cannot enforce; should permit")
+}
+
+func TestStrictDCQLPolicyEvaluator_NoRequestedTypes(t *testing.T) {
+	ev := StrictDCQLPolicyEvaluator{}
+	ent := &RPEntitlements{AllowedAttributes: []string{"pid"}}
+	result := ev.Evaluate(context.Background(), ent, nil)
+	assert.True(t, result.Allowed)
+}
+
+func TestPermissiveDCQLPolicyEvaluator_AlwaysAllows(t *testing.T) {
+	ev := PermissiveDCQLPolicyEvaluator{}
+	ent := &RPEntitlements{
+		RPIdentifier:      "rp1",
+		AllowedAttributes: []string{"eu.europa.ec.eudi.pid.1"},
+	}
+	result := ev.Evaluate(context.Background(), ent, []string{"eu.europa.ec.eudi.pid.1", "org.iso.18013.5.1.mDL"})
+	assert.True(t, result.Allowed, "permissive evaluator must always allow")
+	assert.NotEmpty(t, result.OverRequestedTypes, "but still reports over-requested types")
+	assert.Contains(t, result.Message, "WARN")
+}
+
+// ─── TrustEvaluationError ────────────────────────────────────────────────────
+
+func TestTrustEvaluationError_ErrorString(t *testing.T) {
+	e := NewTrustEvaluationError(ErrCodeTrustAnchorInvalid, "signer not in LoTE", nil)
+	assert.Contains(t, e.Error(), "TRUST_ANCHOR_INVALID")
+	assert.Contains(t, e.Error(), "signer not in LoTE")
+}
+
+func TestTrustEvaluationError_WithCause(t *testing.T) {
+	cause := errors.New("x509: certificate expired")
+	e := NewTrustEvaluationError(ErrCodeCertificateInvalid, "validation failed", cause)
+	assert.Contains(t, e.Error(), "CERTIFICATE_INVALID")
+	assert.Contains(t, e.Error(), "x509: certificate expired")
+	assert.ErrorIs(t, e, cause)
+}
+
+func TestTrustEvaluationError_Codes(t *testing.T) {
+	codes := []TrustEvaluationErrorCode{
+		ErrCodeTrustAnchorInvalid,
+		ErrCodeCertificateInvalid,
+		ErrCodeBindingFailed,
+		ErrCodeWrongEntitlement,
+		ErrCodeRegistrationInvalid,
+		ErrCodeAttestationTypeNotRegistered,
+		ErrCodeIntermediaryNotAuthorized,
+	}
+	for _, code := range codes {
+		e := NewTrustEvaluationError(code, "test", nil)
+		assert.Equal(t, code, e.Code)
+	}
+}
+
+func TestBindingError_ErrorString(t *testing.T) {
+	e := &BindingError{WRPACOrgID: "A", WRPRCSubID: "B"}
+	assert.Contains(t, e.Error(), "A")
+	assert.Contains(t, e.Error(), "B")
+	assert.Contains(t, e.Error(), "ARF RPRC_16")
+}

--- a/pkg/registry/rpcert/rfc003_test.go
+++ b/pkg/registry/rpcert/rfc003_test.go
@@ -50,8 +50,11 @@ func TestCheckWRPACWRPRCBinding_NilWRPRC(t *testing.T) {
 func TestStrictDCQLPolicyEvaluator_AllowsMatchingTypes(t *testing.T) {
 	ev := StrictDCQLPolicyEvaluator{}
 	ent := &RPEntitlements{
-		RPIdentifier:      "rp1",
-		AllowedAttributes: []string{"eu.europa.ec.eudi.pid.1", "org.iso.18013.5.1.mDL"},
+		RPIdentifier: "rp1",
+		ProvidedAttestations: []CredentialQuery{
+			{Format: "vc+sd-jwt", Meta: map[string]interface{}{"vct": "eu.europa.ec.eudi.pid.1"}},
+			{Format: "mso_mdoc", Meta: map[string]interface{}{"doctype": "org.iso.18013.5.1.mDL"}},
+		},
 	}
 	result := ev.Evaluate(context.Background(), ent, []string{"eu.europa.ec.eudi.pid.1"})
 	assert.True(t, result.Allowed)
@@ -61,8 +64,10 @@ func TestStrictDCQLPolicyEvaluator_AllowsMatchingTypes(t *testing.T) {
 func TestStrictDCQLPolicyEvaluator_BlocksOverRequest(t *testing.T) {
 	ev := StrictDCQLPolicyEvaluator{}
 	ent := &RPEntitlements{
-		RPIdentifier:      "rp1",
-		AllowedAttributes: []string{"eu.europa.ec.eudi.pid.1"},
+		RPIdentifier: "rp1",
+		ProvidedAttestations: []CredentialQuery{
+			{Format: "vc+sd-jwt", Meta: map[string]interface{}{"vct": "eu.europa.ec.eudi.pid.1"}},
+		},
 	}
 	result := ev.Evaluate(context.Background(), ent, []string{"eu.europa.ec.eudi.pid.1", "org.iso.18013.5.1.mDL"})
 	assert.False(t, result.Allowed)
@@ -73,23 +78,40 @@ func TestStrictDCQLPolicyEvaluator_BlocksOverRequest(t *testing.T) {
 func TestStrictDCQLPolicyEvaluator_CaseInsensitive(t *testing.T) {
 	ev := StrictDCQLPolicyEvaluator{}
 	ent := &RPEntitlements{
-		RPIdentifier:      "rp1",
-		AllowedAttributes: []string{"Eu.Europa.Ec.Eudi.Pid.1"},
+		RPIdentifier: "rp1",
+		ProvidedAttestations: []CredentialQuery{
+			{Format: "vc+sd-jwt", Meta: map[string]interface{}{"vct": "EU.EUROPA.EC.EUDI.PID.1"}},
+		},
 	}
 	result := ev.Evaluate(context.Background(), ent, []string{"eu.europa.ec.eudi.pid.1"})
 	assert.True(t, result.Allowed)
 }
 
-func TestStrictDCQLPolicyEvaluator_EmptyAllowedSkipsEnforcement(t *testing.T) {
+func TestStrictDCQLPolicyEvaluator_MatchesVctValues(t *testing.T) {
+	// vct_values is the array form used in some DCQL profiles
 	ev := StrictDCQLPolicyEvaluator{}
-	ent := &RPEntitlements{RPIdentifier: "rp1"} // no allowed attrs
+	ent := &RPEntitlements{
+		RPIdentifier: "rp1",
+		ProvidedAttestations: []CredentialQuery{
+			{Format: "vc+sd-jwt", Meta: map[string]interface{}{
+				"vct_values": []interface{}{"eu.europa.ec.eudi.pid.1", "eu.europa.ec.eudi.pid.2"},
+			}},
+		},
+	}
+	result := ev.Evaluate(context.Background(), ent, []string{"eu.europa.ec.eudi.pid.2"})
+	assert.True(t, result.Allowed)
+}
+
+func TestStrictDCQLPolicyEvaluator_EmptyAttestationsSkipsEnforcement(t *testing.T) {
+	ev := StrictDCQLPolicyEvaluator{}
+	ent := &RPEntitlements{RPIdentifier: "rp1"} // no attestations
 	result := ev.Evaluate(context.Background(), ent, []string{"anything"})
 	assert.True(t, result.Allowed, "no registered types means cannot enforce; should permit")
 }
 
 func TestStrictDCQLPolicyEvaluator_NoRequestedTypes(t *testing.T) {
 	ev := StrictDCQLPolicyEvaluator{}
-	ent := &RPEntitlements{AllowedAttributes: []string{"pid"}}
+	ent := &RPEntitlements{ProvidedAttestations: []CredentialQuery{{Format: "vc+sd-jwt"}}}
 	result := ev.Evaluate(context.Background(), ent, nil)
 	assert.True(t, result.Allowed)
 }
@@ -97,8 +119,10 @@ func TestStrictDCQLPolicyEvaluator_NoRequestedTypes(t *testing.T) {
 func TestPermissiveDCQLPolicyEvaluator_AlwaysAllows(t *testing.T) {
 	ev := PermissiveDCQLPolicyEvaluator{}
 	ent := &RPEntitlements{
-		RPIdentifier:      "rp1",
-		AllowedAttributes: []string{"eu.europa.ec.eudi.pid.1"},
+		RPIdentifier: "rp1",
+		ProvidedAttestations: []CredentialQuery{
+			{Format: "vc+sd-jwt", Meta: map[string]interface{}{"vct": "eu.europa.ec.eudi.pid.1"}},
+		},
 	}
 	result := ev.Evaluate(context.Background(), ent, []string{"eu.europa.ec.eudi.pid.1", "org.iso.18013.5.1.mDL"})
 	assert.True(t, result.Allowed, "permissive evaluator must always allow")

--- a/pkg/registry/x5c_enrichment.go
+++ b/pkg/registry/x5c_enrichment.go
@@ -38,6 +38,11 @@ type X5CEnrichmentResult struct {
 	// on policy strictness).
 	ProfileValidationError string
 
+	// WRPACOrgID is the organization_identifier extracted from the WRPAC leaf
+	// certificate. Populated when the matched profile is "wrpac". Used by callers
+	// to perform WRPAC–WRPRC subject binding per ARF RPRC_16.
+	WRPACOrgID string
+
 	// FailureReason is set when Decision is false, describing why.
 	FailureReason map[string]interface{}
 }
@@ -98,16 +103,31 @@ func EnrichX5CResponseWithProfiles(req *authzen.EvaluationRequest, leaf *x509.Ce
 
 	// Extract RP identity if requested — prefer profile-specific extraction
 	if ShouldExtractRPIdentity(req) {
+		var identity map[string]interface{}
 		if matchedProfile != nil {
-			identity, err := matchedProfile.ExtractIdentity(leaf)
-			if err == nil {
-				result.RPIdentity = identity
-			} else {
-				// Fall back to generic extraction
-				result.RPIdentity = ExtractRPIdentity(leaf)
+			var err error
+			identity, err = matchedProfile.ExtractIdentity(leaf)
+			if err != nil {
+				identity = ExtractRPIdentity(leaf)
 			}
 		} else {
-			result.RPIdentity = ExtractRPIdentity(leaf)
+			identity = ExtractRPIdentity(leaf)
+		}
+		result.RPIdentity = identity
+
+		// Populate WRPACOrgID for downstream WRPAC–WRPRC binding checks when
+		// the matched profile is "wrpac" (or any profile that exposes
+		// organization_identifier in its identity map).
+		if id, ok := identity["organization_identifier"].(string); ok && id != "" {
+			result.WRPACOrgID = id
+		}
+	} else if matchedProfile != nil && matchedProfile.Name() == "wrpac" {
+		// Extract org ID for binding even when full identity extraction is not
+		// requested, so the binding check can run without leaking the full map.
+		if identity, err := matchedProfile.ExtractIdentity(leaf); err == nil {
+			if id, ok := identity["organization_identifier"].(string); ok {
+				result.WRPACOrgID = id
+			}
 		}
 	}
 

--- a/pkg/registry/x5c_enrichment_test.go
+++ b/pkg/registry/x5c_enrichment_test.go
@@ -724,3 +724,66 @@ func TestApplyEnrichmentToResponse_ProfileValidationWarning(t *testing.T) {
 	assert.Equal(t, "wrpac: certificate keyUsage does not include nonRepudiation",
 		resp.Context.Reason["profile_validation_warning"])
 }
+
+// ---------------------------------------------------------------------------
+// WRPACOrgID population (Thread 8 — explicit regression guard)
+// ---------------------------------------------------------------------------
+
+func TestEnrichX5CResponseWithProfiles_WRPACOrgID_Populated(t *testing.T) {
+	// Build a WRPAC certificate with a Subject.SerialNumber (organization_identifier).
+	cert := buildWRPACCert(t, "LEIXG-529900T8BM49AURSDO55")
+	req := &authzen.EvaluationRequest{
+		Context: map[string]interface{}{"extract_rp_identity": true},
+	}
+
+	result := EnrichX5CResponseWithProfiles(req, cert, rpcert.DefaultProfileRegistry())
+
+	assert.Equal(t, "wrpac", result.MatchedProfile)
+	assert.Equal(t, "LEIXG-529900T8BM49AURSDO55", result.WRPACOrgID,
+		"WRPACOrgID must be populated from WRPAC organization_identifier for binding checks")
+}
+
+func TestEnrichX5CResponseWithProfiles_WRPACOrgID_PopulatedWithoutFullIdentity(t *testing.T) {
+	// Verify WRPACOrgID is populated even when extract_rp_identity is NOT set —
+	// the binding check must work independently of full identity extraction.
+	cert := buildWRPACCert(t, "LEIXG-529900T8BM49AURSDO55")
+	req := &authzen.EvaluationRequest{} // no extract_rp_identity
+
+	result := EnrichX5CResponseWithProfiles(req, cert, rpcert.DefaultProfileRegistry())
+
+	assert.Equal(t, "wrpac", result.MatchedProfile)
+	assert.Equal(t, "LEIXG-529900T8BM49AURSDO55", result.WRPACOrgID,
+		"WRPACOrgID must be populated regardless of extract_rp_identity flag")
+	assert.Nil(t, result.RPIdentity, "RPIdentity must be nil when not requested")
+}
+
+func TestEnrichX5CResponseWithProfiles_WRPACOrgID_EmptyWhenNoProfile(t *testing.T) {
+	// A non-WRPAC cert should leave WRPACOrgID empty.
+	cert := &x509.Certificate{
+		Subject: pkix.Name{SerialNumber: "SN-12345"},
+	}
+	req := &authzen.EvaluationRequest{}
+
+	result := EnrichX5CResponseWithProfiles(req, cert, nil)
+
+	assert.Empty(t, result.WRPACOrgID)
+}
+
+// buildWRPACCert creates a WRPAC certificate struct with the given org identifier
+// in Subject.SerialNumber, carrying the NCP-l-eudiwrp policy OID.
+// Uses a bare struct (like other enrichment tests) to avoid Go 1.22+ Policies
+// vs PolicyIdentifiers migration issues in x509.CreateCertificate.
+func buildWRPACCert(t *testing.T, orgID string) *x509.Certificate {
+	t.Helper()
+	return &x509.Certificate{
+		Subject: pkix.Name{
+			SerialNumber: orgID,
+			Organization: []string{"Test Corp"},
+			Country:      []string{"SE"},
+		},
+		KeyUsage:          x509.KeyUsageContentCommitment,
+		PolicyIdentifiers: []asn1.ObjectIdentifier{{0, 4, 0, 194118, 1, 2}}, // NCP-l-eudiwrp
+		NotBefore:         time.Now().Add(-time.Minute),
+		NotAfter:          time.Now().Add(time.Hour),
+	}
+}


### PR DESCRIPTION
## Summary

Closes the general ETSI compliance gaps identified during analysis of [APTITUDE RFC003](https://github.com/APTITUDE-Consortium/aptitude-eudi-wallet-specs/pull/153). All changes are designed to be deployment-agnostic — APTITUDE-specific behaviour (OJEU cross-check, register API shape, ITB+ status strings) stays outside this library and must be injected by callers.

---

## Phase 1 — LoTE JWS signature verification (ETSI TS 119 615)

**New files:** `pkg/registry/lote/trust_anchor.go`, `pkg/registry/lote/jws_verify.go`

**Problem:** RFC003 TAV-LOTE-VAL-01 requires cryptographic verification of the LoTE JWT signature against a trust-anchored signer certificate chain. We previously accepted LoTE content from any configured URL without signature checks.

**Solution:**
- `LoTETrustAnchorProvider` interface — callers inject root certificates
- `NilTrustAnchorProvider` — no-op, skips verification (backwards-compatible default)
- `StaticTrustAnchorProvider` — fixed pool for tests / pinned deployments
- `VerifyLoTESignature()` — verifies compact or JSON-serialised JWS; supports RS/PS/ES 256/384/512; validates x5c signer chain
- `Config.TrustAnchorProvider` wired into `refresh()`; raw bytes fetched before the parsed LoTE is accepted; nil = skip

For APTITUDE/EUDI production: inject an `OJEUTrustAnchorProvider` (in go-wallet-backend or a separate package) that fetches root certs from the OJEU endpoint.

---

## Phase 2 — WRPAC–WRPRC subject binding (ARF RPRC_16, TS 119 475 §5.1)

**Files:** `pkg/registry/rpcert/entitlements.go`, `pkg/registry/x5c_enrichment.go`

**Problem:** The WRPAC `organization_identifier` must match the WRPRC `sub.id`. The requirement was documented in a comment but not enforced.

**Solution:**
- `CheckWRPACWRPRCBinding(wrpacOrgID, wrprc)` — typed `*BindingError` when they differ; nil if either is absent (safe for WRPRC-only flows)
- `X5CEnrichmentResult.WRPACOrgID` populated during `EnrichX5CResponseWithProfiles` so callers have the org ID without re-extracting

---

## Phase 3 — National Register fallback wiring

**File:** `pkg/registry/lote/registry.go`

**Problem:** `NationalRegisterClient` interface existed but was never called in the evaluation path.

**Solution:**
- `Config.RegisterClient rpcert.NationalRegisterClient` (optional, nil-safe)
- `Evaluate()` calls `LookupRP` when entity is not in the LoTE and a client is configured (RFC003 AUTHZ-WRPAC-01-FAIL / AUTHZ-WRPRC-01-FAIL fallback)
- Register is not consulted when the entity is already in the LoTE

---

## Phase 4 — DCQLPolicyEvaluator interface (ETSI TS 119 475, RFC003 AUTHZ-ENT-*/AUTHZ-EDPV-*)

**New file:** `pkg/registry/rpcert/dcql_policy.go`

- `DCQLPolicyEvaluator` interface with `Evaluate(ctx, ent, requestedTypes)`
- `StrictDCQLPolicyEvaluator` — blocks over-requests, returns AUTHZ-ATT-01-FAIL message
- `PermissiveDCQLPolicyEvaluator` — warns without blocking (audit mode)
- User-override prompts (AUTHZ-EDPV-*-OVERRIDE) are intentionally absent — they are a UI/UX concern for the wallet frontend

---

## Phase 5 — Structured TrustEvaluationError codes

**New file:** `pkg/registry/rpcert/errors.go`

- `TrustEvaluationErrorCode` type with RFC003 §10.2 code values
- `TrustEvaluationError` with `Code`, `Message`, `Cause` and `Unwrap()`
- Codes: `TRUST_ANCHOR_INVALID`, `CERTIFICATE_INVALID`, `BINDING_FAILED`, `WRONG_ENTITLEMENT`, `REGISTRATION_INVALID`, `ATTESTATION_TYPE_NOT_REGISTERED`, `INTERMEDIARY_NOT_AUTHORIZED`

Callers switch on `Code` to produce protocol-specific responses (AuthZen reason strings, ITB+, HTTP codes).

---

## What was deliberately NOT changed

| Item | Reason |
|---|---|
| XML LoTE support | RFC003's JSON-only requirement is incorrect; existing national TSLs are XML |
| OJEU cross-check | Deployment-specific; inject via `LoTETrustAnchorProvider` |
| `/wrp/check-intended-use` shape | APTITUDE-specific, no normative basis |
| ITB+ status string literals | Conformance harness concern; map from `TrustEvaluationErrorCode` |
| CWT WRPRC / revocation | Deferred with RFC004 revocation work |

---

## Tests

21 new tests across `lote` and `rpcert` packages. All 21 packages in the module pass.