### PR TITLE
ci: add workflow_dispatch trigger for manual Docker builds

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -6,6 +6,16 @@ on:
     tags: ['v[0-9]+.[0-9]+.[0-9]+*']
   pull_request:
     branches: [main]
+  workflow_dispatch:
+    inputs:
+      git_ref:
+        description: 'Git ref to build (branch, tag, or SHA)'
+        required: false
+        default: 'main'
+      image_tag:
+        description: 'Custom image tag (leave empty for standard policy)'
+        required: false
+        default: ''
 
 jobs:
   docker:
@@ -16,3 +26,5 @@ jobs:
       security-events: write
     with:
       image-name: sirosfoundation/go-trust
+      custom-ref: ${{ github.event_name == 'workflow_dispatch' && inputs.git_ref || '' }}
+      custom-tag: ${{ github.event_name == 'workflow_dispatch' && inputs.image_tag || '' }}


### PR DESCRIPTION
Adds `workflow_dispatch` to `docker-publish.yml` so GitHub renders the **Run workflow** button on the Actions tab.

Also passes `custom-ref`/`custom-tag` inputs through to the reusable `docker-build-push` workflow for ad-hoc builds from any ref. Adds `pull_request` trigger where it was missing.

Part of a cross-repo fix applied to all sirosfoundation repos using Docker workflows.