### PR TITLE
security: add top-level permissions for least-privilege workflow tokens

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -17,6 +17,8 @@ on:
         required: false
         default: ''
 
+permissions: read-all
+
 jobs:
   docker:
     uses: sirosfoundation/.github/.github/workflows/docker-build-push.yml@main

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,6 +12,9 @@ on:
       - '**.md'
       - 'docs/**'
 
+permissions:
+  contents: read
+
 jobs:
   build:
     name: Build and Test


### PR DESCRIPTION
Add `permissions: read-all` as a top-level key to `.github/workflows/docker-publish.yml` and `permissions: contents: read` to `.github/workflows/go.yml` to satisfy the OpenSSF Scorecard **TokenPermissions** check.

The job-level `permissions` blocks already override with the write scopes needed for packages/security-events/contents.

This ensures workflow tokens follow least-privilege by default.