### PR TITLE
security: add top-level permissions for least-privilege workflow tokens

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -14,6 +14,9 @@ on:
   schedule:
     - cron: '0 8 * * 1' # Run every Monday at 8:00 AM
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     name: Analyze

--- a/.github/workflows/network-tests.yml
+++ b/.github/workflows/network-tests.yml
@@ -17,6 +17,9 @@ on:
   pull_request:
     types: [labeled]
 
+permissions:
+  contents: read
+
 jobs:
   network-tests:
     name: Network Integration Tests

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -10,6 +10,9 @@ on:
     types: [published]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   sbom:
     uses: sirosfoundation/.github/.github/workflows/sbom.yml@03160e376dbdeb9f2c904e7a9f45499b2f67e8fa # main


### PR DESCRIPTION
All workflows now declare explicit top-level `permissions: contents: read` for least-privilege. Addresses OpenSSF Scorecard **Token-Permissions** check.