### PR TITLE
docs: add mdoc-issuer policy to example config

### DIFF
--- a/example/config.yaml
+++ b/example/config.yaml
@@ -435,7 +435,7 @@ policies:
 
       # Only use mDOC IACA registry
       registries:
-        - "mdoc-iaca"
+        - "mDOC-IACA"
 
     # ---------------------------------------------------------------------------
     # mDoc Issuer Policy (non-mDL)
@@ -452,7 +452,7 @@ policies:
 
       # Use mDOC IACA registry for certificate validation
       registries:
-        - "mdoc-iaca"
+        - "mDOC-IACA"
 
     # ---------------------------------------------------------------------------
     # Generic Trust Policy

--- a/example/config.yaml
+++ b/example/config.yaml
@@ -438,6 +438,23 @@ policies:
         - "mdoc-iaca"
 
     # ---------------------------------------------------------------------------
+    # mDoc Issuer Policy (non-mDL)
+    # ---------------------------------------------------------------------------
+    # For mDoc credential issuers (PID over mDoc, EAA over mDoc, etc.)
+    # The vc verifier routes any non-mDL DocType here via action "mdoc-issuer".
+    mdoc-issuer:
+      description: "Trust requirements for mDoc issuers (non-mDL doctypes)"
+
+      mdociaca:
+        issuer_allowlist:
+          - "https://pid-issuer.eudiw.dev"
+        require_iaca_endpoint: true
+
+      # Use mDOC IACA registry for certificate validation
+      registries:
+        - "mdoc-iaca"
+
+    # ---------------------------------------------------------------------------
     # Generic Trust Policy
     # ---------------------------------------------------------------------------
     # Fallback policy with minimal constraints


### PR DESCRIPTION
Adds an `mdoc-issuer` policy to the example configuration, matching the new action name that the vc verifier sends for non-mDL mDoc documents (see SUNET/vc#519).\n\nWithout this policy, go-trust instances will deny mDoc verification requests for doctypes like `eu.europa.ec.eudi.pid.1` because no registry is configured to handle the `mdoc-issuer` action with `x5c` resource type.