### PR TITLE
fix: allow HTTP JWKS fetch for config-file whitelist registry

### DIFF
--- a/cmd/gt/main.go
+++ b/cmd/gt/main.go
@@ -465,6 +465,7 @@ func configureRegistriesFromConfig(cfg *config.Config, registryMgr *registry.Reg
 					Issuers:         wlCfg.Issuers,
 					Verifiers:       wlCfg.Verifiers,
 					TrustedSubjects: wlCfg.TrustedSubjects,
+					AllowHTTP:       wlCfg.AllowHTTP,
 				}),
 			)
 		}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -80,6 +80,9 @@ type WhitelistRegistryConfig struct {
 	Issuers         []string `yaml:"issuers,omitempty"`
 	Verifiers       []string `yaml:"verifiers,omitempty"`
 	TrustedSubjects []string `yaml:"trusted_subjects,omitempty"`
+	// AllowHTTP permits JWKS auto-discovery over plain HTTP instead of
+	// requiring HTTPS. Testing only - see pkg/registry/static.WhitelistConfig.
+	AllowHTTP bool `yaml:"allow_http,omitempty"`
 }
 
 // StaticRegistryConfig contains static (always/never trusted) registry configuration.


### PR DESCRIPTION
## Summary

- `WhitelistRegistryConfig` had no `allow_http` field, unlike its `DIDWebRegistryConfig`/`DIDWebVHRegistryConfig`/`DIDJWKSRegistryConfig` siblings, so a whitelist registry configured via `--config` had no way to reach `pkg/registry/static.WhitelistConfig`'s existing `AllowHTTP` option.
- JWKS auto-discovery therefore always required HTTPS for config-file-driven whitelists, even for local/testing entities, failing with `"HTTPS required for JWKS fetch"` and registering 0 usable issuers/verifiers.
- Adds the field and wires it through `configureRegistriesFromConfig`'s inline whitelist branch (the `wlCfg.ConfigFile` / `NewWhitelistRegistryFromFile` path is untouched — out of scope here).

Found while aligning `sirosid-dev`'s local PDP config with `helm-charts/siros-id-stack`'s rendered `config.yaml`, which needs to whitelist plain-HTTP local services.

## Test plan
- [x] Rebuilt `cmd/gt` and ran it against a rendered whitelist config with `allow_http: true` for local `http://` entities — the `"HTTPS required for JWKS fetch"` error no longer occurs.
- [x] `golangci-lint` pre-commit hook passed.