### PR TITLE
fix: don't hold write lock across network I/O in WhitelistRegistry.Refresh

### DIFF
--- a/pkg/registry/static/whitelist.go
+++ b/pkg/registry/static/whitelist.go
@@ -742,12 +742,19 @@ func (r *WhitelistRegistry) Healthy() bool {
 // at least some keys were loaded, allowing continued operation during transient
 // outages of individual issuers.
 func (r *WhitelistRegistry) Refresh(ctx context.Context) error {
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	// Snapshot the inputs to this refresh under a brief read lock.
+	// resolvedLists/config are only ever set at construction time (never
+	// mutated afterward), and oldKeyHashes is only used to preserve stale
+	// entries for entities whose fetch fails this round - neither needs to
+	// stay locked for the network I/O below.
+	r.mu.RLock()
+	resolvedLists := r.resolvedLists
+	oldKeyHashes := r.keyHashes
+	r.mu.RUnlock()
 
 	// Collect all unique entities from all resolved lists
 	entities := make(map[string]bool)
-	for _, entries := range r.resolvedLists {
+	for _, entries := range resolvedLists {
 		for _, entry := range entries {
 			if entry != "*" && !strings.HasSuffix(entry, "*") {
 				entities[entry] = true
@@ -755,10 +762,22 @@ func (r *WhitelistRegistry) Refresh(ctx context.Context) error {
 		}
 	}
 
-	// Build new key hashes map, preserving stale entries for failed fetches
+	// Build new key hashes map, preserving stale entries for failed fetches.
+	//
+	// Deliberately NOT holding r.mu across this loop: fetchEntityKeys does
+	// real network I/O (JWKS discovery across several well-known endpoint
+	// patterns, each with its own retries/timeouts) that can take minutes
+	// per entity when an entity is slow or unreachable - e.g. an mdoc-only
+	// issuer with no JWKS endpoint at all. Evaluate() only needs a read lock,
+	// so holding the write lock for this whole loop (as this used to)
+	// blocked every concurrent evaluation - including fast resolution-only
+	// requests that don't even need the data being refreshed - for as long
+	// as the slowest entity's fetch took. Building the new map here and only
+	// taking the write lock afterward to swap it in lets concurrent
+	// Evaluate() calls keep using the still-valid old state while a refresh
+	// is in progress.
 	newKeyHashes := make(map[string]map[string]bool)
 
-	// Fetch JWKS for each entity
 	var fetchErrors []string
 	for entity := range entities {
 		normEntity := normalizeEntityID(entity)
@@ -769,7 +788,7 @@ func (r *WhitelistRegistry) Refresh(ctx context.Context) error {
 				"error", err)
 			fetchErrors = append(fetchErrors, fmt.Sprintf("%s: %s", entity, err))
 			// Preserve stale keys for this entity if available
-			if old, ok := r.keyHashes[normEntity]; ok && len(old) > 0 {
+			if old, ok := oldKeyHashes[normEntity]; ok && len(old) > 0 {
 				newKeyHashes[normEntity] = old
 				r.logger.Info("preserving stale keys for entity",
 					"entity", entity,
@@ -804,19 +823,27 @@ func (r *WhitelistRegistry) Refresh(ctx context.Context) error {
 		}
 	}
 
+	// Swap in the new state - brief write lock, no I/O.
+	r.mu.Lock()
 	r.keyHashes = newKeyHashes
 	r.lastRefresh = time.Now()
+	if len(fetchErrors) > 0 {
+		// Still consider loaded if at least some entities have keys.
+		r.keysLoaded = len(newKeyHashes) > 0
+	} else {
+		r.keysLoaded = true
+	}
+	entityCount := len(r.keyHashes)
+	totalKeys := r.countTotalKeys()
+	r.mu.Unlock()
 
 	if len(fetchErrors) > 0 {
-		// Still consider loaded if at least some entities have keys
-		r.keysLoaded = len(newKeyHashes) > 0
 		return fmt.Errorf("failed to fetch keys for %d entities", len(fetchErrors))
 	}
 
-	r.keysLoaded = true
 	r.logger.Info("whitelist keys refreshed",
-		"entities", len(r.keyHashes),
-		"total_keys", r.countTotalKeys())
+		"entities", entityCount,
+		"total_keys", totalKeys)
 	return nil
 }
 

--- a/pkg/registry/static/whitelist_test.go
+++ b/pkg/registry/static/whitelist_test.go
@@ -1533,6 +1533,94 @@ func TestWhitelistRegistry_RefreshLoop(t *testing.T) {
 	}
 }
 
+// TestWhitelistRegistry_EvaluateDoesNotBlockOnConcurrentRefresh guards
+// against a real bug: Refresh() used to hold r.mu (the write lock) for its
+// entire duration, including the network I/O to fetch each entity's JWKS.
+// Evaluate() only needs a read lock, so a slow-to-resolve entity (an
+// unreachable host, one with no JWKS endpoint at all, etc.) meant every
+// concurrent Evaluate() call - even a fast resolution-only one needing none
+// of the data being refreshed - blocked for as long as that fetch took.
+// Confirmed in production: a background refresh (default every 5 minutes)
+// stalling on one slow entity caused every trust evaluation during that
+// window to time out from the caller's perspective, well before the fetch
+// itself ever gave up.
+func TestWhitelistRegistry_EvaluateDoesNotBlockOnConcurrentRefresh(t *testing.T) {
+	key, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	jwks := map[string]interface{}{
+		"keys": []interface{}{ecdsaPubKeyToJWK(&key.PublicKey, "slow-refresh-key")},
+	}
+
+	fetchStarted := make(chan struct{})
+	releaseFetch := make(chan struct{})
+	var startOnce sync.Once
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		startOnce.Do(func() { close(fetchStarted) })
+		<-releaseFetch
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(jwks)
+	}))
+	defer server.Close()
+
+	reg := NewWhitelistRegistry(
+		WithWhitelistConfig(WhitelistConfig{
+			Issuers:   []string{server.URL},
+			AllowHTTP: true,
+		}),
+	)
+	defer reg.Close()
+
+	// Kick off a Refresh() that will block inside the HTTP handler above
+	// until the test releases it - simulating a slow/unreachable entity.
+	refreshDone := make(chan error, 1)
+	go func() {
+		refreshDone <- reg.Refresh(context.Background())
+	}()
+
+	select {
+	case <-fetchStarted:
+	case <-time.After(2 * time.Second):
+		t.Fatal("Refresh() did not start fetching in time")
+	}
+
+	// While that Refresh() is still blocked on network I/O, a concurrent
+	// resolution-only Evaluate() for the same entity must complete quickly -
+	// whitelist membership only depends on config set at construction time,
+	// not on the JWKS cache Refresh() is rebuilding, so it must not wait for
+	// the in-flight Refresh() to finish.
+	req := &authzen.EvaluationRequest{
+		Subject: authzen.Subject{ID: server.URL},
+		Action:  &authzen.Action{Name: "issuer"},
+	}
+
+	evalDone := make(chan struct{})
+	var resp *authzen.EvaluationResponse
+	var evalErr error
+	go func() {
+		resp, evalErr = reg.Evaluate(context.Background(), req)
+		close(evalDone)
+	}()
+
+	select {
+	case <-evalDone:
+		// Good - Evaluate() did not block behind the in-flight Refresh().
+	case <-time.After(500 * time.Millisecond):
+		t.Fatal("Evaluate() blocked on a concurrent Refresh()'s network I/O - lock held too long")
+	}
+
+	close(releaseFetch)
+	if err := <-refreshDone; err != nil {
+		t.Fatalf("Refresh() failed: %v", err)
+	}
+
+	if evalErr != nil {
+		t.Fatalf("Evaluate() returned error: %v", evalErr)
+	}
+	if !resp.Decision {
+		t.Error("expected decision=true for whitelisted entity (resolution-only)")
+	}
+}
+
 func TestWhitelistRegistry_RefreshLoopWithOption(t *testing.T) {
 	// Test using WithRefreshInterval option
 	key, _ := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)


### PR DESCRIPTION
## Summary

`WhitelistRegistry.Refresh()` held the write lock (`r.mu.Lock()`) for its entire duration, including the per-entity JWKS discovery loop - real network I/O across several well-known endpoint patterns (SD-JWT VC issuer metadata, OAuth AS metadata, OIDC discovery, OpenID4VCI metadata, falling back to raw JWKS), each with its own retries/timeouts. For a slow or unreachable entity (e.g. one with no JWKS endpoint at all, like an mdoc-only issuer), this loop can take minutes.

`Evaluate()` only needs a read lock (`r.mu.RLock()`), but since it blocks on the same mutex, every concurrent evaluation - including fast resolution-only requests that don't even need the JWKS cache being rebuilt - stalled for as long as the slowest entity's fetch took.

## Real-world impact

Confirmed live against a deployed PDP: the default 5-minute background refresh (`DefaultRefreshInterval`) stalling on one slow entity caused every trust evaluation request arriving during that window to time out from the calling client's perspective (e.g. go-wallet-backend's AuthZEN client, with its own shorter HTTP timeout), well before the underlying fetch itself ever gave up. This manifested as intermittent, unexplained "issuer is not trusted" failures for an issuer that was in fact correctly whitelisted - the whitelist membership check itself never even ran in time.

## Fix

Build the new `keyHashes` map without holding any lock - all network I/O happens lock-free. `resolvedLists`/`config`, snapshotted under a brief `RLock` at the start, are only ever set once at construction time and never mutated afterward, so a snapshot is safe to use without holding the lock throughout. Take the write lock only briefly at the end to swap in the new state. Concurrent `Evaluate()` calls now keep using the still-valid old cached state while a refresh is in progress, instead of blocking on it.

## Test plan

- [x] New regression test `TestWhitelistRegistry_EvaluateDoesNotBlockOnConcurrentRefresh`: a slow-to-respond entity blocks `Refresh()` mid-fetch via a test HTTP server; a concurrent resolution-only `Evaluate()` for the same entity must still complete within 500ms.
  - Confirmed this test **hangs for 30s+ against the old code** (reverted locally to check) and **passes instantly** against the fix - it's a real regression guard, not just a happy-path test.
- [x] Full existing test suite (`go test ./...`) passes, all packages, no regressions.
- [x] `golangci-lint` clean (pre-commit hook).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>