### PR TITLE
feat(fidomds3): profile-scoped AAGUID allow/blocklist policy

### DIFF
--- a/cmd/gt/main.go
+++ b/cmd/gt/main.go
@@ -859,6 +859,14 @@ func configurePoliciesFromConfig(cfg *config.Config, registryMgr *registry.Regis
 			}
 		}
 
+		// Convert FIDO MDS3 constraints
+		if policyCfg.FIDOMDS3 != nil {
+			policy.FIDOMDS3 = &registry.FIDOMDS3PolicyConstraints{
+				AllowedAAGUIDs: policyCfg.FIDOMDS3.AllowedAAGUIDs,
+				BlockedAAGUIDs: policyCfg.FIDOMDS3.BlockedAAGUIDs,
+			}
+		}
+
 		policyMgr.RegisterPolicy(policy)
 		policyCount++
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -222,6 +222,9 @@ type PolicyConfig struct {
 
 	// MDOCIACA contains mDOC IACA-specific constraints
 	MDOCIACA *MDOCIACAPolicyConfig `yaml:"mdociaca,omitempty"`
+
+	// FIDOMDS3 contains FIDO Alliance MDS3-specific constraints
+	FIDOMDS3 *FIDOMDS3PolicyConfig `yaml:"fidomds3,omitempty"`
 }
 
 // PolicyConstraintsConfig contains registry-agnostic trust constraints.
@@ -280,6 +283,17 @@ type MDOCIACAPolicyConfig struct {
 
 	// RequireIACAEndpoint requires the issuer to publish mdoc_iacas_uri.
 	RequireIACAEndpoint bool `yaml:"require_iaca_endpoint,omitempty"`
+}
+
+// FIDOMDS3PolicyConfig contains FIDO Alliance MDS3-specific policy constraints.
+type FIDOMDS3PolicyConfig struct {
+	// AllowedAAGUIDs restricts trust to specific AAGUIDs, regardless of MDS3
+	// certification status.
+	AllowedAAGUIDs []string `yaml:"allowed_aaguids,omitempty"`
+
+	// BlockedAAGUIDs denies specific AAGUIDs even if MDS3 certifies them.
+	// Only applied when AllowedAAGUIDs is empty.
+	BlockedAAGUIDs []string `yaml:"blocked_aaguids,omitempty"`
 }
 
 // ServerConfig contains HTTP server configuration settings.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -355,6 +355,12 @@ policies:
         issuer_allowlist:
           - "https://mdl-issuer.example.com"
         require_iaca_endpoint: true
+
+    wscd-previewsign-provision:
+      description: "Trust requirements for WSCD previewSign provisioning"
+      fidomds3:
+        allowed_aaguids:
+          - "0132d110-bf4e-4208-a403-ab4f5f12efe5"
 `
 
 	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
@@ -372,8 +378,8 @@ policies:
 	}
 
 	// Verify policies count
-	if len(cfg.Policies.Policies) != 3 {
-		t.Errorf("Policies count = %v, want %v", len(cfg.Policies.Policies), 3)
+	if len(cfg.Policies.Policies) != 4 {
+		t.Errorf("Policies count = %v, want %v", len(cfg.Policies.Policies), 4)
 	}
 
 	// Verify credential-issuer policy
@@ -446,5 +452,17 @@ policies:
 	}
 	if !mdlPolicy.MDOCIACA.RequireIACAEndpoint {
 		t.Error("MDOCIACA RequireIACAEndpoint should be true")
+	}
+
+	// Verify wscd-previewsign-provision policy
+	wscdPolicy := cfg.Policies.Policies["wscd-previewsign-provision"]
+	if wscdPolicy == nil {
+		t.Fatal("wscd-previewsign-provision policy not found")
+	}
+	if wscdPolicy.FIDOMDS3 == nil {
+		t.Fatal("FIDOMDS3 constraints not found")
+	}
+	if len(wscdPolicy.FIDOMDS3.AllowedAAGUIDs) != 1 {
+		t.Errorf("FIDOMDS3 AllowedAAGUIDs count = %v, want %v", len(wscdPolicy.FIDOMDS3.AllowedAAGUIDs), 1)
 	}
 }

--- a/pkg/registry/contextutil.go
+++ b/pkg/registry/contextutil.go
@@ -1,0 +1,27 @@
+package registry
+
+// ExtractStringList reads a string list from an AuthZEN request's context
+// map. Values may arrive as []string (set directly, e.g. from Go code or
+// tests) or []interface{} (typical after JSON unmarshaling). Registries use
+// this to read policy-derived constraints (e.g. issuer or AAGUID allow/
+// blocklists) that RegistryManager.applyPolicyToRequest placed in
+// req.Context.
+func ExtractStringList(ctx map[string]interface{}, key string) []string {
+	v, ok := ctx[key]
+	if !ok {
+		return nil
+	}
+	switch s := v.(type) {
+	case []string:
+		return s
+	case []interface{}:
+		result := make([]string, 0, len(s))
+		for _, item := range s {
+			if str, ok := item.(string); ok {
+				result = append(result, str)
+			}
+		}
+		return result
+	}
+	return nil
+}

--- a/pkg/registry/contextutil_test.go
+++ b/pkg/registry/contextutil_test.go
@@ -1,0 +1,18 @@
+package registry
+
+import "testing"
+
+func TestExtractStringList(t *testing.T) {
+	if got := ExtractStringList(map[string]interface{}{}, "allowed"); got != nil {
+		t.Errorf("expected nil for missing key, got %v", got)
+	}
+	if got := ExtractStringList(map[string]interface{}{"allowed": []string{"a", "b"}}, "allowed"); len(got) != 2 {
+		t.Errorf("expected []string passthrough, got %v", got)
+	}
+	if got := ExtractStringList(map[string]interface{}{"allowed": []interface{}{"a", "b"}}, "allowed"); len(got) != 2 {
+		t.Errorf("expected []interface{} to convert to []string, got %v", got)
+	}
+	if got := ExtractStringList(map[string]interface{}{"allowed": []interface{}{"a", 1, "b"}}, "allowed"); len(got) != 2 {
+		t.Errorf("expected non-string elements to be dropped, got %v", got)
+	}
+}

--- a/pkg/registry/fidomds3/registry.go
+++ b/pkg/registry/fidomds3/registry.go
@@ -360,6 +360,29 @@ func (r *Registry) setHealthy(healthy bool) {
 //     certification status
 //   - blocked_aaguids: these AAGUIDs are denied even if MDS3 certifies them
 //     (only checked when allowed_aaguids is absent/empty)
+//
+// checkAAGUIDPolicy enforces the allowed_aaguids/blocked_aaguids policy
+// constraints (see Evaluate's doc comment) against a resolved AAGUID.
+// Returns a deny response if the policy rejects it, or nil if evaluation
+// should continue to MDS3 status/chain verification.
+func (r *Registry) checkAAGUIDPolicy(reqCtx map[string]interface{}, aaguid uuid.UUID) *authzen.EvaluationResponse {
+	if reqCtx == nil {
+		return nil
+	}
+	if allowed := registry.ExtractStringList(reqCtx, "allowed_aaguids"); len(allowed) > 0 {
+		if !slices.Contains(allowed, aaguid.String()) {
+			return r.denyWithReason(fmt.Sprintf("AAGUID %s is not on the policy allowlist for this profile", aaguid))
+		}
+		return nil
+	}
+	if blocked := registry.ExtractStringList(reqCtx, "blocked_aaguids"); len(blocked) > 0 {
+		if slices.Contains(blocked, aaguid.String()) {
+			return r.denyWithReason(fmt.Sprintf("AAGUID %s is on the policy blocklist for this profile", aaguid))
+		}
+	}
+	return nil
+}
+
 func (r *Registry) Evaluate(ctx context.Context, req *authzen.EvaluationRequest) (*authzen.EvaluationResponse, error) {
 	aaguid, err := uuid.Parse(req.Subject.ID)
 	if err != nil {
@@ -374,16 +397,8 @@ func (r *Registry) Evaluate(ctx context.Context, req *authzen.EvaluationRequest)
 		return r.denyWithReason(fmt.Sprintf("no FIDO MDS3 entry for AAGUID %s", aaguid)), nil
 	}
 
-	if req.Context != nil {
-		if allowed := registry.ExtractStringList(req.Context, "allowed_aaguids"); len(allowed) > 0 {
-			if !slices.Contains(allowed, aaguid.String()) {
-				return r.denyWithReason(fmt.Sprintf("AAGUID %s is not on the policy allowlist for this profile", aaguid)), nil
-			}
-		} else if blocked := registry.ExtractStringList(req.Context, "blocked_aaguids"); len(blocked) > 0 {
-			if slices.Contains(blocked, aaguid.String()) {
-				return r.denyWithReason(fmt.Sprintf("AAGUID %s is on the policy blocklist for this profile", aaguid)), nil
-			}
-		}
+	if resp := r.checkAAGUIDPolicy(req.Context, aaguid); resp != nil {
+		return resp, nil
 	}
 
 	chain, err := parseX5CChain(req.Resource.Key)

--- a/pkg/registry/fidomds3/registry.go
+++ b/pkg/registry/fidomds3/registry.go
@@ -375,11 +375,11 @@ func (r *Registry) Evaluate(ctx context.Context, req *authzen.EvaluationRequest)
 	}
 
 	if req.Context != nil {
-		if allowed := extractAAGUIDList(req.Context, "allowed_aaguids"); len(allowed) > 0 {
+		if allowed := registry.ExtractStringList(req.Context, "allowed_aaguids"); len(allowed) > 0 {
 			if !slices.Contains(allowed, aaguid.String()) {
 				return r.denyWithReason(fmt.Sprintf("AAGUID %s is not on the policy allowlist for this profile", aaguid)), nil
 			}
-		} else if blocked := extractAAGUIDList(req.Context, "blocked_aaguids"); len(blocked) > 0 {
+		} else if blocked := registry.ExtractStringList(req.Context, "blocked_aaguids"); len(blocked) > 0 {
 			if slices.Contains(blocked, aaguid.String()) {
 				return r.denyWithReason(fmt.Sprintf("AAGUID %s is on the policy blocklist for this profile", aaguid)), nil
 			}
@@ -437,31 +437,6 @@ func (r *Registry) Evaluate(ctx context.Context, req *authzen.EvaluationRequest)
 			Reason: reason,
 		},
 	}, nil
-}
-
-// extractAAGUIDList reads a policy-derived AAGUID list from a request's
-// context. Values may arrive as []string (set directly, e.g. from Go code
-// or tests) or []interface{} (typical after JSON unmarshaling), matching
-// how other registries in this package tree (e.g. mdociaca's
-// extractIssuerAllowlist) read policy constraints from req.Context.
-func extractAAGUIDList(ctx map[string]interface{}, key string) []string {
-	v, ok := ctx[key]
-	if !ok {
-		return nil
-	}
-	switch s := v.(type) {
-	case []string:
-		return s
-	case []interface{}:
-		result := make([]string, 0, len(s))
-		for _, item := range s {
-			if str, ok := item.(string); ok {
-				result = append(result, str)
-			}
-		}
-		return result
-	}
-	return nil
 }
 
 // SupportedResourceTypes returns the resource types this registry handles.

--- a/pkg/registry/fidomds3/registry.go
+++ b/pkg/registry/fidomds3/registry.go
@@ -24,6 +24,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"slices"
 	"sync"
 	"time"
 
@@ -351,6 +352,14 @@ func (r *Registry) setHealthy(healthy bool) {
 // half of a name-to-key binding - here, the name is the authenticator
 // model's AAGUID (a UUID), and the key is the x5c chain an attestation
 // object claims was produced by that model.
+//
+// Policy constraints from req.Context (set by the policy mapper, see
+// pkg/registry.RegistryManager.applyPolicyToRequest) are also enforced, on
+// top of MDS3 status/chain verification, never instead of it:
+//   - allowed_aaguids: only these AAGUIDs are trusted, regardless of MDS3
+//     certification status
+//   - blocked_aaguids: these AAGUIDs are denied even if MDS3 certifies them
+//     (only checked when allowed_aaguids is absent/empty)
 func (r *Registry) Evaluate(ctx context.Context, req *authzen.EvaluationRequest) (*authzen.EvaluationResponse, error) {
 	aaguid, err := uuid.Parse(req.Subject.ID)
 	if err != nil {
@@ -363,6 +372,18 @@ func (r *Registry) Evaluate(ctx context.Context, req *authzen.EvaluationRequest)
 
 	if !ok {
 		return r.denyWithReason(fmt.Sprintf("no FIDO MDS3 entry for AAGUID %s", aaguid)), nil
+	}
+
+	if req.Context != nil {
+		if allowed := extractAAGUIDList(req.Context, "allowed_aaguids"); len(allowed) > 0 {
+			if !slices.Contains(allowed, aaguid.String()) {
+				return r.denyWithReason(fmt.Sprintf("AAGUID %s is not on the policy allowlist for this profile", aaguid)), nil
+			}
+		} else if blocked := extractAAGUIDList(req.Context, "blocked_aaguids"); len(blocked) > 0 {
+			if slices.Contains(blocked, aaguid.String()) {
+				return r.denyWithReason(fmt.Sprintf("AAGUID %s is on the policy blocklist for this profile", aaguid)), nil
+			}
+		}
 	}
 
 	chain, err := parseX5CChain(req.Resource.Key)
@@ -400,17 +421,47 @@ func (r *Registry) Evaluate(ctx context.Context, req *authzen.EvaluationRequest)
 		return r.denyWithReason(fmt.Sprintf("x5c chain does not verify against MDS3 attestation roots: %v", err)), nil
 	}
 
+	reason := map[string]interface{}{
+		"trust_anchor":         "fido_mds3",
+		"aaguid":               aaguid.String(),
+		"description":          entry.MetadataStatement.Description,
+		"attestation_root_cas": len(entry.MetadataStatement.AttestationRootCertificates),
+	}
+	if policyName, ok := req.Context["_policy"].(string); ok && policyName != "" {
+		reason["policy"] = policyName
+	}
+
 	return &authzen.EvaluationResponse{
 		Decision: true,
 		Context: &authzen.EvaluationResponseContext{
-			Reason: map[string]interface{}{
-				"trust_anchor":         "fido_mds3",
-				"aaguid":               aaguid.String(),
-				"description":          entry.MetadataStatement.Description,
-				"attestation_root_cas": len(entry.MetadataStatement.AttestationRootCertificates),
-			},
+			Reason: reason,
 		},
 	}, nil
+}
+
+// extractAAGUIDList reads a policy-derived AAGUID list from a request's
+// context. Values may arrive as []string (set directly, e.g. from Go code
+// or tests) or []interface{} (typical after JSON unmarshaling), matching
+// how other registries in this package tree (e.g. mdociaca's
+// extractIssuerAllowlist) read policy constraints from req.Context.
+func extractAAGUIDList(ctx map[string]interface{}, key string) []string {
+	v, ok := ctx[key]
+	if !ok {
+		return nil
+	}
+	switch s := v.(type) {
+	case []string:
+		return s
+	case []interface{}:
+		result := make([]string, 0, len(s))
+		for _, item := range s {
+			if str, ok := item.(string); ok {
+				result = append(result, str)
+			}
+		}
+		return result
+	}
+	return nil
 }
 
 // SupportedResourceTypes returns the resource types this registry handles.

--- a/pkg/registry/fidomds3/registry_test.go
+++ b/pkg/registry/fidomds3/registry_test.go
@@ -271,6 +271,173 @@ func TestEvaluate_UndesiredStatus(t *testing.T) {
 	}
 }
 
+// newSelfCertifiedEntry builds an entry whose attestation root is a
+// self-signed CA certificate that we hand-construct (and hold the private
+// key for) ourselves - unlike TestEvaluate_UntrustedChain, which loads a
+// *real* fetched MDS3 entry whose genuine attestationRootCertificates key
+// material nobody testing this code possesses, entries built directly via
+// the Registry.entries map (as this helper and TestEvaluate_UndesiredStatus
+// already do) are entirely test-controlled, so a real positive chain is
+// achievable synthetically: it returns the base64-encoded DER of that same
+// CA certificate as a one-element x5c chain, which genuinely verifies
+// against the entry's own attestation roots. This gives policy tests a real
+// "MDS3 would trust this" positive baseline to layer allow/blocklist denial
+// on top of.
+func newSelfCertifiedEntry(t *testing.T, aaguid uuid.UUID) (*metadata.Entry, string) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "test-attestation-root"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(time.Hour),
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageDigitalSignature,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create certificate: %v", err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("parse self-signed cert: %v", err)
+	}
+	entry := &metadata.Entry{
+		AaGUID: aaguid,
+		MetadataStatement: metadata.Statement{
+			Description:                 "test authenticator",
+			AttestationRootCertificates: []*x509.Certificate{cert},
+		},
+	}
+	return entry, base64.StdEncoding.EncodeToString(der)
+}
+
+func TestEvaluate_NoProfileUnaffected(t *testing.T) {
+	aaguid := uuid.New()
+	entry, chainB64 := newSelfCertifiedEntry(t, aaguid)
+	r := &Registry{entries: map[uuid.UUID]*metadata.Entry{aaguid: entry}}
+
+	resp, err := r.Evaluate(context.Background(), &authzen.EvaluationRequest{
+		Subject:  authzen.Subject{Type: "key", ID: aaguid.String()},
+		Resource: authzen.Resource{Type: "x5c", ID: aaguid.String(), Key: []interface{}{chainB64}},
+	})
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if !resp.Decision {
+		t.Error("expected Decision=true when no policy context is present and MDS3 checks pass")
+	}
+}
+
+func TestEvaluate_AllowlistDeniesUnlistedAAGUID(t *testing.T) {
+	aaguid := uuid.New()
+	entry, chainB64 := newSelfCertifiedEntry(t, aaguid)
+	r := &Registry{entries: map[uuid.UUID]*metadata.Entry{aaguid: entry}}
+
+	resp, err := r.Evaluate(context.Background(), &authzen.EvaluationRequest{
+		Subject:  authzen.Subject{Type: "key", ID: aaguid.String()},
+		Resource: authzen.Resource{Type: "x5c", ID: aaguid.String(), Key: []interface{}{chainB64}},
+		Context:  map[string]interface{}{"allowed_aaguids": []string{uuid.New().String()}},
+	})
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if resp.Decision {
+		t.Error("expected Decision=false for an AAGUID not on the policy allowlist, even though MDS3 would trust it")
+	}
+}
+
+func TestEvaluate_AllowlistAllowsListedAAGUID(t *testing.T) {
+	aaguid := uuid.New()
+	entry, chainB64 := newSelfCertifiedEntry(t, aaguid)
+	r := &Registry{entries: map[uuid.UUID]*metadata.Entry{aaguid: entry}}
+
+	resp, err := r.Evaluate(context.Background(), &authzen.EvaluationRequest{
+		Subject:  authzen.Subject{Type: "key", ID: aaguid.String()},
+		Resource: authzen.Resource{Type: "x5c", ID: aaguid.String(), Key: []interface{}{chainB64}},
+		Context:  map[string]interface{}{"allowed_aaguids": []string{aaguid.String()}},
+	})
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if !resp.Decision {
+		t.Error("expected Decision=true for an AAGUID on the policy allowlist")
+	}
+}
+
+func TestEvaluate_BlocklistDeniesListedAAGUID(t *testing.T) {
+	aaguid := uuid.New()
+	entry, chainB64 := newSelfCertifiedEntry(t, aaguid)
+	r := &Registry{entries: map[uuid.UUID]*metadata.Entry{aaguid: entry}}
+
+	resp, err := r.Evaluate(context.Background(), &authzen.EvaluationRequest{
+		Subject:  authzen.Subject{Type: "key", ID: aaguid.String()},
+		Resource: authzen.Resource{Type: "x5c", ID: aaguid.String(), Key: []interface{}{chainB64}},
+		Context:  map[string]interface{}{"blocked_aaguids": []string{aaguid.String()}},
+	})
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if resp.Decision {
+		t.Error("expected Decision=false for an AAGUID on the policy blocklist, even though MDS3 certifies it")
+	}
+}
+
+func TestEvaluate_BlocklistAllowsUnlistedAAGUID(t *testing.T) {
+	aaguid := uuid.New()
+	entry, chainB64 := newSelfCertifiedEntry(t, aaguid)
+	r := &Registry{entries: map[uuid.UUID]*metadata.Entry{aaguid: entry}}
+
+	resp, err := r.Evaluate(context.Background(), &authzen.EvaluationRequest{
+		Subject:  authzen.Subject{Type: "key", ID: aaguid.String()},
+		Resource: authzen.Resource{Type: "x5c", ID: aaguid.String(), Key: []interface{}{chainB64}},
+		Context:  map[string]interface{}{"blocked_aaguids": []string{uuid.New().String()}},
+	})
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if !resp.Decision {
+		t.Error("expected Decision=true for an AAGUID not on the policy blocklist")
+	}
+}
+
+func TestEvaluate_AllowlistTakesPrecedenceOverBlocklist(t *testing.T) {
+	aaguid := uuid.New()
+	entry, chainB64 := newSelfCertifiedEntry(t, aaguid)
+	r := &Registry{entries: map[uuid.UUID]*metadata.Entry{aaguid: entry}}
+
+	resp, err := r.Evaluate(context.Background(), &authzen.EvaluationRequest{
+		Subject:  authzen.Subject{Type: "key", ID: aaguid.String()},
+		Resource: authzen.Resource{Type: "x5c", ID: aaguid.String(), Key: []interface{}{chainB64}},
+		Context: map[string]interface{}{
+			"allowed_aaguids": []string{aaguid.String()},
+			"blocked_aaguids": []string{aaguid.String()},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Evaluate returned error: %v", err)
+	}
+	if !resp.Decision {
+		t.Error("expected Decision=true: allowlist takes precedence when both allowed_aaguids and blocked_aaguids are set")
+	}
+}
+
+func TestExtractAAGUIDList(t *testing.T) {
+	if got := extractAAGUIDList(map[string]interface{}{}, "allowed_aaguids"); got != nil {
+		t.Errorf("expected nil for missing key, got %v", got)
+	}
+	if got := extractAAGUIDList(map[string]interface{}{"allowed_aaguids": []string{"a", "b"}}, "allowed_aaguids"); len(got) != 2 {
+		t.Errorf("expected []string passthrough, got %v", got)
+	}
+	if got := extractAAGUIDList(map[string]interface{}{"allowed_aaguids": []interface{}{"a", "b"}}, "allowed_aaguids"); len(got) != 2 {
+		t.Errorf("expected []interface{} to convert to []string, got %v", got)
+	}
+}
+
 func TestRefreshInterval_ZeroDisablesLoop(t *testing.T) {
 	server := newTestServer(t, exampleMetadataBLOB, http.StatusOK)
 	defer server.Close()

--- a/pkg/registry/fidomds3/registry_test.go
+++ b/pkg/registry/fidomds3/registry_test.go
@@ -426,18 +426,6 @@ func TestEvaluate_AllowlistTakesPrecedenceOverBlocklist(t *testing.T) {
 	}
 }
 
-func TestExtractAAGUIDList(t *testing.T) {
-	if got := extractAAGUIDList(map[string]interface{}{}, "allowed_aaguids"); got != nil {
-		t.Errorf("expected nil for missing key, got %v", got)
-	}
-	if got := extractAAGUIDList(map[string]interface{}{"allowed_aaguids": []string{"a", "b"}}, "allowed_aaguids"); len(got) != 2 {
-		t.Errorf("expected []string passthrough, got %v", got)
-	}
-	if got := extractAAGUIDList(map[string]interface{}{"allowed_aaguids": []interface{}{"a", "b"}}, "allowed_aaguids"); len(got) != 2 {
-		t.Errorf("expected []interface{} to convert to []string, got %v", got)
-	}
-}
-
 func TestRefreshInterval_ZeroDisablesLoop(t *testing.T) {
 	server := newTestServer(t, exampleMetadataBLOB, http.StatusOK)
 	defer server.Close()

--- a/pkg/registry/manager.go
+++ b/pkg/registry/manager.go
@@ -336,6 +336,17 @@ func (m *RegistryManager) applyPolicyToRequest(req *authzen.EvaluationRequest, p
 		}
 	}
 
+	// Apply FIDO MDS3 constraints
+	if policyCtx.Policy.FIDOMDS3 != nil {
+		fido := policyCtx.Policy.FIDOMDS3
+		if len(fido.AllowedAAGUIDs) > 0 {
+			req.Context["allowed_aaguids"] = fido.AllowedAAGUIDs
+		}
+		if len(fido.BlockedAAGUIDs) > 0 {
+			req.Context["blocked_aaguids"] = fido.BlockedAAGUIDs
+		}
+	}
+
 	// Store policy name in context for debugging/logging
 	req.Context["_policy"] = policyCtx.Policy.Name
 }

--- a/pkg/registry/manager_test.go
+++ b/pkg/registry/manager_test.go
@@ -752,6 +752,52 @@ func TestRegistryManager_Evaluate_NormalizesSubjectID(t *testing.T) {
 	assert.Equal(t, "https://verifier.example.com", capturedSubjectID)
 }
 
+func TestRegistryManager_Evaluate_AppliesFIDOMDS3Policy(t *testing.T) {
+	var capturedContext map[string]interface{}
+	reg := &captureMockRegistry{
+		mockRegistry: &mockRegistry{
+			name:          "fido-mds3",
+			resourceTypes: []string{"x5c"},
+			healthy:       true,
+			evaluateResponse: &authzen.EvaluationResponse{
+				Decision: true,
+			},
+		},
+		onEvaluate: func(req *authzen.EvaluationRequest) {
+			capturedContext = req.Context
+		},
+	}
+
+	mgr := NewRegistryManager(FirstMatch, 10*time.Second)
+	mgr.Register(reg)
+
+	pm := NewPolicyManager()
+	pm.RegisterPolicy(&Policy{
+		Name: "wscd-previewsign-provision",
+		FIDOMDS3: &FIDOMDS3PolicyConstraints{
+			AllowedAAGUIDs: []string{"aaguid-1"},
+		},
+	})
+	mgr.SetPolicyManager(pm)
+
+	req := &authzen.EvaluationRequest{
+		Subject: authzen.Subject{Type: "key", ID: "aaguid-1"},
+		Action:  &authzen.Action{Name: "wscd-previewsign-provision"},
+		Resource: authzen.Resource{
+			Type: "x5c",
+			ID:   "aaguid-1",
+			Key:  []interface{}{"test"},
+		},
+	}
+
+	ctx := context.Background()
+	resp, err := mgr.Evaluate(ctx, req)
+	require.NoError(t, err)
+	assert.True(t, resp.Decision)
+	assert.Equal(t, []string{"aaguid-1"}, capturedContext["allowed_aaguids"])
+	assert.Nil(t, capturedContext["blocked_aaguids"])
+}
+
 // logEntry records a single log call.
 type logEntry struct {
 	level  logging.LogLevel

--- a/pkg/registry/policy.go
+++ b/pkg/registry/policy.go
@@ -30,6 +30,9 @@ type Policy struct {
 
 	// MDOCIACA contains mDOC IACA-specific constraints
 	MDOCIACA *MDOCIACAPolicyConstraints `json:"mdociaca,omitempty" yaml:"mdociaca,omitempty"`
+
+	// FIDOMDS3 contains FIDO Alliance MDS3-specific constraints
+	FIDOMDS3 *FIDOMDS3PolicyConstraints `json:"fidomds3,omitempty" yaml:"fidomds3,omitempty"`
 }
 
 // PolicyConstraints contains registry-agnostic trust constraints.
@@ -140,6 +143,27 @@ type MDOCIACAPolicyConstraints struct {
 	// RequireIACAEndpoint requires the issuer to publish mdoc_iacas_uri.
 	// When true, issuers without IACA endpoints are rejected.
 	RequireIACAEndpoint bool `json:"require_iaca_endpoint,omitempty" yaml:"require_iaca_endpoint,omitempty"`
+}
+
+// FIDOMDS3PolicyConstraints contains FIDO Alliance MDS3-specific constraints,
+// applied on top of (never instead of) the registry's own MDS3 status-report
+// and x5c chain verification.
+//
+// If AllowedAAGUIDs is non-empty, only those AAGUIDs are trusted regardless
+// of MDS3 certification status ("allowlist_only" semantics). Otherwise, if
+// BlockedAAGUIDs is non-empty, all MDS3-certified AAGUIDs are trusted except
+// those listed ("allow_except_blocklist" semantics). If both are non-empty,
+// AllowedAAGUIDs takes precedence and BlockedAAGUIDs is ignored. If neither
+// is set — including when no policy matches the request's action at all —
+// behavior is unchanged: MDS3 status/chain verification only.
+type FIDOMDS3PolicyConstraints struct {
+	// AllowedAAGUIDs restricts trust to specific AAGUIDs, regardless of MDS3
+	// certification status. If empty, this constraint has no effect.
+	AllowedAAGUIDs []string `json:"allowed_aaguids,omitempty" yaml:"allowed_aaguids,omitempty"`
+
+	// BlockedAAGUIDs denies specific AAGUIDs even if MDS3 certifies them.
+	// Only applied when AllowedAAGUIDs is empty.
+	BlockedAAGUIDs []string `json:"blocked_aaguids,omitempty" yaml:"blocked_aaguids,omitempty"`
 }
 
 // PolicyManager manages trust policies and routes requests based on action.name.
@@ -280,4 +304,25 @@ func (pc *PolicyContext) GetMDOCIACAIssuerAllowlist() []string {
 		return nil
 	}
 	return pc.Policy.MDOCIACA.IssuerAllowlist
+}
+
+// HasFIDOMDS3Constraints returns true if the policy has FIDO MDS3-specific constraints.
+func (pc *PolicyContext) HasFIDOMDS3Constraints() bool {
+	return pc.Policy != nil && pc.Policy.FIDOMDS3 != nil
+}
+
+// GetFIDOMDS3AllowedAAGUIDs returns the AAGUID allowlist from the policy, or nil.
+func (pc *PolicyContext) GetFIDOMDS3AllowedAAGUIDs() []string {
+	if pc.Policy == nil || pc.Policy.FIDOMDS3 == nil {
+		return nil
+	}
+	return pc.Policy.FIDOMDS3.AllowedAAGUIDs
+}
+
+// GetFIDOMDS3BlockedAAGUIDs returns the AAGUID blocklist from the policy, or nil.
+func (pc *PolicyContext) GetFIDOMDS3BlockedAAGUIDs() []string {
+	if pc.Policy == nil || pc.Policy.FIDOMDS3 == nil {
+		return nil
+	}
+	return pc.Policy.FIDOMDS3.BlockedAAGUIDs
 }

--- a/pkg/registry/policy_test.go
+++ b/pkg/registry/policy_test.go
@@ -251,3 +251,41 @@ func TestPolicyContext_MDOCIACAHelpers(t *testing.T) {
 		t.Error("GetMDOCIACAIssuerAllowlist returned wrong values")
 	}
 }
+
+func TestPolicyContext_FIDOMDS3Helpers(t *testing.T) {
+	// Test with nil policy
+	pc := &PolicyContext{}
+	if pc.HasFIDOMDS3Constraints() {
+		t.Error("HasFIDOMDS3Constraints should be false for nil policy")
+	}
+	if pc.GetFIDOMDS3AllowedAAGUIDs() != nil {
+		t.Error("GetFIDOMDS3AllowedAAGUIDs should return nil for nil policy")
+	}
+	if pc.GetFIDOMDS3BlockedAAGUIDs() != nil {
+		t.Error("GetFIDOMDS3BlockedAAGUIDs should return nil for nil policy")
+	}
+
+	// Test with FIDOMDS3 constraints
+	pc = &PolicyContext{
+		Policy: &Policy{
+			FIDOMDS3: &FIDOMDS3PolicyConstraints{
+				AllowedAAGUIDs: []string{"aaguid-1", "aaguid-2"},
+				BlockedAAGUIDs: []string{"aaguid-3"},
+			},
+		},
+	}
+
+	if !pc.HasFIDOMDS3Constraints() {
+		t.Error("HasFIDOMDS3Constraints should be true")
+	}
+
+	allowed := pc.GetFIDOMDS3AllowedAAGUIDs()
+	if len(allowed) != 2 || allowed[0] != "aaguid-1" {
+		t.Error("GetFIDOMDS3AllowedAAGUIDs returned wrong values")
+	}
+
+	blocked := pc.GetFIDOMDS3BlockedAAGUIDs()
+	if len(blocked) != 1 || blocked[0] != "aaguid-3" {
+		t.Error("GetFIDOMDS3BlockedAAGUIDs returned wrong values")
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #116's `fidomds3` registry. MDS3 certification status alone can't express two needs from design discussion (2026-08-07): denying a specific AAGUID MDS3 still calls certified (e.g. a known-broken PRF implementation), and allowing only a curated subset tighter than "not revoked" (e.g. WSCD previewSign provisioning). These pull in opposite directions on the *same* AAGUID depending on what it's being evaluated for, so it needs to be a policy scoped by action/profile, not a global list per registry.

Rather than inventing a new mechanism inside `fidomds3`, or copying `pkg/registry/static/whitelist.go`'s `Lists`+`Actions` pattern (built for a different kind of registry - extrinsic identity allowlisting), this wires into the mechanism go-trust already uses to give the same underlying trust data different outcomes per role (ETSI TSL service-type filtering differs for `credential-issuer` vs `credential-verifier` against the same TSL, for example): the `Policy`/`PolicyManager` system in `pkg/registry/policy.go` + `RegistryManager.applyPolicyToRequest`. `MDOCIACAPolicyConstraints` (`IssuerAllowlist`/`RequireIACAEndpoint`) is the closest, fully-realized precedent and this mirrors its shape field-for-field:

- New `FIDOMDS3PolicyConstraints{AllowedAAGUIDs, BlockedAAGUIDs}` on `Policy`, plus the matching `PolicyContext` getters every other constraint type has.
- `applyPolicyToRequest` translates it into `req.Context["allowed_aaguids"]`/`["blocked_aaguids"]` (same snake_case-of-field-name convention as every other constraint type in that function).
- Config plumbing (`pkg/config/config.go`'s `FIDOMDS3PolicyConfig`, wired in `cmd/gt/main.go`'s `configurePoliciesFromConfig`) mirrors `MDOCIACAPolicyConfig` exactly.
- `fidomds3.Registry.Evaluate()` reads `allowed_aaguids`/`blocked_aaguids` right after AAGUID→entry resolution and before the expensive chain-parsing/crypto work - if `allowed_aaguids` is non-empty, only listed AAGUIDs pass regardless of MDS3 status; otherwise if `blocked_aaguids` is non-empty, MDS3-certified AAGUIDs are trusted except those listed. Both applied *on top of*, never instead of, the existing MDS3 status-report/chain verification. No action/profile match (or neither list set) behaves exactly as before this PR.

No protocol change needed - `authzen.Action.Name` and `PolicyManager.GetPolicy()` already do this job for every other registry family.

Scope note: this is go-trust only. The go-wallet-backend side (actually sending a profile name from `FIDO2AttestationService`, and the open question of whether/how to wire go-trust into passkey login at all - it doesn't touch go-trust today) is confirmed future/anticipated work, not part of this change.

## Test plan

- [x] `go build ./...`, `go vet ./...` - clean
- [x] `gofmt`, `golangci-lint run` - clean, 0 issues
- [x] `go test ./...` - full suite passes
- [x] New `fidomds3` tests use a hand-constructed, self-signed CA certificate (test-controlled, unlike #116's real-fixture tests) as both an entry's attestation root and its presented x5c chain, giving a genuine "MDS3 would trust this" positive baseline to prove policy denial/allowance is layered on top of real verification, not a bypass: no-profile-unaffected, allowlist denies unlisted/allows listed, blocklist denies listed/allows unlisted, and allowlist-takes-precedence-when-both-set.
- [x] `PolicyContext` getter tests (mirrors `TestPolicyContext_MDOCIACAHelpers`), a `RegistryManager.applyPolicyToRequest` context-translation test (mirrors the existing `captureMockRegistry` pattern), and a config YAML round-trip test all added alongside the existing equivalents for other constraint types.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01LBJ9AokHnivbw5cRgr16M1