### PR TITLE
feat(whitelist): trust x509_san_dns/x509_hash verifiers via system CA pool

### DIFF
--- a/cmd/gt/main.go
+++ b/cmd/gt/main.go
@@ -461,12 +461,13 @@ func configureRegistriesFromConfig(cfg *config.Config, registryMgr *registry.Reg
 				static.WithWhitelistName(name),
 				static.WithWhitelistDescription(desc),
 				static.WithWhitelistConfig(static.WhitelistConfig{
-					Lists:           wlCfg.Lists,
-					Actions:         wlCfg.Actions,
-					Issuers:         wlCfg.Issuers,
-					Verifiers:       wlCfg.Verifiers,
-					TrustedSubjects: wlCfg.TrustedSubjects,
-					AllowHTTP:       wlCfg.AllowHTTP,
+					Lists:                wlCfg.Lists,
+					Actions:              wlCfg.Actions,
+					Issuers:              wlCfg.Issuers,
+					Verifiers:            wlCfg.Verifiers,
+					TrustedSubjects:      wlCfg.TrustedSubjects,
+					AllowHTTP:            wlCfg.AllowHTTP,
+					TrustX509ViaSystemCA: wlCfg.TrustX509ViaSystemCA,
 				}),
 			)
 		}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -85,6 +85,11 @@ type WhitelistRegistryConfig struct {
 	// AllowHTTP permits JWKS auto-discovery over plain HTTP instead of
 	// requiring HTTPS. Testing only - see pkg/registry/static.WhitelistConfig.
 	AllowHTTP bool `yaml:"allow_http,omitempty"`
+	// TrustX509ViaSystemCA enables the system-CA-pool fallback for whitelisted
+	// entities with no JWKS endpoint (e.g. OpenID4VP x509_san_dns or x509_hash
+	// client_id_scheme verifiers) - see
+	// pkg/registry/static.WhitelistConfig.TrustX509ViaSystemCA.
+	TrustX509ViaSystemCA bool `yaml:"trust_x509_via_system_ca,omitempty"`
 }
 
 // StaticRegistryConfig contains static (always/never trusted) registry configuration.

--- a/pkg/registry/static/whitelist.go
+++ b/pkg/registry/static/whitelist.go
@@ -535,13 +535,9 @@ func (r *WhitelistRegistry) Evaluate(ctx context.Context, req *authzen.Evaluatio
 		return r.allowResolutionOnly(subjectID, role, matchedList, req)
 	}
 
-	// Verify key binding: extract the key from the request and check against cached hashes
-	keyFingerprint, err := r.extractKeyFingerprint(req)
-	if err != nil {
-		return r.deny(subjectID, fmt.Sprintf("failed to extract key: %s", err))
-	}
-
-	// Check if the key fingerprint matches any of the entity's registered keys.
+	// Check if we have any keys cached for this entity via JWKS before even
+	// trying to extract a key from the request - if there's nothing cached
+	// to compare against, there's no point parsing the presented key yet.
 	// Normalize the subject ID for lookup since keyHashes keys are normalized.
 	normSubjectID := normalizeEntityID(subjectID)
 	allowedKeys, hasKeys := r.keyHashes[normSubjectID]
@@ -553,11 +549,21 @@ func (r *WhitelistRegistry) Evaluate(ctx context.Context, req *authzen.Evaluatio
 		// back to validating the presented x5c chain directly - this is
 		// still gated by the whitelist-membership check above (subjectID
 		// had to match an entry in this action's list), it is not a blanket
-		// "trust any CA-signed cert" path.
+		// "trust any CA-signed cert" path. This must run before
+		// extractKeyFingerprint below: evaluateViaSystemCA does its own x5c
+		// parsing, and reaching it only after a successful fingerprint
+		// extraction (which parses the same x5c bytes) would make its parse
+		// error branch dead code.
 		if r.config.TrustX509ViaSystemCA && req.Resource.Type == "x5c" && !isHTTPScheme(subjectID) {
 			return r.evaluateViaSystemCA(subjectID, role, matchedList, req)
 		}
 		return r.deny(subjectID, "no keys cached for entity; call Refresh() to load keys")
+	}
+
+	// Verify key binding: extract the key from the request and check against cached hashes
+	keyFingerprint, err := r.extractKeyFingerprint(req)
+	if err != nil {
+		return r.deny(subjectID, fmt.Sprintf("failed to extract key: %s", err))
 	}
 
 	if allowedKeys[keyFingerprint] {
@@ -605,12 +611,12 @@ func (r *WhitelistRegistry) evaluateViaSystemCA(subjectID, role, matchedList str
 		return r.deny(subjectID, fmt.Sprintf("system CA pool unavailable: %s", err))
 	}
 
+	// ParseX5CFromArray returns an error for an empty/malformed input and
+	// otherwise one *x509.Certificate per input entry, so certs is
+	// guaranteed non-empty here - no separate "no certificates" check needed.
 	certs, err := x509util.ParseX5CFromArray(req.Resource.Key)
 	if err != nil {
 		return r.deny(subjectID, fmt.Sprintf("failed to parse x5c chain: %s", err))
-	}
-	if len(certs) == 0 {
-		return r.deny(subjectID, "no certificates found in resource.key")
 	}
 
 	opts := x509.VerifyOptions{

--- a/pkg/registry/static/whitelist.go
+++ b/pkg/registry/static/whitelist.go
@@ -4,6 +4,7 @@ package static
 import (
 	"context"
 	"crypto"
+	"crypto/x509"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -18,6 +19,7 @@ import (
 	"github.com/fsnotify/fsnotify"
 	"gopkg.in/yaml.v3"
 
+	"github.com/sirosfoundation/g119612/pkg/utils/x509util"
 	"github.com/sirosfoundation/go-trust/pkg/authzen"
 	"github.com/sirosfoundation/go-trust/pkg/registry"
 	"github.com/sirosfoundation/go-trust/pkg/resilience"
@@ -76,6 +78,13 @@ type WhitelistRegistry struct {
 
 	// jwksFetcher handles JWKS fetches with retry and stale-cache fallback.
 	jwksFetcher *resilience.Fetcher[[]crypto.PublicKey]
+
+	// systemCertPool backs the TrustX509ViaSystemCA fallback path. Lazily
+	// loaded once (loading the OS root pool is a real, non-trivial syscall
+	// on some platforms) and reused for the registry's lifetime.
+	systemCertPoolOnce sync.Once
+	systemCertPool     *x509.CertPool
+	systemCertPoolErr  error
 }
 
 // WhitelistConfig holds the whitelist configuration.
@@ -126,6 +135,22 @@ type WhitelistConfig struct {
 	// Default: 5m (5 minutes). Set to "0" to disable background refresh.
 	// Example: "5m", "1h", "30s"
 	RefreshInterval string `json:"refresh_interval,omitempty" yaml:"refresh_interval,omitempty"`
+
+	// TrustX509ViaSystemCA enables a fallback trust path for whitelisted
+	// entities identified by a non-HTTP(S) scheme (e.g. OpenID4VP's
+	// "x509_san_dns:example.com" or "x509_hash:<leaf-cert-der-hash>"
+	// client_id_schemes) that therefore have no JWKS endpoint to fetch keys
+	// from at all. When true, if an entity in
+	// this state is a member of the matched action's list (still gated by
+	// the same whitelist membership check every other entry goes through -
+	// this is NOT a blanket "trust any certificate" fallback), its presented
+	// x5c certificate chain is verified against the operating system's root
+	// CA pool instead of being denied outright for having no cached JWKS
+	// keys. This only applies to entities that were never JWKS-fetchable in
+	// the first place; a real https:// entity whose JWKS fetch failed
+	// (network error, misconfiguration) is still denied, not silently
+	// downgraded to cert-pool trust.
+	TrustX509ViaSystemCA bool `json:"trust_x509_via_system_ca,omitempty" yaml:"trust_x509_via_system_ca,omitempty"`
 }
 
 // WhitelistOption is a functional option for configuring WhitelistRegistry.
@@ -521,7 +546,17 @@ func (r *WhitelistRegistry) Evaluate(ctx context.Context, req *authzen.Evaluatio
 	normSubjectID := normalizeEntityID(subjectID)
 	allowedKeys, hasKeys := r.keyHashes[normSubjectID]
 	if !hasKeys || len(allowedKeys) == 0 {
-		// No keys cached for this entity - need to refresh
+		// No keys cached for this entity via JWKS. If this entity was never
+		// JWKS-fetchable to begin with (a non-HTTP(S) scheme, e.g. OpenID4VP's
+		// x509_san_dns:example.com client_id_scheme) and the registry is
+		// configured to trust such entities via the system CA pool, fall
+		// back to validating the presented x5c chain directly - this is
+		// still gated by the whitelist-membership check above (subjectID
+		// had to match an entry in this action's list), it is not a blanket
+		// "trust any CA-signed cert" path.
+		if r.config.TrustX509ViaSystemCA && req.Resource.Type == "x5c" && !isHTTPScheme(subjectID) {
+			return r.evaluateViaSystemCA(subjectID, role, matchedList, req)
+		}
 		return r.deny(subjectID, "no keys cached for entity; call Refresh() to load keys")
 	}
 
@@ -530,6 +565,100 @@ func (r *WhitelistRegistry) Evaluate(ctx context.Context, req *authzen.Evaluatio
 	}
 
 	return r.deny(subjectID, "key fingerprint does not match any registered keys for this entity")
+}
+
+// isHTTPScheme reports whether id parses as a URL with an http/https scheme -
+// i.e. whether it was ever a candidate for JWKS discovery at all. Entities
+// using a non-fetchable scheme (OpenID4VP's x509_san_dns:..., x509_hash:...,
+// did:..., etc.) never had keys loaded via Refresh() and are the only ones
+// eligible for the TrustX509ViaSystemCA fallback.
+func isHTTPScheme(id string) bool {
+	u, err := url.Parse(id)
+	return err == nil && (u.Scheme == "https" || u.Scheme == "http")
+}
+
+// loadSystemCertPool lazily loads and caches the OS root CA pool, used by
+// evaluateViaSystemCA. Loading is one-time for the registry's lifetime -
+// x509.SystemCertPool() re-reads the OS trust store on every call otherwise,
+// which is unnecessary work on the hot Evaluate() path.
+func (r *WhitelistRegistry) loadSystemCertPool() (*x509.CertPool, error) {
+	r.systemCertPoolOnce.Do(func() {
+		r.systemCertPool, r.systemCertPoolErr = x509.SystemCertPool()
+		if r.systemCertPoolErr == nil && r.systemCertPool == nil {
+			r.systemCertPoolErr = fmt.Errorf("system cert pool is nil (unsupported on this platform)")
+		}
+	})
+	return r.systemCertPool, r.systemCertPoolErr
+}
+
+// evaluateViaSystemCA validates the request's x5c certificate chain against
+// the OS root CA pool, for a whitelisted entity that has no JWKS to check
+// key fingerprints against (see the TrustX509ViaSystemCA doc comment). The
+// caller has already confirmed subjectID matched an entry in the relevant
+// action's list - this only decides whether the presented certificate chain
+// is itself valid, mirroring the same public-CA chain validation
+// static.SystemCertPoolRegistry performs, scoped here to whitelisted
+// entities only rather than any presented certificate.
+func (r *WhitelistRegistry) evaluateViaSystemCA(subjectID, role, matchedList string, req *authzen.EvaluationRequest) (*authzen.EvaluationResponse, error) {
+	pool, err := r.loadSystemCertPool()
+	if err != nil {
+		return r.deny(subjectID, fmt.Sprintf("system CA pool unavailable: %s", err))
+	}
+
+	certs, err := x509util.ParseX5CFromArray(req.Resource.Key)
+	if err != nil {
+		return r.deny(subjectID, fmt.Sprintf("failed to parse x5c chain: %s", err))
+	}
+	if len(certs) == 0 {
+		return r.deny(subjectID, "no certificates found in resource.key")
+	}
+
+	opts := x509.VerifyOptions{
+		Roots: pool,
+		// ExtKeyUsageAny: relying-party/verifier leaf certs commonly carry
+		// only id-kp-clientAuth (or no EKU at all); Go's zero-value
+		// KeyUsages defaults to ExtKeyUsageServerAuth, which would reject
+		// them even though the chain itself is otherwise valid.
+		KeyUsages: []x509.ExtKeyUsage{x509.ExtKeyUsageAny},
+	}
+	if len(certs) > 1 {
+		intermediates := x509.NewCertPool()
+		for _, cert := range certs[1:] {
+			intermediates.AddCert(cert)
+		}
+		opts.Intermediates = intermediates
+	}
+
+	chains, err := certs[0].Verify(opts)
+	if err != nil {
+		return r.deny(subjectID, fmt.Sprintf("x509 chain validation against system CA pool failed: %s", err))
+	}
+
+	reason := map[string]interface{}{
+		"user":         fmt.Sprintf("trusted via whitelist (%s, system CA chain validation)", matchedList),
+		"registry":     r.name,
+		"type":         "whitelist",
+		"role":         role,
+		"matched_list": matchedList,
+		"trust_path":   "system_ca",
+		"chain_length": len(chains),
+	}
+	if credTypes := r.extractCredentialTypes(req); len(credTypes) > 0 {
+		reason["requested_credential_types"] = credTypes
+	}
+
+	return &authzen.EvaluationResponse{
+		Decision: true,
+		Context: &authzen.EvaluationResponseContext{
+			Reason: reason,
+			TrustMetadata: map[string]interface{}{
+				"trust_framework": "whitelist",
+				"registry":        r.name,
+				"matched_list":    matchedList,
+				"trust_path":      "system_ca",
+			},
+		},
+	}, nil
 }
 
 // extractKeyFingerprint extracts and computes fingerprint of the key from the request.

--- a/pkg/registry/static/whitelist_test.go
+++ b/pkg/registry/static/whitelist_test.go
@@ -13,6 +13,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -2215,4 +2216,175 @@ func TestWithHTTPClient(t *testing.T) {
 	if r.httpClient != custom {
 		t.Error("WithHTTPClient did not set httpClient on WhitelistRegistry")
 	}
+}
+
+// TestWhitelistRegistry_TrustX509ViaSystemCA covers the fallback trust path
+// for whitelisted entities identified by a non-HTTP(S) scheme (e.g.
+// OpenID4VP's x509_san_dns:example.com client_id_scheme), which have no JWKS
+// endpoint and would otherwise always be denied with "no keys cached for
+// entity" regardless of how legitimate their presented certificate is.
+func TestWhitelistRegistry_TrustX509ViaSystemCA(t *testing.T) {
+	cert := generateSelfSignedCert(t)
+	certB64 := base64.StdEncoding.EncodeToString(cert.Raw)
+
+	t.Run("disabled_by_default_denies_non_jwks_entity", func(t *testing.T) {
+		reg := NewWhitelistRegistry(WithWhitelistConfig(WhitelistConfig{
+			Lists:   map[string][]string{"verifiers": {"x509_san_dns:verifier.example.com"}},
+			Actions: map[string]string{"credential-verifier": "verifiers"},
+		}))
+		// Refresh() returns an error whenever ANY entity's JWKS fetch fails -
+		// expected and benign here, since this entity was never JWKS-fetchable
+		// to begin with (mirrors what the real PDP deployment does: logs the
+		// warning, keeps running).
+		_ = reg.Refresh(context.Background())
+
+		resp, err := reg.Evaluate(context.Background(), &authzen.EvaluationRequest{
+			Subject: authzen.Subject{ID: "x509_san_dns:verifier.example.com"},
+			Action:  &authzen.Action{Name: "credential-verifier"},
+			Resource: authzen.Resource{
+				Type: "x5c",
+				Key:  []interface{}{certB64},
+			},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.Decision {
+			t.Error("expected decision=false when TrustX509ViaSystemCA is disabled")
+		}
+		if resp.Context.Reason["error"] != "no keys cached for entity; call Refresh() to load keys" {
+			t.Errorf("expected the original JWKS-missing deny reason, got: %v", resp.Context.Reason["error"])
+		}
+	})
+
+	t.Run("enabled_attempts_chain_validation_for_whitelisted_entity", func(t *testing.T) {
+		reg := NewWhitelistRegistry(WithWhitelistConfig(WhitelistConfig{
+			Lists:                map[string][]string{"verifiers": {"x509_san_dns:verifier.example.com"}},
+			Actions:              map[string]string{"credential-verifier": "verifiers"},
+			TrustX509ViaSystemCA: true,
+		}))
+		_ = reg.Refresh(context.Background())
+
+		resp, err := reg.Evaluate(context.Background(), &authzen.EvaluationRequest{
+			Subject: authzen.Subject{ID: "x509_san_dns:verifier.example.com"},
+			Action:  &authzen.Action{Name: "credential-verifier"},
+			Resource: authzen.Resource{
+				Type: "x5c",
+				Key:  []interface{}{certB64},
+			},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// A self-signed test cert does not chain to any real public CA, so
+		// this is expected to deny - but critically via chain validation,
+		// not the "no keys cached" reason, proving the fallback path ran.
+		if resp.Decision {
+			t.Error("expected decision=false for a self-signed cert (doesn't chain to a public CA)")
+		}
+		errReason, _ := resp.Context.Reason["error"].(string)
+		if !strings.Contains(errReason, "x509 chain validation") {
+			t.Errorf("expected a chain-validation error proving the system-CA fallback ran, got: %v", errReason)
+		}
+	})
+
+	t.Run("enabled_attempts_chain_validation_for_x509_hash_scheme", func(t *testing.T) {
+		// The fallback is scheme-agnostic: it triggers on "any non-HTTP(S)
+		// scheme", not specifically x509_san_dns. Prove it also covers
+		// OpenID4VP's x509_hash:<hash-of-leaf-cert-der> client_id_scheme,
+		// which is a different non-fetchable scheme with the same problem
+		// (no JWKS endpoint), through the exact same code path.
+		reg := NewWhitelistRegistry(WithWhitelistConfig(WhitelistConfig{
+			Lists:                map[string][]string{"verifiers": {"x509_hash:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"}},
+			Actions:              map[string]string{"credential-verifier": "verifiers"},
+			TrustX509ViaSystemCA: true,
+		}))
+		_ = reg.Refresh(context.Background())
+
+		resp, err := reg.Evaluate(context.Background(), &authzen.EvaluationRequest{
+			Subject: authzen.Subject{ID: "x509_hash:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"},
+			Action:  &authzen.Action{Name: "credential-verifier"},
+			Resource: authzen.Resource{
+				Type: "x5c",
+				Key:  []interface{}{certB64},
+			},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		// Same expectation as the x509_san_dns case: a self-signed test cert
+		// doesn't chain to a public CA, so this denies - but via chain
+		// validation, not "no keys cached", proving the fallback ran for
+		// this scheme too.
+		if resp.Decision {
+			t.Error("expected decision=false for a self-signed cert (doesn't chain to a public CA)")
+		}
+		errReason, _ := resp.Context.Reason["error"].(string)
+		if !strings.Contains(errReason, "x509 chain validation") {
+			t.Errorf("expected a chain-validation error proving the system-CA fallback ran for x509_hash, got: %v", errReason)
+		}
+	})
+
+	t.Run("still_gated_by_whitelist_membership", func(t *testing.T) {
+		reg := NewWhitelistRegistry(WithWhitelistConfig(WhitelistConfig{
+			Lists:                map[string][]string{"verifiers": {"x509_san_dns:verifier.example.com"}},
+			Actions:              map[string]string{"credential-verifier": "verifiers"},
+			TrustX509ViaSystemCA: true,
+		}))
+		_ = reg.Refresh(context.Background())
+
+		// A DIFFERENT x509_san_dns entity, not in the whitelist - must be
+		// denied on membership grounds, never even reaching the cert-chain
+		// fallback. TrustX509ViaSystemCA is not a blanket "trust any
+		// certificate" switch.
+		resp, err := reg.Evaluate(context.Background(), &authzen.EvaluationRequest{
+			Subject: authzen.Subject{ID: "x509_san_dns:not-whitelisted.example.com"},
+			Action:  &authzen.Action{Name: "credential-verifier"},
+			Resource: authzen.Resource{
+				Type: "x5c",
+				Key:  []interface{}{certB64},
+			},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.Decision {
+			t.Error("expected decision=false for an entity not in the whitelist")
+		}
+		errReason, _ := resp.Context.Reason["error"].(string)
+		if !strings.Contains(errReason, "not in whitelist") {
+			t.Errorf("expected a whitelist-membership deny reason (not a cert-chain error), got: %v", errReason)
+		}
+	})
+
+	t.Run("http_scheme_entity_unaffected_by_flag", func(t *testing.T) {
+		// A normal https:// entity whose JWKS fetch genuinely failed must
+		// still be denied outright - TrustX509ViaSystemCA only applies to
+		// entities that were never JWKS-fetchable to begin with.
+		reg := NewWhitelistRegistry(WithWhitelistConfig(WhitelistConfig{
+			Lists:                map[string][]string{"verifiers": {"https://unreachable.invalid.example"}},
+			Actions:              map[string]string{"credential-verifier": "verifiers"},
+			TrustX509ViaSystemCA: true,
+		}))
+		_ = reg.Refresh(context.Background())
+
+		resp, err := reg.Evaluate(context.Background(), &authzen.EvaluationRequest{
+			Subject: authzen.Subject{ID: "https://unreachable.invalid.example"},
+			Action:  &authzen.Action{Name: "credential-verifier"},
+			Resource: authzen.Resource{
+				Type: "x5c",
+				Key:  []interface{}{certB64},
+			},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.Decision {
+			t.Error("expected decision=false for an unreachable https entity")
+		}
+		errReason, _ := resp.Context.Reason["error"].(string)
+		if !strings.Contains(errReason, "no keys cached") {
+			t.Errorf("expected the JWKS-missing deny reason (not the system-CA fallback), got: %v", errReason)
+		}
+	})
 }

--- a/pkg/registry/static/whitelist_test.go
+++ b/pkg/registry/static/whitelist_test.go
@@ -2418,12 +2418,18 @@ func TestWhitelistRegistry_TrustX509ViaSystemCA(t *testing.T) {
 		reg.systemCertPoolErr = nil
 
 		leafB64 := base64.StdEncoding.EncodeToString(leafCert.Raw)
+		// Also exercise the requested_credential_types branch of the success
+		// reason - a real OpenID4VP presentation request typically carries
+		// this in Context.
 		resp, err := reg.Evaluate(context.Background(), &authzen.EvaluationRequest{
 			Subject: authzen.Subject{ID: "x509_san_dns:verifier.example.com"},
 			Action:  &authzen.Action{Name: "credential-verifier"},
 			Resource: authzen.Resource{
 				Type: "x5c",
 				Key:  []interface{}{leafB64},
+			},
+			Context: map[string]interface{}{
+				"credential_types": []interface{}{"org.iso.18013.5.1.mDL"},
 			},
 		})
 		if err != nil {
@@ -2438,6 +2444,49 @@ func TestWhitelistRegistry_TrustX509ViaSystemCA(t *testing.T) {
 		}
 		if resp.Context.Reason["trust_path"] != "system_ca" {
 			t.Errorf("expected trust_path=system_ca in reason, got: %v", resp.Context.Reason["trust_path"])
+		}
+		credTypes, _ := resp.Context.Reason["requested_credential_types"].([]string)
+		if len(credTypes) != 1 || credTypes[0] != "org.iso.18013.5.1.mDL" {
+			t.Errorf("expected requested_credential_types=[org.iso.18013.5.1.mDL] in reason, got: %v", resp.Context.Reason["requested_credential_types"])
+		}
+	})
+
+	t.Run("enabled_grants_trust_for_a_chain_with_an_intermediate", func(t *testing.T) {
+		// Exercise the multi-cert (leaf + intermediate) branch of
+		// evaluateViaSystemCA - the previous success subtest only presented a
+		// single leaf cert signed directly by a pool-trusted root.
+		leafCert, intermediateCert, rootCert := generateCASignedLeafCertWithIntermediate(t)
+		customPool := x509.NewCertPool()
+		customPool.AddCert(rootCert)
+
+		reg := NewWhitelistRegistry(WithWhitelistConfig(WhitelistConfig{
+			Lists:                map[string][]string{"verifiers": {"x509_san_dns:verifier.example.com"}},
+			Actions:              map[string]string{"credential-verifier": "verifiers"},
+			TrustX509ViaSystemCA: true,
+		}))
+		_ = reg.Refresh(context.Background())
+		reg.systemCertPoolOnce.Do(func() {})
+		reg.systemCertPool = customPool
+		reg.systemCertPoolErr = nil
+
+		leafB64 := base64.StdEncoding.EncodeToString(leafCert.Raw)
+		intermediateB64 := base64.StdEncoding.EncodeToString(intermediateCert.Raw)
+		resp, err := reg.Evaluate(context.Background(), &authzen.EvaluationRequest{
+			Subject: authzen.Subject{ID: "x509_san_dns:verifier.example.com"},
+			Action:  &authzen.Action{Name: "credential-verifier"},
+			Resource: authzen.Resource{
+				Type: "x5c",
+				Key:  []interface{}{leafB64, intermediateB64},
+			},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !resp.Decision {
+			t.Fatalf("expected decision=true for a leaf+intermediate chain that validates against the injected root pool, got deny: %v", resp.Context.Reason["error"])
+		}
+		if resp.Context.Reason["chain_length"] != 1 {
+			t.Errorf("expected a single resolved chain, got chain_length=%v", resp.Context.Reason["chain_length"])
 		}
 	})
 
@@ -2563,4 +2612,89 @@ func generateCASignedLeafCert(t *testing.T) (leaf *x509.Certificate, ca *x509.Ce
 	}
 
 	return leafCert, caCert
+}
+
+// generateCASignedLeafCertWithIntermediate builds a 3-tier root CA ->
+// intermediate CA -> leaf chain, for testing evaluateViaSystemCA's
+// multi-cert (len(certs) > 1) branch: the presented x5c array carries the
+// leaf and intermediate, while only the root is in the trusted pool.
+func generateCASignedLeafCertWithIntermediate(t *testing.T) (leaf, intermediate, root *x509.Certificate) {
+	t.Helper()
+
+	rootKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate root key: %v", err)
+	}
+	rootTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			Organization: []string{"Test Root CA Org"},
+			CommonName:   "Test Root CA",
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	rootDER, err := x509.CreateCertificate(rand.Reader, rootTemplate, rootTemplate, &rootKey.PublicKey, rootKey)
+	if err != nil {
+		t.Fatalf("failed to create root certificate: %v", err)
+	}
+	rootCert, err := x509.ParseCertificate(rootDER)
+	if err != nil {
+		t.Fatalf("failed to parse root certificate: %v", err)
+	}
+
+	intermediateKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate intermediate key: %v", err)
+	}
+	intermediateTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject: pkix.Name{
+			Organization: []string{"Test Intermediate CA Org"},
+			CommonName:   "Test Intermediate CA",
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	intermediateDER, err := x509.CreateCertificate(rand.Reader, intermediateTemplate, rootCert, &intermediateKey.PublicKey, rootKey)
+	if err != nil {
+		t.Fatalf("failed to create intermediate certificate: %v", err)
+	}
+	intermediateCert, err := x509.ParseCertificate(intermediateDER)
+	if err != nil {
+		t.Fatalf("failed to parse intermediate certificate: %v", err)
+	}
+
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate leaf key: %v", err)
+	}
+	leafTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(3),
+		Subject: pkix.Name{
+			Organization: []string{"Test Org"},
+			CommonName:   "verifier.example.com",
+		},
+		DNSNames:    []string{"verifier.example.com"},
+		NotBefore:   time.Now(),
+		NotAfter:    time.Now().Add(24 * time.Hour),
+		KeyUsage:    x509.KeyUsageDigitalSignature,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTemplate, intermediateCert, &leafKey.PublicKey, intermediateKey)
+	if err != nil {
+		t.Fatalf("failed to create leaf certificate: %v", err)
+	}
+	leafCert, err := x509.ParseCertificate(leafDER)
+	if err != nil {
+		t.Fatalf("failed to parse leaf certificate: %v", err)
+	}
+
+	return leafCert, intermediateCert, rootCert
 }

--- a/pkg/registry/static/whitelist_test.go
+++ b/pkg/registry/static/whitelist_test.go
@@ -5,10 +5,13 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"math/big"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -2387,4 +2390,177 @@ func TestWhitelistRegistry_TrustX509ViaSystemCA(t *testing.T) {
 			t.Errorf("expected the JWKS-missing deny reason (not the system-CA fallback), got: %v", errReason)
 		}
 	})
+
+	t.Run("enabled_grants_trust_for_a_chain_that_validates", func(t *testing.T) {
+		// The previous "enabled" subtests only prove the fallback path *runs*
+		// (via a self-signed cert that can never chain to any pool). Prove it
+		// can also *succeed*: build a real CA + leaf chain, inject a cert
+		// pool containing just that CA directly into the registry (same
+		// package as production code, so private fields are reachable here
+		// without needing a public test-only constructor), and confirm a
+		// Decision=true with trust_path=system_ca in both the reason and
+		// trust metadata.
+		leafCert, caCert := generateCASignedLeafCert(t)
+		customPool := x509.NewCertPool()
+		customPool.AddCert(caCert)
+
+		reg := NewWhitelistRegistry(WithWhitelistConfig(WhitelistConfig{
+			Lists:                map[string][]string{"verifiers": {"x509_san_dns:verifier.example.com"}},
+			Actions:              map[string]string{"credential-verifier": "verifiers"},
+			TrustX509ViaSystemCA: true,
+		}))
+		_ = reg.Refresh(context.Background())
+		// Pre-seed the once-loaded system cert pool with our own test CA
+		// instead of the real OS trust store, so the outcome is deterministic
+		// and doesn't depend on any real public CA.
+		reg.systemCertPoolOnce.Do(func() {})
+		reg.systemCertPool = customPool
+		reg.systemCertPoolErr = nil
+
+		leafB64 := base64.StdEncoding.EncodeToString(leafCert.Raw)
+		resp, err := reg.Evaluate(context.Background(), &authzen.EvaluationRequest{
+			Subject: authzen.Subject{ID: "x509_san_dns:verifier.example.com"},
+			Action:  &authzen.Action{Name: "credential-verifier"},
+			Resource: authzen.Resource{
+				Type: "x5c",
+				Key:  []interface{}{leafB64},
+			},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !resp.Decision {
+			t.Fatalf("expected decision=true for a chain that validates against the injected pool, got deny: %v", resp.Context.Reason["error"])
+		}
+		trustMetadata, _ := resp.Context.TrustMetadata.(map[string]interface{})
+		if trustMetadata["trust_path"] != "system_ca" {
+			t.Errorf("expected trust_path=system_ca in trust metadata, got: %v", trustMetadata["trust_path"])
+		}
+		if resp.Context.Reason["trust_path"] != "system_ca" {
+			t.Errorf("expected trust_path=system_ca in reason, got: %v", resp.Context.Reason["trust_path"])
+		}
+	})
+
+	t.Run("malformed_x5c_denies_with_parse_error", func(t *testing.T) {
+		reg := NewWhitelistRegistry(WithWhitelistConfig(WhitelistConfig{
+			Lists:                map[string][]string{"verifiers": {"x509_san_dns:verifier.example.com"}},
+			Actions:              map[string]string{"credential-verifier": "verifiers"},
+			TrustX509ViaSystemCA: true,
+		}))
+		_ = reg.Refresh(context.Background())
+
+		resp, err := reg.Evaluate(context.Background(), &authzen.EvaluationRequest{
+			Subject: authzen.Subject{ID: "x509_san_dns:verifier.example.com"},
+			Action:  &authzen.Action{Name: "credential-verifier"},
+			Resource: authzen.Resource{
+				Type: "x5c",
+				Key:  []interface{}{"not-valid-base64!!!"},
+			},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.Decision {
+			t.Error("expected decision=false for a malformed x5c entry")
+		}
+		errReason, _ := resp.Context.Reason["error"].(string)
+		if !strings.Contains(errReason, "failed to parse x5c chain") {
+			t.Errorf("expected a parse-error deny reason, got: %v", errReason)
+		}
+	})
+
+	t.Run("system_cert_pool_unavailable_denies", func(t *testing.T) {
+		// Simulate loadSystemCertPool() itself failing (e.g. an unsupported
+		// platform) by pre-seeding the once-loaded state directly, since
+		// x509.SystemCertPool() can't be made to fail on demand in this test
+		// environment.
+		reg := NewWhitelistRegistry(WithWhitelistConfig(WhitelistConfig{
+			Lists:                map[string][]string{"verifiers": {"x509_san_dns:verifier.example.com"}},
+			Actions:              map[string]string{"credential-verifier": "verifiers"},
+			TrustX509ViaSystemCA: true,
+		}))
+		_ = reg.Refresh(context.Background())
+		reg.systemCertPoolOnce.Do(func() {})
+		reg.systemCertPool = nil
+		reg.systemCertPoolErr = fmt.Errorf("simulated: system cert pool unavailable")
+
+		resp, err := reg.Evaluate(context.Background(), &authzen.EvaluationRequest{
+			Subject: authzen.Subject{ID: "x509_san_dns:verifier.example.com"},
+			Action:  &authzen.Action{Name: "credential-verifier"},
+			Resource: authzen.Resource{
+				Type: "x5c",
+				Key:  []interface{}{certB64},
+			},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.Decision {
+			t.Error("expected decision=false when the system cert pool failed to load")
+		}
+		errReason, _ := resp.Context.Reason["error"].(string)
+		if !strings.Contains(errReason, "system CA pool unavailable") {
+			t.Errorf("expected a pool-unavailable deny reason, got: %v", errReason)
+		}
+	})
+}
+
+// generateCASignedLeafCert creates a self-signed CA certificate and a leaf
+// certificate signed by it, for testing the TrustX509ViaSystemCA success path
+// with a deterministic, injectable pool instead of depending on any real
+// public CA.
+func generateCASignedLeafCert(t *testing.T) (leaf *x509.Certificate, ca *x509.Certificate) {
+	t.Helper()
+
+	caKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate CA key: %v", err)
+	}
+	caTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			Organization: []string{"Test CA Org"},
+			CommonName:   "Test Root CA",
+		},
+		NotBefore:             time.Now(),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		KeyUsage:              x509.KeyUsageDigitalSignature | x509.KeyUsageCertSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	caDER, err := x509.CreateCertificate(rand.Reader, caTemplate, caTemplate, &caKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("failed to create CA certificate: %v", err)
+	}
+	caCert, err := x509.ParseCertificate(caDER)
+	if err != nil {
+		t.Fatalf("failed to parse CA certificate: %v", err)
+	}
+
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate leaf key: %v", err)
+	}
+	leafTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(2),
+		Subject: pkix.Name{
+			Organization: []string{"Test Org"},
+			CommonName:   "verifier.example.com",
+		},
+		DNSNames:    []string{"verifier.example.com"},
+		NotBefore:   time.Now(),
+		NotAfter:    time.Now().Add(24 * time.Hour),
+		KeyUsage:    x509.KeyUsageDigitalSignature,
+		ExtKeyUsage: []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTemplate, caCert, &leafKey.PublicKey, caKey)
+	if err != nil {
+		t.Fatalf("failed to create leaf certificate: %v", err)
+	}
+	leafCert, err := x509.ParseCertificate(leafDER)
+	if err != nil {
+		t.Fatalf("failed to parse leaf certificate: %v", err)
+	}
+
+	return leafCert, caCert
 }


### PR DESCRIPTION
## Summary
- Whitelisted OpenID4VP verifiers identified by a non-HTTP(S) `client_id_scheme` (e.g. `x509_san_dns:example.com`, `x509_hash:<leaf-cert-hash>`) have no JWKS endpoint - they were unconditionally denied for "no keys cached for entity", even when named exactly in the whitelist config.
- Adds an opt-in `TrustX509ViaSystemCA` config flag on `WhitelistRegistry`: for a whitelisted entity with no JWKS-fetchable scheme, fall back to validating its presented `x5c` chain against the OS system CA pool instead of denying outright.
- Still fully gated by the same whitelist-membership check every other entry goes through - this is not a blanket "trust any CA-signed cert" path, and it's scoped to the whitelist registry (unlike the existing standalone `SystemCertPoolRegistry`, which isn't action-scoped and would also loosen mdoc-issuer trust).
- Scheme-agnostic by design (triggers on "any non-HTTP(S) scheme", not one hardcoded prefix) - verified with tests for both `x509_san_dns` and `x509_hash`.
- Defaults to `false`; existing behavior unchanged unless explicitly enabled.

Motivated by live OpenID4VP interop testing needing to trust a real external verifier (Multipaz, `verifier.multipaz.org`) that only presents a certificate chain, no JWKS.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` (full repo, including new `TestWhitelistRegistry_TrustX509ViaSystemCA` with 5 subtests: disabled-by-default denies, enabled attempts chain validation for `x509_san_dns`, enabled attempts chain validation for `x509_hash`, still gated by whitelist membership, http-scheme entities unaffected)
- [x] `golangci-lint` clean (pre-commit hook)