### PR TITLE
security: verify certificate-to-client_id binding for x509_san_dns/uri/hash

### DIFF
--- a/pkg/registry/clientid.go
+++ b/pkg/registry/clientid.go
@@ -1,0 +1,176 @@
+package registry
+
+import (
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/hex"
+	"fmt"
+	"net/url"
+	"strings"
+
+	"github.com/sirosfoundation/go-trust/pkg/authzen"
+)
+
+// ClientIDScheme identifies an OpenID4VP client_id_scheme whose semantics
+// require the presented certificate to be cryptographically or structurally
+// bound to the claimed identity value, rather than merely chaining to some
+// trusted CA. Per OpenID4VP, the client_id itself carries the claim that
+// must be checked against the certificate's content:
+//   - x509_san_dns: client_id is a DNS name that MUST appear as a dNSName
+//     Subject Alternative Name in the presented leaf certificate.
+//   - x509_san_uri: client_id is a URI that MUST appear as a
+//     uniformResourceIdentifier SAN in the presented leaf certificate.
+//   - x509_hash: client_id is the SHA-256 digest (hex or base64url encoded)
+//     of the presented leaf certificate's DER encoding.
+//
+// Verifying chain-of-trust to a root CA (system pool, TSL, or LoTE) proves a
+// certificate was validly issued; it says nothing about whether it belongs
+// to the identity being claimed. VerifyLeafBinding closes that gap and MUST
+// be called by any registry that grants trust via a certificate pool that
+// isn't already scoped to a single, already-identified entity's own certs.
+type ClientIDScheme string
+
+const (
+	ClientIDSchemeX509SANDNS ClientIDScheme = "x509_san_dns"
+	ClientIDSchemeX509SANURI ClientIDScheme = "x509_san_uri"
+	ClientIDSchemeX509Hash   ClientIDScheme = "x509_hash"
+)
+
+// clientIDSchemes lists the recognized non-HTTP(S) client_id_scheme prefixes
+// that carry a certificate-binding claim, in a fixed order so
+// ParseClientIDScheme is deterministic.
+var clientIDSchemes = []ClientIDScheme{
+	ClientIDSchemeX509SANDNS,
+	ClientIDSchemeX509SANURI,
+	ClientIDSchemeX509Hash,
+}
+
+// ParseClientIDScheme splits a raw (pre-normalization) OpenID4VP client_id /
+// AuthZEN Subject.ID value into its client_id_scheme prefix and bare value.
+// Use OriginalSubjectID to recover the pre-normalization form when the
+// request has passed through RegistryManager.Evaluate, which rewrites
+// Subject.ID (e.g. "x509_san_dns:host" -> "https://host") for whitelist
+// matching purposes.
+//
+// Examples:
+//
+//	"x509_san_dns:example.com"        -> (ClientIDSchemeX509SANDNS, "example.com", true)
+//	"x509_san_uri:https://rp.example" -> (ClientIDSchemeX509SANURI, "https://rp.example", true)
+//	"x509_hash:deadbeef..."           -> (ClientIDSchemeX509Hash, "deadbeef...", true)
+//	"https://example.com"             -> ("", "", false)
+//	"did:web:example.com"             -> ("", "", false)
+func ParseClientIDScheme(id string) (scheme ClientIDScheme, value string, ok bool) {
+	for _, s := range clientIDSchemes {
+		prefix := string(s) + ":"
+		if strings.HasPrefix(id, prefix) {
+			return s, strings.TrimPrefix(id, prefix), true
+		}
+	}
+	return "", "", false
+}
+
+// VerifyLeafBinding checks that leaf is bound to the claimed identity for the
+// given client_id_scheme. Returns nil when bound, otherwise an error
+// describing the mismatch (safe to surface in a deny reason - it does not
+// leak anything the caller didn't already present).
+//
+// Callers should treat an unrecognized scheme as a hard deny, not as "no
+// check needed": only the three schemes above have OpenID4VP-defined
+// certificate-binding semantics, so there is no way to verify that an
+// arbitrary other identifier (e.g. a did: value) is bound to a presented x5c
+// chain at all.
+func VerifyLeafBinding(scheme ClientIDScheme, value string, leaf *x509.Certificate) error {
+	switch scheme {
+	case ClientIDSchemeX509SANDNS:
+		if !DNSSANMatches(value, leaf.DNSNames) {
+			return fmt.Errorf("client_id %q does not match any DNS SAN in the presented certificate (dns_sans=%v)", value, leaf.DNSNames)
+		}
+		return nil
+
+	case ClientIDSchemeX509SANURI:
+		if !URISANMatches(value, leaf.URIs) {
+			return fmt.Errorf("client_id %q does not match any URI SAN in the presented certificate", value)
+		}
+		return nil
+
+	case ClientIDSchemeX509Hash:
+		digest := sha256.Sum256(leaf.Raw)
+		hexDigest := hex.EncodeToString(digest[:])
+		b64Digest := base64.RawURLEncoding.EncodeToString(digest[:])
+		if !strings.EqualFold(value, hexDigest) && value != b64Digest {
+			return fmt.Errorf("client_id hash %q does not match the SHA-256 digest of the presented certificate", value)
+		}
+		return nil
+
+	default:
+		return fmt.Errorf("unrecognized client_id_scheme %q: cannot verify certificate binding", scheme)
+	}
+}
+
+// DNSSANMatches reports whether clientID matches one of dnsNames, per
+// OpenID4VP's x509_san_dns semantics (exact match) with RFC 6125 single-label
+// wildcard support: "*.example.com" matches "sub.example.com" but not
+// "example.com" or "deep.sub.example.com".
+func DNSSANMatches(clientID string, dnsNames []string) bool {
+	for _, dnsName := range dnsNames {
+		if dnsName == clientID {
+			return true
+		}
+		if strings.HasPrefix(dnsName, "*.") {
+			suffix := dnsName[1:]     // *.example.com -> .example.com
+			baseDomain := dnsName[2:] // *.example.com -> example.com
+			if strings.HasSuffix(clientID, suffix) && clientID != baseDomain {
+				// Ensure only a single label before the suffix (no nested subdomains).
+				prefix := strings.TrimSuffix(clientID, suffix)
+				if !strings.Contains(prefix, ".") {
+					return true
+				}
+			}
+		}
+	}
+	return false
+}
+
+// URISANMatches reports whether clientID matches one of the certificate's
+// URI SANs, per OpenID4VP's x509_san_uri semantics (exact match).
+func URISANMatches(clientID string, uris []*url.URL) bool {
+	for _, u := range uris {
+		if u != nil && u.String() == clientID {
+			return true
+		}
+	}
+	return false
+}
+
+// OriginalSubjectIDContextKey is the EvaluationRequest.Context key under
+// which RegistryManager.Evaluate stashes the pre-normalization Subject.ID
+// before rewriting it via NormalizeSubjectID. Unexported deliberately -
+// callers should go through OriginalSubjectID rather than reading the
+// context map directly.
+const originalSubjectIDContextKey = "_original_subject_id"
+
+// OriginalSubjectID returns req.Subject.ID as it was originally received,
+// before any RegistryManager normalization (e.g. "x509_san_dns:host" ->
+// "https://host"). Falls back to req.Subject.ID unchanged when the request
+// never passed through RegistryManager.Evaluate (e.g. a registry's own unit
+// tests calling Evaluate directly), so existing scheme-prefixed test
+// fixtures keep working unmodified.
+func OriginalSubjectID(req *authzen.EvaluationRequest) string {
+	if req.Context != nil {
+		if v, ok := req.Context[originalSubjectIDContextKey].(string); ok && v != "" {
+			return v
+		}
+	}
+	return req.Subject.ID
+}
+
+// StashOriginalSubjectID records id (the pre-normalization Subject.ID) on
+// req.Context under the key OriginalSubjectID reads from. Called by
+// RegistryManager.Evaluate before it rewrites req.Subject.ID.
+func StashOriginalSubjectID(req *authzen.EvaluationRequest, id string) {
+	if req.Context == nil {
+		req.Context = make(map[string]interface{})
+	}
+	req.Context[originalSubjectIDContextKey] = id
+}

--- a/pkg/registry/clientid_test.go
+++ b/pkg/registry/clientid_test.go
@@ -1,0 +1,161 @@
+package registry
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/base64"
+	"encoding/hex"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/sirosfoundation/go-trust/pkg/authzen"
+)
+
+func TestParseClientIDScheme(t *testing.T) {
+	tests := []struct {
+		id            string
+		expectScheme  ClientIDScheme
+		expectValue   string
+		expectMatched bool
+	}{
+		{"x509_san_dns:example.com", ClientIDSchemeX509SANDNS, "example.com", true},
+		{"x509_san_uri:https://rp.example.com/cb", ClientIDSchemeX509SANURI, "https://rp.example.com/cb", true},
+		{"x509_hash:deadbeef", ClientIDSchemeX509Hash, "deadbeef", true},
+		{"https://example.com", "", "", false},
+		{"did:web:example.com", "", "", false},
+		{"", "", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.id, func(t *testing.T) {
+			scheme, value, ok := ParseClientIDScheme(tt.id)
+			if ok != tt.expectMatched {
+				t.Fatalf("expected matched=%v, got %v", tt.expectMatched, ok)
+			}
+			if scheme != tt.expectScheme || value != tt.expectValue {
+				t.Errorf("expected (%q, %q), got (%q, %q)", tt.expectScheme, tt.expectValue, scheme, value)
+			}
+		})
+	}
+}
+
+func TestDNSSANMatches(t *testing.T) {
+	tests := []struct {
+		name     string
+		clientID string
+		dnsNames []string
+		want     bool
+	}{
+		{"exact match", "example.com", []string{"example.com"}, true},
+		{"no match", "attacker.com", []string{"example.com"}, false},
+		{"wildcard match", "sub.example.com", []string{"*.example.com"}, true},
+		{"wildcard does not match base domain", "example.com", []string{"*.example.com"}, false},
+		{"wildcard does not match nested subdomain", "deep.sub.example.com", []string{"*.example.com"}, false},
+		{"empty SAN list", "example.com", nil, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := DNSSANMatches(tt.clientID, tt.dnsNames); got != tt.want {
+				t.Errorf("DNSSANMatches(%q, %v) = %v, want %v", tt.clientID, tt.dnsNames, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVerifyLeafBinding(t *testing.T) {
+	leaf := generateLeafCertForBindingTest(t, []string{"verifier.example.com"})
+	digest := sha256.Sum256(leaf.Raw)
+	hexDigest := hex.EncodeToString(digest[:])
+	b64Digest := base64.RawURLEncoding.EncodeToString(digest[:])
+
+	t.Run("dns_san matches", func(t *testing.T) {
+		if err := VerifyLeafBinding(ClientIDSchemeX509SANDNS, "verifier.example.com", leaf); err != nil {
+			t.Errorf("expected binding to succeed, got: %v", err)
+		}
+	})
+
+	t.Run("dns_san mismatch is rejected - this is the actual vulnerability this check closes", func(t *testing.T) {
+		// Without this check, a certificate valid for ANY domain (chaining
+		// to any public CA) would be accepted for ANY claimed identity, as
+		// long as the caller asserted a whitelisted subject ID string. The
+		// certificate itself was never checked against the claim.
+		if err := VerifyLeafBinding(ClientIDSchemeX509SANDNS, "not-the-real-verifier.example.com", leaf); err == nil {
+			t.Error("expected binding to fail for a certificate with no matching DNS SAN")
+		}
+	})
+
+	t.Run("hash matches (hex)", func(t *testing.T) {
+		if err := VerifyLeafBinding(ClientIDSchemeX509Hash, hexDigest, leaf); err != nil {
+			t.Errorf("expected hex hash binding to succeed, got: %v", err)
+		}
+	})
+
+	t.Run("hash matches (base64url)", func(t *testing.T) {
+		if err := VerifyLeafBinding(ClientIDSchemeX509Hash, b64Digest, leaf); err != nil {
+			t.Errorf("expected base64url hash binding to succeed, got: %v", err)
+		}
+	})
+
+	t.Run("hash mismatch is rejected", func(t *testing.T) {
+		if err := VerifyLeafBinding(ClientIDSchemeX509Hash, "deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef", leaf); err == nil {
+			t.Error("expected binding to fail for a mismatched hash")
+		}
+	})
+
+	t.Run("unrecognized scheme is rejected, not silently accepted", func(t *testing.T) {
+		if err := VerifyLeafBinding(ClientIDScheme("did"), "web:example.com", leaf); err == nil {
+			t.Error("expected an unrecognized scheme to fail closed")
+		}
+	})
+}
+
+func TestOriginalSubjectID(t *testing.T) {
+	t.Run("falls back to Subject.ID when never stashed", func(t *testing.T) {
+		req := &authzen.EvaluationRequest{Subject: authzen.Subject{ID: "x509_san_dns:example.com"}}
+		if got := OriginalSubjectID(req); got != "x509_san_dns:example.com" {
+			t.Errorf("expected fallback to Subject.ID, got %q", got)
+		}
+	})
+
+	t.Run("recovers the pre-normalization value after Subject.ID is rewritten", func(t *testing.T) {
+		req := &authzen.EvaluationRequest{Subject: authzen.Subject{ID: "x509_san_dns:example.com"}}
+		StashOriginalSubjectID(req, req.Subject.ID)
+		req.Subject.ID = "https://example.com" // simulates NormalizeSubjectID's rewrite
+		if got := OriginalSubjectID(req); got != "x509_san_dns:example.com" {
+			t.Errorf("expected original pre-normalization value, got %q", got)
+		}
+	})
+}
+
+// generateLeafCertForBindingTest creates a minimal self-signed certificate
+// carrying the given DNS SANs, for exercising VerifyLeafBinding independent
+// of any chain-validation concerns.
+func generateLeafCertForBindingTest(t *testing.T, dnsNames []string) *x509.Certificate {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+	template := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test-leaf"},
+		DNSNames:     dnsNames,
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, template, template, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("failed to create certificate: %v", err)
+	}
+	cert, err := x509.ParseCertificate(der)
+	if err != nil {
+		t.Fatalf("failed to parse certificate: %v", err)
+	}
+	return cert
+}

--- a/pkg/registry/etsi/registry.go
+++ b/pkg/registry/etsi/registry.go
@@ -889,31 +889,8 @@ func (r *TSLRegistry) Evaluate(ctx context.Context, req *authzen.EvaluationReque
 	if req.Resource.Type == "x509_san_dns" {
 		clientID := req.Subject.ID
 		leafCert := certs[0]
-		sanMatched := false
 
-		for _, dnsName := range leafCert.DNSNames {
-			if dnsName == clientID {
-				sanMatched = true
-				break
-			}
-			// Support wildcard certificates (e.g., *.example.com)
-			// Per RFC 6125, wildcards match only a single label
-			if strings.HasPrefix(dnsName, "*.") {
-				// *.example.com matches sub.example.com but NOT example.com or deep.sub.example.com
-				suffix := dnsName[1:]     // *.example.com -> .example.com
-				baseDomain := dnsName[2:] // *.example.com -> example.com
-				if strings.HasSuffix(clientID, suffix) && clientID != baseDomain {
-					// Ensure only a single label before the suffix (no nested subdomains)
-					prefix := strings.TrimSuffix(clientID, suffix)
-					if !strings.Contains(prefix, ".") {
-						sanMatched = true
-						break
-					}
-				}
-			}
-		}
-
-		if !sanMatched {
+		if !registry.DNSSANMatches(clientID, leafCert.DNSNames) {
 			reason := map[string]interface{}{
 				"error":           fmt.Sprintf("subject.id '%s' not found in certificate DNS SANs", clientID),
 				"dns_sans":        leafCert.DNSNames,
@@ -935,16 +912,8 @@ func (r *TSLRegistry) Evaluate(ctx context.Context, req *authzen.EvaluationReque
 	if req.Resource.Type == "x509_san_uri" {
 		clientID := req.Subject.ID
 		leafCert := certs[0]
-		sanMatched := false
 
-		for _, uri := range leafCert.URIs {
-			if uri != nil && uri.String() == clientID {
-				sanMatched = true
-				break
-			}
-		}
-
-		if !sanMatched {
+		if !registry.URISANMatches(clientID, leafCert.URIs) {
 			// Extract URI strings for error response
 			uriSANs := make([]string, 0, len(leafCert.URIs))
 			for _, uri := range leafCert.URIs {
@@ -965,6 +934,36 @@ func (r *TSLRegistry) Evaluate(ctx context.Context, req *authzen.EvaluationReque
 					Reason: reason,
 				},
 			}, nil
+		}
+	}
+
+	// The two blocks above only run when the caller signals the
+	// client_id_scheme via Resource.Type ("x509_san_dns"/"x509_san_uri"). The
+	// real-world OpenID4VP convention used by go-wallet-backend never does
+	// that - it always sends Resource.Type="x5c" and encodes the
+	// client_id_scheme in Subject.ID itself (e.g. "x509_san_dns:example.com"),
+	// which RegistryManager.Evaluate may have already rewritten to
+	// "https://example.com" for whitelist-style matching elsewhere. Recover
+	// the original claim and, if it names one of the certificate-binding
+	// schemes, verify it here too - otherwise the checks above are
+	// unreachable for any real caller and a verifier would be trusted on
+	// chain-validity to a listed CA alone, regardless of which identity it
+	// actually claims.
+	if req.Resource.Type == "x5c" {
+		if scheme, value, ok := registry.ParseClientIDScheme(registry.OriginalSubjectID(req)); ok {
+			if bindErr := registry.VerifyLeafBinding(scheme, value, certs[0]); bindErr != nil {
+				reason := map[string]interface{}{
+					"error":         fmt.Sprintf("certificate binding check failed: %s", bindErr),
+					"validation_ms": validationDuration.Milliseconds(),
+				}
+				addCredentialTypesToReason(reason, credentialTypes)
+				return &authzen.EvaluationResponse{
+					Decision: false,
+					Context: &authzen.EvaluationResponseContext{
+						Reason: reason,
+					},
+				}, nil
+			}
 		}
 	}
 

--- a/pkg/registry/etsi/registry_test.go
+++ b/pkg/registry/etsi/registry_test.go
@@ -1527,6 +1527,68 @@ func TestTSLRegistry_Evaluate_X509SanDNS(t *testing.T) {
 	}
 }
 
+// TestTSLRegistry_Evaluate_X5C_ClientIDSchemeBinding proves the certificate
+// binding check is reachable via the resource type real callers actually
+// send. go-wallet-backend (the real production caller of go-trust) never
+// sets Resource.Type to "x509_san_dns"/"x509_san_uri" - it always sends
+// Resource.Type="x5c" and encodes the client_id_scheme in Subject.ID itself
+// (e.g. "x509_san_dns:example.com"). Before this fix, the DNS-SAN check above
+// only ran for Resource.Type=="x509_san_dns", making it dead code for any
+// real caller: an x5c request would chain-validate and be trusted regardless
+// of what Subject.ID claimed.
+func TestTSLRegistry_Evaluate_X5C_ClientIDSchemeBinding(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "tsl-x5c-scheme-binding-test-*")
+	if err != nil {
+		t.Fatalf("failed to create temp dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	cert, pemData := generateTestCertificateWithDNSSAN(t, "Test CA", []string{"example.com"})
+	certPath := writeTestCertFile(t, tmpDir, "test-ca.pem", pemData)
+
+	reg, err := NewTSLRegistry(TSLConfig{
+		Name:       "x5c-scheme-binding-test",
+		CertBundle: certPath,
+	})
+	if err != nil {
+		t.Fatalf("failed to create registry: %v", err)
+	}
+
+	certB64 := base64.StdEncoding.EncodeToString(cert.Raw)
+
+	t.Run("matching x509_san_dns claim in Subject.ID is trusted", func(t *testing.T) {
+		req := &authzen.EvaluationRequest{
+			Subject:  authzen.Subject{Type: "key", ID: "x509_san_dns:example.com"},
+			Resource: authzen.Resource{Type: "x5c", ID: "x509_san_dns:example.com", Key: []interface{}{certB64}},
+		}
+		resp, err := reg.Evaluate(context.Background(), req)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !resp.Decision {
+			t.Errorf("expected decision=true for a matching x509_san_dns claim, got deny: %v", resp.Context.Reason)
+		}
+	})
+
+	t.Run("mismatched x509_san_dns claim in Subject.ID is denied even though the chain validates", func(t *testing.T) {
+		req := &authzen.EvaluationRequest{
+			Subject:  authzen.Subject{Type: "key", ID: "x509_san_dns:attacker.com"},
+			Resource: authzen.Resource{Type: "x5c", ID: "x509_san_dns:attacker.com", Key: []interface{}{certB64}},
+		}
+		resp, err := reg.Evaluate(context.Background(), req)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.Decision {
+			t.Error("expected decision=false: certificate has no DNS SAN for the claimed identity")
+		}
+		errReason, _ := resp.Context.Reason["error"].(string)
+		if !strings.Contains(errReason, "certificate binding check failed") {
+			t.Errorf("expected a certificate-binding deny reason, got: %v", errReason)
+		}
+	})
+}
+
 // TestTSLRegistry_Evaluate_X509SanDNS_NoDNSSANs tests x509_san_dns with certificate without DNS SANs
 func TestTSLRegistry_Evaluate_X509SanDNS_NoDNSSANs(t *testing.T) {
 	// Create temp directory

--- a/pkg/registry/lote/registry.go
+++ b/pkg/registry/lote/registry.go
@@ -520,6 +520,29 @@ func (r *Registry) validateX5CChainCA(req *authzen.EvaluationRequest, credential
 		return nil // chain does not validate against any listed CA
 	}
 
+	// Chaining to a listed CA proves the certificate was validly issued by
+	// one of the LoTE's own trust anchors; it says nothing about whether it
+	// belongs to the identity req.Subject.ID is claiming. When the caller
+	// used one of OpenID4VP's certificate-binding client_id_schemes
+	// (x509_san_dns/x509_san_uri/x509_hash - recovered via OriginalSubjectID
+	// since RegistryManager may have rewritten Subject.ID), verify the
+	// binding before trusting the chain. Requests that don't use one of
+	// these schemes (e.g. a plain RP identifier under an Access Certificate
+	// list, issue #90) are unaffected - there is no additional claim to bind
+	// in that model, so behavior is unchanged for them.
+	if scheme, value, ok := registry.ParseClientIDScheme(registry.OriginalSubjectID(req)); ok {
+		if bindErr := registry.VerifyLeafBinding(scheme, value, certs[0]); bindErr != nil {
+			reason := map[string]interface{}{
+				"admin": fmt.Sprintf("x5c chain validates against a listed CA but certificate binding check failed: %s", bindErr),
+			}
+			addCredentialTypesToReason(reason, credentialTypes)
+			return &authzen.EvaluationResponse{
+				Decision: false,
+				Context:  &authzen.EvaluationResponseContext{Reason: reason},
+			}
+		}
+	}
+
 	// Find which listed entity's CA pool the chain validates against (for metadata
 	// and profile-aware status checking).
 	matchedEnt := r.findMatchingEntityForChain(certs)

--- a/pkg/registry/lote/registry_test.go
+++ b/pkg/registry/lote/registry_test.go
@@ -1176,6 +1176,101 @@ func TestEvaluate_X5C_CAAnchored_SubjectIDNotListed(t *testing.T) {
 	}
 }
 
+// TestEvaluate_X5C_CAAnchored_ClientIDSchemeBindingMismatch proves the CA-anchored
+// fallback no longer grants trust on chain-validity alone when the caller uses
+// an OpenID4VP certificate-binding client_id_scheme: chaining to a listed CA is
+// necessary but not sufficient - the leaf must also be bound to the claimed
+// identity. Without this check, any certificate issued by a listed CA could
+// impersonate ANY x509_san_dns/x509_san_uri/x509_hash identity, regardless of
+// what the certificate itself actually says.
+func TestEvaluate_X5C_CAAnchored_ClientIDSchemeBindingMismatch(t *testing.T) {
+	caCert, caKey := generateTestCA(t)
+
+	// Leaf legitimately issued by the listed CA, but for a DIFFERENT DNS name
+	// than the one the caller claims via the x509_san_dns client_id_scheme.
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	leafTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(43),
+		Subject:      pkix.Name{CommonName: "unrelated.example.com"},
+		DNSNames:     []string{"unrelated.example.com"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTemplate, caCert, &leafKey.PublicKey, caKey)
+	require.NoError(t, err)
+	leafCert, err := x509.ParseCertificate(leafDER)
+	require.NoError(t, err)
+
+	caEntityID := "https://access-ca-binding.example.com"
+	lote := minimalLoTE("SE", x509Entity(caEntityID, caCert))
+	path := writeLoTE(t, t.TempDir(), "lote.json", lote)
+
+	reg, err := New(Config{Name: "ca-anchored-binding-test", Sources: []string{path}})
+	require.NoError(t, err)
+
+	resp, err := reg.Evaluate(context.Background(), &authzen.EvaluationRequest{
+		Subject: authzen.Subject{Type: "key", ID: "x509_san_dns:rp.example.com"},
+		Resource: authzen.Resource{
+			Type: "x5c",
+			ID:   "x509_san_dns:rp.example.com",
+			Key: []interface{}{
+				base64.StdEncoding.EncodeToString(leafCert.Raw),
+				base64.StdEncoding.EncodeToString(caCert.Raw),
+			},
+		},
+	})
+	require.NoError(t, err)
+	assert.False(t, resp.Decision, "leaf chains to a listed CA but is not bound to the claimed x509_san_dns identity - must be denied")
+	admin, _ := resp.Context.Reason["admin"].(string)
+	assert.Contains(t, admin, "certificate binding check failed", "expected a certificate-binding deny reason, got: %s", admin)
+}
+
+// TestEvaluate_X5C_CAAnchored_ClientIDSchemeBindingSuccess proves the CA-anchored
+// fallback still grants trust when the leaf IS bound to the claimed identity.
+func TestEvaluate_X5C_CAAnchored_ClientIDSchemeBindingSuccess(t *testing.T) {
+	caCert, caKey := generateTestCA(t)
+
+	leafKey, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+	leafTemplate := &x509.Certificate{
+		SerialNumber: big.NewInt(44),
+		Subject:      pkix.Name{CommonName: "rp.example.com"},
+		DNSNames:     []string{"rp.example.com"},
+		NotBefore:    time.Now().Add(-time.Hour),
+		NotAfter:     time.Now().Add(24 * time.Hour),
+		KeyUsage:     x509.KeyUsageDigitalSignature,
+		ExtKeyUsage:  []x509.ExtKeyUsage{x509.ExtKeyUsageClientAuth},
+	}
+	leafDER, err := x509.CreateCertificate(rand.Reader, leafTemplate, caCert, &leafKey.PublicKey, caKey)
+	require.NoError(t, err)
+	leafCert, err := x509.ParseCertificate(leafDER)
+	require.NoError(t, err)
+
+	caEntityID := "https://access-ca-binding-ok.example.com"
+	lote := minimalLoTE("SE", x509Entity(caEntityID, caCert))
+	path := writeLoTE(t, t.TempDir(), "lote.json", lote)
+
+	reg, err := New(Config{Name: "ca-anchored-binding-ok-test", Sources: []string{path}})
+	require.NoError(t, err)
+
+	resp, err := reg.Evaluate(context.Background(), &authzen.EvaluationRequest{
+		Subject: authzen.Subject{Type: "key", ID: "x509_san_dns:rp.example.com"},
+		Resource: authzen.Resource{
+			Type: "x5c",
+			ID:   "x509_san_dns:rp.example.com",
+			Key: []interface{}{
+				base64.StdEncoding.EncodeToString(leafCert.Raw),
+				base64.StdEncoding.EncodeToString(caCert.Raw),
+			},
+		},
+	})
+	require.NoError(t, err)
+	assert.True(t, resp.Decision, "leaf chains to a listed CA and is bound to the claimed x509_san_dns identity - should be trusted, got reason: %v", resp.Context.Reason)
+}
+
 // TestEvaluate_X5C_CAAnchored_UntrustedLeafRejected ensures that the global CA
 // pool fallback does not grant access to a leaf issued by an unknown CA.
 func TestEvaluate_X5C_CAAnchored_UntrustedLeafRejected(t *testing.T) {

--- a/pkg/registry/manager.go
+++ b/pkg/registry/manager.go
@@ -113,6 +113,15 @@ func (m *RegistryManager) Evaluate(ctx context.Context, req *authzen.EvaluationR
 		}, nil
 	}
 
+	// Preserve the pre-normalization Subject.ID before rewriting it below.
+	// Registries that need the raw OpenID4VP client_id_scheme claim (e.g. to
+	// verify a presented certificate is actually bound to the claimed
+	// x509_san_dns/x509_san_uri/x509_hash identity, not just chained to a
+	// trusted CA - see registry.VerifyLeafBinding) recover it via
+	// registry.OriginalSubjectID, since the rewrite below is otherwise
+	// irreversible from their point of view.
+	StashOriginalSubjectID(req, req.Subject.ID)
+
 	// Normalize subject ID: strip OpenID4VP client_id_scheme prefixes
 	// (e.g. "x509_san_dns:host" -> "https://host") so all registries
 	// receive a consistent identifier.

--- a/pkg/registry/manager_test.go
+++ b/pkg/registry/manager_test.go
@@ -752,6 +752,52 @@ func TestRegistryManager_Evaluate_NormalizesSubjectID(t *testing.T) {
 	assert.Equal(t, "https://verifier.example.com", capturedSubjectID)
 }
 
+func TestRegistryManager_Evaluate_PreservesOriginalSubjectIDForDownstreamRegistries(t *testing.T) {
+	// RegistryManager.Evaluate rewrites Subject.ID for whitelist-style
+	// matching (see TestRegistryManager_Evaluate_NormalizesSubjectID above),
+	// but registries that need to verify a presented certificate is actually
+	// bound to the claimed identity (WhitelistRegistry's
+	// TrustX509ViaSystemCA fallback, the ETSI TSL registry, LoTE's
+	// CA-anchored fallback) need the ORIGINAL, pre-normalization claim to do
+	// so. Prove OriginalSubjectID recovers it even after the manager has
+	// rewritten req.Subject.ID.
+	var capturedOriginal string
+	reg := &captureMockRegistry{
+		mockRegistry: &mockRegistry{
+			name:          "capture-registry",
+			resourceTypes: []string{"x5c"},
+			healthy:       true,
+			evaluateResponse: &authzen.EvaluationResponse{
+				Decision: true,
+			},
+		},
+		onEvaluate: func(req *authzen.EvaluationRequest) {
+			capturedOriginal = OriginalSubjectID(req)
+		},
+	}
+
+	mgr := NewRegistryManager(FirstMatch, 10*time.Second)
+	mgr.Register(reg)
+
+	req := &authzen.EvaluationRequest{
+		Subject: authzen.Subject{
+			Type: "key",
+			ID:   "x509_san_dns:verifier.example.com",
+		},
+		Resource: authzen.Resource{
+			Type: "x5c",
+			ID:   "x509_san_dns:verifier.example.com",
+			Key:  []interface{}{"test"},
+		},
+	}
+
+	resp, err := mgr.Evaluate(context.Background(), req)
+	require.NoError(t, err)
+	assert.True(t, resp.Decision)
+	assert.Equal(t, "https://verifier.example.com", req.Subject.ID, "Subject.ID should still be rewritten for whitelist matching")
+	assert.Equal(t, "x509_san_dns:verifier.example.com", capturedOriginal, "OriginalSubjectID should recover the pre-normalization claim")
+}
+
 func TestRegistryManager_Evaluate_AppliesFIDOMDS3Policy(t *testing.T) {
 	var capturedContext map[string]interface{}
 	reg := &captureMockRegistry{

--- a/pkg/registry/static/keyutil.go
+++ b/pkg/registry/static/keyutil.go
@@ -114,7 +114,7 @@ func PublicKeyToCanonicalJWK(pubKey crypto.PublicKey) (map[string]string, error)
 // Supports both x5c (X.509 certificate chain) and jwk resource types.
 func ExtractPublicKeyFromRequest(resourceType string, resourceKey []interface{}) (crypto.PublicKey, error) {
 	switch resourceType {
-	case "x5c", "x509_san_dns":
+	case "x5c", "x509_san_dns", "x509_san_uri":
 		certs, err := x509util.ParseX5CFromArray(resourceKey)
 		if err != nil {
 			return nil, fmt.Errorf("parsing x5c: %w", err)

--- a/pkg/registry/static/whitelist.go
+++ b/pkg/registry/static/whitelist.go
@@ -144,9 +144,15 @@ type WhitelistConfig struct {
 	// this state is a member of the matched action's list (still gated by
 	// the same whitelist membership check every other entry goes through -
 	// this is NOT a blanket "trust any certificate" fallback), its presented
-	// x5c certificate chain is verified against the operating system's root
-	// CA pool instead of being denied outright for having no cached JWKS
-	// keys. This only applies to entities that were never JWKS-fetchable in
+	// x5c certificate chain must (a) be bound to the claimed identity per
+	// the client_id_scheme's own semantics - a DNS/URI SAN match for
+	// x509_san_dns/x509_san_uri, or a cert-hash match for x509_hash, see
+	// registry.VerifyLeafBinding - and (b) verify against the operating
+	// system's root CA pool, instead of being denied outright for having no
+	// cached JWKS keys. Only entities using one of these three recognized
+	// schemes are eligible; any other non-fetchable scheme (e.g. "did:...")
+	// is denied outright since there is no defined way to bind it to an x5c
+	// chain. This only applies to entities that were never JWKS-fetchable in
 	// the first place; a real https:// entity whose JWKS fetch failed
 	// (network error, misconfiguration) is still denied, not silently
 	// downgraded to cert-pool trust.
@@ -554,8 +560,16 @@ func (r *WhitelistRegistry) Evaluate(ctx context.Context, req *authzen.Evaluatio
 		// parsing, and reaching it only after a successful fingerprint
 		// extraction (which parses the same x5c bytes) would make its parse
 		// error branch dead code.
-		if r.config.TrustX509ViaSystemCA && req.Resource.Type == "x5c" && !isHTTPScheme(subjectID) {
-			return r.evaluateViaSystemCA(subjectID, role, matchedList, req)
+		// isHTTPScheme (and the certificate-binding check inside
+		// evaluateViaSystemCA) must see the claim as the client actually
+		// asserted it - e.g. "x509_san_dns:host" - not the https://-rewritten
+		// form RegistryManager.Evaluate produces for whitelist-matching
+		// purposes. Recover it via OriginalSubjectID; this is a no-op (falls
+		// back to subjectID) when Evaluate is called directly, as all of this
+		// package's own tests do.
+		originalSubjectID := registry.OriginalSubjectID(req)
+		if r.config.TrustX509ViaSystemCA && isCertificateArrayResourceType(req.Resource.Type) && !isHTTPScheme(originalSubjectID) {
+			return r.evaluateViaSystemCA(subjectID, originalSubjectID, role, matchedList, req)
 		}
 		return r.deny(subjectID, "no keys cached for entity; call Refresh() to load keys")
 	}
@@ -583,6 +597,27 @@ func isHTTPScheme(id string) bool {
 	return err == nil && (u.Scheme == "https" || u.Scheme == "http")
 }
 
+// isCertificateArrayResourceType reports whether resourceType carries an x5c
+// certificate array as its payload, whichever of the equivalent resource
+// type names is used for it. "x5c" is what real callers (e.g.
+// go-wallet-backend) always send, encoding the client_id_scheme in
+// Subject.ID instead (see registry.ParseClientIDScheme); "x509_san_dns" /
+// "x509_san_uri" are an alternative convention - used by
+// ExtractPublicKeyFromRequest and SupportedResourceTypes below - where the
+// scheme is signaled via Resource.Type instead. Both must be accepted here:
+// previously this gate only matched "x5c" while SupportedResourceTypes
+// advertised "x509_san_dns" as routable, so a request legitimately arriving
+// with that resource type and no cached JWKS was denied even with
+// TrustX509ViaSystemCA enabled.
+func isCertificateArrayResourceType(resourceType string) bool {
+	switch resourceType {
+	case "x5c", "x509_san_dns", "x509_san_uri":
+		return true
+	default:
+		return false
+	}
+}
+
 // loadSystemCertPool lazily loads and caches the OS root CA pool, used by
 // evaluateViaSystemCA. Loading is one-time for the registry's lifetime -
 // x509.SystemCertPool() re-reads the OS trust store on every call otherwise,
@@ -601,11 +636,16 @@ func (r *WhitelistRegistry) loadSystemCertPool() (*x509.CertPool, error) {
 // the OS root CA pool, for a whitelisted entity that has no JWKS to check
 // key fingerprints against (see the TrustX509ViaSystemCA doc comment). The
 // caller has already confirmed subjectID matched an entry in the relevant
-// action's list - this only decides whether the presented certificate chain
-// is itself valid, mirroring the same public-CA chain validation
-// static.SystemCertPoolRegistry performs, scoped here to whitelisted
-// entities only rather than any presented certificate.
-func (r *WhitelistRegistry) evaluateViaSystemCA(subjectID, role, matchedList string, req *authzen.EvaluationRequest) (*authzen.EvaluationResponse, error) {
+// action's list, but that only proves the CLAIMED identity string is
+// allowed - not that the PRESENTED certificate actually belongs to it.
+// Chaining to a public CA is trivial for anyone to obtain for any domain, so
+// before trusting the chain at all, evaluateViaSystemCA verifies the
+// certificate is bound to the claimed identity per the OpenID4VP
+// client_id_scheme semantics (DNS/URI SAN match, or cert hash match - see
+// registry.VerifyLeafBinding). Without this check, any whitelisted
+// x509_san_dns/x509_san_uri/x509_hash identity could be impersonated by
+// anyone holding an unrelated, publicly-issued certificate.
+func (r *WhitelistRegistry) evaluateViaSystemCA(subjectID, originalSubjectID, role, matchedList string, req *authzen.EvaluationRequest) (*authzen.EvaluationResponse, error) {
 	pool, err := r.loadSystemCertPool()
 	if err != nil {
 		return r.deny(subjectID, fmt.Sprintf("system CA pool unavailable: %s", err))
@@ -617,6 +657,21 @@ func (r *WhitelistRegistry) evaluateViaSystemCA(subjectID, role, matchedList str
 	certs, err := x509util.ParseX5CFromArray(req.Resource.Key)
 	if err != nil {
 		return r.deny(subjectID, fmt.Sprintf("failed to parse x5c chain: %s", err))
+	}
+
+	// Only the three OpenID4VP schemes below have defined certificate-binding
+	// semantics. Anything else (e.g. a "did:..." identity reaching this
+	// fallback because it's a non-http(s) scheme) cannot be verified against
+	// an x5c chain at all, so it is denied rather than silently accepted on
+	// chain-validity alone.
+	scheme, value, ok := registry.ParseClientIDScheme(originalSubjectID)
+	if !ok {
+		return r.deny(subjectID, fmt.Sprintf(
+			"cannot verify certificate binding for %q: not a recognized x509 client_id_scheme (x509_san_dns/x509_san_uri/x509_hash)",
+			originalSubjectID))
+	}
+	if bindErr := registry.VerifyLeafBinding(scheme, value, certs[0]); bindErr != nil {
+		return r.deny(subjectID, fmt.Sprintf("certificate binding check failed: %s", bindErr))
 	}
 
 	opts := x509.VerifyOptions{
@@ -831,7 +886,7 @@ func (r *WhitelistRegistry) deny(subject, reason string) (*authzen.EvaluationRes
 
 // SupportedResourceTypes returns the resource types this registry can validate.
 func (r *WhitelistRegistry) SupportedResourceTypes() []string {
-	return []string{"jwk", "x5c", "x509_san_dns"}
+	return []string{"jwk", "x5c", "x509_san_dns", "x509_san_uri"}
 }
 
 // SupportsResolutionOnly returns true since whitelist supports resolution-only requests
@@ -846,11 +901,13 @@ func (r *WhitelistRegistry) Info() registry.RegistryInfo {
 	defer r.mu.RUnlock()
 
 	info := registry.RegistryInfo{
-		Name:           r.name,
-		Type:           "static_whitelist",
-		Description:    r.description,
-		Version:        "2.0.0",
-		ResourceTypes:  []string{"jwk", "x5c"},
+		Name:        r.name,
+		Type:        "static_whitelist",
+		Description: r.description,
+		Version:     "2.0.0",
+		// Reuse SupportedResourceTypes() instead of a second hardcoded list -
+		// the two had drifted (this list was missing "x509_san_dns").
+		ResourceTypes:  r.SupportedResourceTypes(),
 		ResolutionOnly: true,
 		Healthy:        r.keysLoaded,
 	}

--- a/pkg/registry/static/whitelist_test.go
+++ b/pkg/registry/static/whitelist_test.go
@@ -5,9 +5,11 @@ import (
 	"crypto/ecdsa"
 	"crypto/elliptic"
 	"crypto/rand"
+	"crypto/sha256"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"log/slog"
@@ -414,7 +416,7 @@ func TestWhitelistRegistry_InterfaceMethods(t *testing.T) {
 
 	// Test SupportedResourceTypes - now returns specific types for key validation
 	types := reg.SupportedResourceTypes()
-	expected := map[string]bool{"jwk": true, "x5c": true, "x509_san_dns": true}
+	expected := map[string]bool{"jwk": true, "x5c": true, "x509_san_dns": true, "x509_san_uri": true}
 	if len(types) != len(expected) {
 		t.Errorf("expected %d resource types, got %v", len(expected), types)
 	}
@@ -2260,7 +2262,15 @@ func TestWhitelistRegistry_TrustX509ViaSystemCA(t *testing.T) {
 		}
 	})
 
-	t.Run("enabled_attempts_chain_validation_for_whitelisted_entity", func(t *testing.T) {
+	t.Run("enabled_denies_on_certificate_binding_mismatch", func(t *testing.T) {
+		// certB64 (generateSelfSignedCert) carries no DNS SAN at all, so it
+		// can never be bound to the claimed "verifier.example.com" identity -
+		// this must be denied on the binding check, before chain validation
+		// is even attempted (and regardless of whether the cert would
+		// otherwise chain to a public CA). This is the exact case the
+		// binding check exists to close: without it, ANY certificate the
+		// caller holds - chaining to any public CA, for any domain - would
+		// have been accepted for this claimed identity.
 		reg := NewWhitelistRegistry(WithWhitelistConfig(WhitelistConfig{
 			Lists:                map[string][]string{"verifiers": {"x509_san_dns:verifier.example.com"}},
 			Actions:              map[string]string{"credential-verifier": "verifiers"},
@@ -2279,24 +2289,104 @@ func TestWhitelistRegistry_TrustX509ViaSystemCA(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		// A self-signed test cert does not chain to any real public CA, so
-		// this is expected to deny - but critically via chain validation,
-		// not the "no keys cached" reason, proving the fallback path ran.
 		if resp.Decision {
-			t.Error("expected decision=false for a self-signed cert (doesn't chain to a public CA)")
+			t.Error("expected decision=false for a certificate with no matching DNS SAN")
+		}
+		errReason, _ := resp.Context.Reason["error"].(string)
+		if !strings.Contains(errReason, "certificate binding check failed") {
+			t.Errorf("expected a certificate-binding deny reason, got: %v", errReason)
+		}
+	})
+
+	t.Run("enabled_attempts_chain_validation_once_binding_matches", func(t *testing.T) {
+		// Prove the fallback still reaches chain validation (and denies
+		// there) once the binding check itself passes: use a cert whose DNS
+		// SAN matches the claimed identity, but deliberately don't trust its
+		// issuing CA - so the binding check passes and the deny comes from
+		// chain validation, proving both checks run in the right order.
+		leafCert, _ := generateCASignedLeafCert(t)
+
+		reg := NewWhitelistRegistry(WithWhitelistConfig(WhitelistConfig{
+			Lists:                map[string][]string{"verifiers": {"x509_san_dns:verifier.example.com"}},
+			Actions:              map[string]string{"credential-verifier": "verifiers"},
+			TrustX509ViaSystemCA: true,
+		}))
+		_ = reg.Refresh(context.Background())
+		// Force the pool to one that does NOT contain this leaf's issuer, so
+		// the binding check (which matches) passes but chain validation
+		// still fails - proving both checks run, in the right order.
+		reg.systemCertPoolOnce.Do(func() {})
+		reg.systemCertPoolErr = nil
+		reg.systemCertPool = x509.NewCertPool()
+
+		leafB64 := base64.StdEncoding.EncodeToString(leafCert.Raw)
+		resp, err := reg.Evaluate(context.Background(), &authzen.EvaluationRequest{
+			Subject: authzen.Subject{ID: "x509_san_dns:verifier.example.com"},
+			Action:  &authzen.Action{Name: "credential-verifier"},
+			Resource: authzen.Resource{
+				Type: "x5c",
+				Key:  []interface{}{leafB64},
+			},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.Decision {
+			t.Error("expected decision=false: leaf's issuing CA is not in the (deliberately empty) pool")
 		}
 		errReason, _ := resp.Context.Reason["error"].(string)
 		if !strings.Contains(errReason, "x509 chain validation") {
-			t.Errorf("expected a chain-validation error proving the system-CA fallback ran, got: %v", errReason)
+			t.Errorf("expected a chain-validation error (binding check should have already passed), got: %v", errReason)
 		}
 	})
 
 	t.Run("enabled_attempts_chain_validation_for_x509_hash_scheme", func(t *testing.T) {
-		// The fallback is scheme-agnostic: it triggers on "any non-HTTP(S)
-		// scheme", not specifically x509_san_dns. Prove it also covers
-		// OpenID4VP's x509_hash:<hash-of-leaf-cert-der> client_id_scheme,
-		// which is a different non-fetchable scheme with the same problem
-		// (no JWKS endpoint), through the exact same code path.
+		// The fallback is scheme-agnostic across the three recognized
+		// certificate-binding schemes. Prove it also covers OpenID4VP's
+		// x509_hash:<hash-of-leaf-cert-der> client_id_scheme, using a claimed
+		// hash that actually matches this leaf's digest so the binding check
+		// passes and the deny comes from chain validation, same as the
+		// x509_san_dns case above.
+		leafCert, _ := generateCASignedLeafCert(t)
+		digest := sha256.Sum256(leafCert.Raw)
+		hashHex := hex.EncodeToString(digest[:])
+
+		reg := NewWhitelistRegistry(WithWhitelistConfig(WhitelistConfig{
+			Lists:                map[string][]string{"verifiers": {"x509_hash:" + hashHex}},
+			Actions:              map[string]string{"credential-verifier": "verifiers"},
+			TrustX509ViaSystemCA: true,
+		}))
+		_ = reg.Refresh(context.Background())
+		reg.systemCertPoolOnce.Do(func() {})
+		reg.systemCertPoolErr = nil
+		reg.systemCertPool = x509.NewCertPool()
+
+		leafB64 := base64.StdEncoding.EncodeToString(leafCert.Raw)
+		resp, err := reg.Evaluate(context.Background(), &authzen.EvaluationRequest{
+			Subject: authzen.Subject{ID: "x509_hash:" + hashHex},
+			Action:  &authzen.Action{Name: "credential-verifier"},
+			Resource: authzen.Resource{
+				Type: "x5c",
+				Key:  []interface{}{leafB64},
+			},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.Decision {
+			t.Error("expected decision=false: leaf's issuing CA is not in the (deliberately empty) pool")
+		}
+		errReason, _ := resp.Context.Reason["error"].(string)
+		if !strings.Contains(errReason, "x509 chain validation") {
+			t.Errorf("expected a chain-validation error (binding check should have already passed for x509_hash), got: %v", errReason)
+		}
+	})
+
+	t.Run("enabled_denies_x509_hash_mismatch", func(t *testing.T) {
+		// The mirror image of the DNS SAN mismatch case above: a whitelisted
+		// x509_hash entity whose claimed hash does NOT match the presented
+		// certificate's actual digest must be denied on the binding check,
+		// never reaching (and so never benefiting from) chain validation.
 		reg := NewWhitelistRegistry(WithWhitelistConfig(WhitelistConfig{
 			Lists:                map[string][]string{"verifiers": {"x509_hash:deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"}},
 			Actions:              map[string]string{"credential-verifier": "verifiers"},
@@ -2315,16 +2405,45 @@ func TestWhitelistRegistry_TrustX509ViaSystemCA(t *testing.T) {
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
-		// Same expectation as the x509_san_dns case: a self-signed test cert
-		// doesn't chain to a public CA, so this denies - but via chain
-		// validation, not "no keys cached", proving the fallback ran for
-		// this scheme too.
 		if resp.Decision {
-			t.Error("expected decision=false for a self-signed cert (doesn't chain to a public CA)")
+			t.Error("expected decision=false for a certificate whose hash doesn't match the claimed x509_hash identity")
 		}
 		errReason, _ := resp.Context.Reason["error"].(string)
-		if !strings.Contains(errReason, "x509 chain validation") {
-			t.Errorf("expected a chain-validation error proving the system-CA fallback ran for x509_hash, got: %v", errReason)
+		if !strings.Contains(errReason, "certificate binding check failed") {
+			t.Errorf("expected a certificate-binding deny reason, got: %v", errReason)
+		}
+	})
+
+	t.Run("enabled_denies_unrecognized_client_id_scheme", func(t *testing.T) {
+		// A whitelisted entity using a non-HTTP(S) scheme this package has no
+		// certificate-binding rule for (e.g. "did:web:...") must be denied
+		// outright rather than falling back to chain-validity-only trust -
+		// there's no defined way to verify such an identity is bound to a
+		// presented x5c chain at all.
+		reg := NewWhitelistRegistry(WithWhitelistConfig(WhitelistConfig{
+			Lists:                map[string][]string{"verifiers": {"did:web:verifier.example.com"}},
+			Actions:              map[string]string{"credential-verifier": "verifiers"},
+			TrustX509ViaSystemCA: true,
+		}))
+		_ = reg.Refresh(context.Background())
+
+		resp, err := reg.Evaluate(context.Background(), &authzen.EvaluationRequest{
+			Subject: authzen.Subject{ID: "did:web:verifier.example.com"},
+			Action:  &authzen.Action{Name: "credential-verifier"},
+			Resource: authzen.Resource{
+				Type: "x5c",
+				Key:  []interface{}{certB64},
+			},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.Decision {
+			t.Error("expected decision=false: did: has no defined certificate-binding rule")
+		}
+		errReason, _ := resp.Context.Reason["error"].(string)
+		if !strings.Contains(errReason, "not a recognized x509 client_id_scheme") {
+			t.Errorf("expected an unrecognized-scheme deny reason, got: %v", errReason)
 		}
 	})
 


### PR DESCRIPTION
## Summary

Closes a real trust-bypass gap found during a security/code-quality review of PR #120 (x509_san_dns/x509_hash whitelist support) and the LoTE registry's client_id_scheme handling, plus two bugs that made the gap hard to see from unit tests alone.

**The core issue:** PR #120's `TrustX509ViaSystemCA` fallback (whitelist), the pre-existing ETSI TSL registry SAN-matching, and LoTE's CA-anchored fallback (issue #90) all verify that a presented `x5c` chain was validly issued by *some* trusted CA — but never that the certificate actually belongs to the identity being claimed. Per OpenID4VP, the `client_id` itself carries that claim (a DNS/URI SAN, or a certificate hash) and MUST be checked against the certificate's content. Without that check, anyone holding *any* publicly-issued certificate (or, for LoTE, any certificate chaining to a listed CA) could impersonate *any* whitelisted `x509_san_dns`/`x509_san_uri`/`x509_hash` identity just by asserting its subject string.

This isn't theoretical: `go-wallet-backend` (the real production caller) explicitly delegates this exact check to go-trust — `"client_id vs SAN DNS validation is performed by go-trust PDP via /v1/evaluate"` — and always sends `Resource.Type="x5c"` with the scheme encoded in `Subject.ID` (e.g. `"x509_san_dns:example.com"`), never `Resource.Type="x509_san_dns"`. So the gap was live in the actual request path, not just theoretical unit-test territory.

## What changed

- **New `pkg/registry/clientid.go`**: shared `ParseClientIDScheme` / `VerifyLeafBinding` helper (DNS SAN exact + RFC 6125 wildcard match, URI SAN match, SHA-256 hash match in hex or base64url) reused by whitelist, LoTE, and etsi instead of each reimplementing (or omitting) it.
- **`whitelist.evaluateViaSystemCA`**: now verifies the binding before trusting the chain. Unrecognized non-fetchable schemes (e.g. `did:...`) fail closed instead of being silently accepted on chain-validity alone.
- **`RegistryManager.Evaluate`**: stashes the pre-normalization `Subject.ID` on `Context` before rewriting it (`"x509_san_dns:host" -> "https://host"`), since that rewrite was flipping whitelist's own `isHTTPScheme()` gate and making the fallback unreachable for `x509_san_dns` in production (only `x509_hash`, untouched by the rewrite, ever reached it). Registries recover the original via `registry.OriginalSubjectID`.
- **`whitelist`**: fixed the `TrustX509ViaSystemCA` gate hardcoding `Resource.Type=="x5c"` while `SupportedResourceTypes()`/`keyutil.go` treat `"x509_san_dns"` as an equally valid alias; fixed `Info()`'s `ResourceTypes` list, which had drifted from `SupportedResourceTypes()`; added `x509_san_uri` for consistency.
- **`etsi.TSLRegistry`**: SAN-matching was gated on `Resource.Type=="x509_san_dns"/"x509_san_uri"`, a convention the real caller never uses — making it dead code in production. Added the same binding check for the real `x5c` + scheme-prefixed-`Subject.ID` convention, and de-duplicated the SAN-matching logic into the shared helper.
- **`lote.Registry.validateX5CChainCA`**: gets the same binding check when the caller uses one of these schemes; it's a no-op for plain RP identifiers (the existing Access Certificate List model per issue #90), so that behavior is unchanged. The per-entity direct-match path (`validateX5CChain`) is untouched since identity there is already established by the unique entity lookup, not a shared CA pool.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `golangci-lint run` all clean
- [x] `go test ./...` passes (full suite, no regressions)
- [x] New `pkg/registry/clientid_test.go`: unit coverage for scheme parsing, DNS/hash binding match+mismatch, unrecognized-scheme rejection, original-subject-ID recovery
- [x] New `TestRegistryManager_Evaluate_PreservesOriginalSubjectIDForDownstreamRegistries`: proves the original claim survives the real manager rewrite end-to-end
- [x] Updated whitelist tests to prove the binding check runs (and denies) *before* chain validation, plus new tests for hash-mismatch and unrecognized-scheme denial
- [x] New LoTE tests proving the CA-anchored fallback now denies a binding mismatch and still allows a correct binding
- [x] New etsi test proving the binding check is reachable via the real `x5c` convention (previously dead code)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NEpSbhafKum83TmXqs1C8h