### PR TITLE
feat(whitelist): support additional trusted roots for system-CA validation

### DIFF
--- a/pkg/registry/static/whitelist.go
+++ b/pkg/registry/static/whitelist.go
@@ -173,6 +173,29 @@ type WhitelistConfig struct {
 	// error, misconfiguration) is still denied, not silently downgraded to
 	// cert-pool trust.
 	TrustX509ViaSystemCA bool `json:"trust_x509_via_system_ca,omitempty" yaml:"trust_x509_via_system_ca,omitempty"`
+
+	// AdditionalTrustedRoots is a list of PEM-encoded CA certificates merged
+	// into the OS root pool used by TrustX509ViaSystemCA's chain-validation
+	// step (x509_san_dns/x509_san_uri only - x509_hash skips chain
+	// validation entirely, see allowViaPinnedHash, so this has no effect on
+	// that scheme).
+	//
+	// This exists for verifiers whose request-signing certificate is issued
+	// by a long-lived, self-signed "reader CA" root that is meant to be
+	// trusted out-of-band per ISO 18013-5 convention, rather than chaining
+	// to a public root - confirmed live: verifier.multipaz.org's
+	// request-signing leaf is issued by exactly such a root (published at
+	// https://verifier.multipaz.org/verifier/readerRootCert), distinct from
+	// its ordinary publicly-CA-issued HTTPS/TLS certificate. Trusting the
+	// root here is preferable to x509_hash-pinning the leaf: the root is
+	// long-lived and covers future leaf rotations, whereas a pinned leaf
+	// hash breaks the moment the verifier rotates its signing certificate.
+	//
+	// Mirrors the same "trust a specific root for a specific purpose"
+	// pattern this package's sibling mdociaca registry already uses for
+	// credential issuers (IACA cert validation) - this is the equivalent
+	// for verifiers.
+	AdditionalTrustedRoots []string `json:"additional_trusted_roots,omitempty" yaml:"additional_trusted_roots,omitempty"`
 }
 
 // WhitelistOption is a functional option for configuring WhitelistRegistry.
@@ -634,15 +657,24 @@ func isCertificateArrayResourceType(resourceType string) bool {
 	}
 }
 
-// loadSystemCertPool lazily loads and caches the OS root CA pool, used by
-// evaluateViaSystemCA. Loading is one-time for the registry's lifetime -
-// x509.SystemCertPool() re-reads the OS trust store on every call otherwise,
-// which is unnecessary work on the hot Evaluate() path.
+// loadSystemCertPool lazily loads and caches the OS root CA pool merged with
+// any AdditionalTrustedRoots, used by evaluateViaSystemCA. Loading is
+// one-time for the registry's lifetime - x509.SystemCertPool() re-reads the
+// OS trust store on every call otherwise, which is unnecessary work on the
+// hot Evaluate() path.
 func (r *WhitelistRegistry) loadSystemCertPool() (*x509.CertPool, error) {
 	r.systemCertPoolOnce.Do(func() {
 		r.systemCertPool, r.systemCertPoolErr = x509.SystemCertPool()
 		if r.systemCertPoolErr == nil && r.systemCertPool == nil {
 			r.systemCertPoolErr = fmt.Errorf("system cert pool is nil (unsupported on this platform)")
+		}
+		if r.systemCertPoolErr == nil {
+			for i, pemCert := range r.config.AdditionalTrustedRoots {
+				if !r.systemCertPool.AppendCertsFromPEM([]byte(pemCert)) {
+					r.systemCertPoolErr = fmt.Errorf("additional_trusted_roots[%d]: failed to parse PEM certificate", i)
+					return
+				}
+			}
 		}
 	})
 	return r.systemCertPool, r.systemCertPoolErr

--- a/pkg/registry/static/whitelist_test.go
+++ b/pkg/registry/static/whitelist_test.go
@@ -11,6 +11,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"encoding/pem"
 	"fmt"
 	"log/slog"
 	"math/big"
@@ -2609,6 +2610,77 @@ func TestWhitelistRegistry_TrustX509ViaSystemCA(t *testing.T) {
 		}
 		if resp.Context.Reason["chain_length"] != 1 {
 			t.Errorf("expected a single resolved chain, got chain_length=%v", resp.Context.Reason["chain_length"])
+		}
+	})
+
+	t.Run("additional_trusted_roots_extends_chain_validation", func(t *testing.T) {
+		// Proves the AdditionalTrustedRoots config field itself - not the
+		// registry-internal systemCertPool test seam the subtests above use.
+		// This is the real-world shape: a verifier's request-signing leaf is
+		// issued by a long-lived, self-signed "reader CA" root (the ISO
+		// 18013-5 convention this field exists for - see its doc comment)
+		// that will never appear in any OS system CA pool, so chain
+		// validation must succeed via ONLY the configured additional root,
+		// not the real system pool this test also loads alongside it.
+		leafCert, caCert := generateCASignedLeafCert(t)
+		caPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: caCert.Raw})
+
+		reg := NewWhitelistRegistry(WithWhitelistConfig(WhitelistConfig{
+			Lists:                  map[string][]string{"verifiers": {"x509_san_dns:verifier.example.com"}},
+			Actions:                map[string]string{"credential-verifier": "verifiers"},
+			TrustX509ViaSystemCA:   true,
+			AdditionalTrustedRoots: []string{string(caPEM)},
+		}))
+		_ = reg.Refresh(context.Background())
+
+		leafB64 := base64.StdEncoding.EncodeToString(leafCert.Raw)
+		resp, err := reg.Evaluate(context.Background(), &authzen.EvaluationRequest{
+			Subject: authzen.Subject{ID: "x509_san_dns:verifier.example.com"},
+			Action:  &authzen.Action{Name: "credential-verifier"},
+			Resource: authzen.Resource{
+				Type: "x5c",
+				Key:  []interface{}{leafB64},
+			},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if !resp.Decision {
+			t.Fatalf("expected decision=true: leaf is signed by a root supplied via AdditionalTrustedRoots, got deny: %v", resp.Context.Reason["error"])
+		}
+		if resp.Context.Reason["trust_path"] != "system_ca" {
+			t.Errorf("expected trust_path=system_ca, got: %v", resp.Context.Reason["trust_path"])
+		}
+	})
+
+	t.Run("malformed_additional_trusted_root_denies_with_pool_error", func(t *testing.T) {
+		reg := NewWhitelistRegistry(WithWhitelistConfig(WhitelistConfig{
+			Lists:                  map[string][]string{"verifiers": {"x509_san_dns:verifier.example.com"}},
+			Actions:                map[string]string{"credential-verifier": "verifiers"},
+			TrustX509ViaSystemCA:   true,
+			AdditionalTrustedRoots: []string{"not a real PEM certificate"},
+		}))
+		_ = reg.Refresh(context.Background())
+
+		leafCert, _ := generateCASignedLeafCert(t)
+		leafB64 := base64.StdEncoding.EncodeToString(leafCert.Raw)
+		resp, err := reg.Evaluate(context.Background(), &authzen.EvaluationRequest{
+			Subject: authzen.Subject{ID: "x509_san_dns:verifier.example.com"},
+			Action:  &authzen.Action{Name: "credential-verifier"},
+			Resource: authzen.Resource{
+				Type: "x5c",
+				Key:  []interface{}{leafB64},
+			},
+		})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if resp.Decision {
+			t.Error("expected decision=false: a malformed additional_trusted_roots entry should fail the pool, not be silently ignored")
+		}
+		errReason, _ := resp.Context.Reason["error"].(string)
+		if !strings.Contains(errReason, "additional_trusted_roots") {
+			t.Errorf("expected error to name additional_trusted_roots as the cause, got: %v", errReason)
 		}
 	})
 


### PR DESCRIPTION
## Summary

- Adds `WhitelistConfig.AdditionalTrustedRoots` (PEM-encoded CA certs), merged into the cached system CA pool used by `TrustX509ViaSystemCA`'s chain-validation step (`x509_san_dns`/`x509_san_uri` only - `x509_hash` skips chain validation entirely per #122).
- Fixes a real live gap: `verifier.multipaz.org`'s OpenID4VP request-signing certificate is issued by a long-lived, self-signed "reader CA" root (published at `https://verifier.multipaz.org/verifier/readerRootCert`) meant to be trusted out-of-band per ISO 18013-5 convention - distinct from its ordinary Let's Encrypt-issued HTTPS/TLS certificate. Without this, the `x509_san_dns` whitelist entry matched but chain validation always failed, since a self-signed cert can never validate against any OS system CA pool.
- Chose trusting the root over `x509_hash`-pinning the leaf: the root is long-lived (valid to 2030) and survives future leaf-certificate rotations, whereas a pinned leaf hash breaks the moment the verifier rotates its signing key. Mirrors this package's existing `mdociaca` registry pattern (trust a specific root for a specific purpose) applied here to verifiers instead of issuers.

## Test plan

- [x] `go build ./...`
- [x] `go test ./pkg/registry/static/... -run Whitelist -v` - all pass, including two new subtests: `additional_trusted_roots_extends_chain_validation` (a leaf signed by a root supplied only via config, not the real system pool, now validates) and `malformed_additional_trusted_root_denies_with_pool_error` (a bad PEM entry fails loudly rather than being silently ignored)
- [x] `golangci-lint` clean (pre-commit hook)