### PR TITLE
Log whitelist deny reason at INFO level

### DIFF
--- a/pkg/registry/static/whitelist.go
+++ b/pkg/registry/static/whitelist.go
@@ -964,6 +964,14 @@ func (r *WhitelistRegistry) extractCredentialTypes(req *authzen.EvaluationReques
 }
 
 func (r *WhitelistRegistry) deny(subject, reason string) (*authzen.EvaluationResponse, error) {
+	// The detailed reason is only ever returned in the AuthZEN response
+	// body's Context.Reason today - callers (go-wallet-backend included)
+	// don't currently log it, so a denial's specific cause (not-in-list vs.
+	// certificate-binding-check failure vs. chain-validation failure) was
+	// otherwise unobservable from server-side logs alone. Log it here once,
+	// at the single choke point every denial in this registry passes
+	// through, rather than at each call site.
+	r.logger.Info("whitelist denied request", "registry", r.name, "subject", subject, "reason", reason)
 	return &authzen.EvaluationResponse{
 		Decision: false,
 		Context: &authzen.EvaluationResponseContext{


### PR DESCRIPTION
## Summary
- `WhitelistRegistry.deny()` now logs the specific deny reason (not-in-list, certificate-binding-check failure, chain-validation failure, etc.) at INFO level.

## Why
Debugging a live "verifier not trusted" denial for verifier.multipaz.org showed that the detailed reason is computed and returned in the AuthZEN response body, but never logged anywhere server-side (PDP or go-wallet-backend) - only the boolean decision. This makes root-causing any real denial from logs alone impossible.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./pkg/registry/static/...`