### PR TITLE
Accept CA certs with negative serial numbers via GODEBUG

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,15 @@ WORKDIR /app
 # Add wget for healthchecks and ca-certificates for TLS
 RUN apk add --no-cache ca-certificates wget
 
+# Go 1.23+ rejects x509 certificates with a negative serial number by default
+# (RFC 5280 recommends non-negative, but doesn't forbid it, and real-world CA
+# tooling - e.g. verifier.multipaz.org's self-generated reader-CA root -
+# still produces them; openssl and every other major TLS stack accept them
+# without complaint). Without this, AdditionalTrustedRoots/system-CA chain
+# validation silently can't parse such a root at all, denying every
+# certificate it issues regardless of whitelist membership.
+ENV GODEBUG=x509negativeserial=1
+
 # Copy binary from builder
 COPY --from=builder /app/gt /app/gt
 

--- a/pkg/registry/static/whitelist.go
+++ b/pkg/registry/static/whitelist.go
@@ -195,6 +195,17 @@ type WhitelistConfig struct {
 	// pattern this package's sibling mdociaca registry already uses for
 	// credential issuers (IACA cert validation) - this is the equivalent
 	// for verifiers.
+	//
+	// Gotcha confirmed live against verifier.multipaz.org's actual root:
+	// Go's x509 parser rejects certificates with a negative serial number
+	// by default (since Go 1.23; RFC 5280 recommends non-negative but
+	// doesn't forbid it, and real-world CA tooling still produces them -
+	// openssl and every other major TLS stack accept such certs without
+	// complaint). If a root supplied here has one, AppendCertsFromPEM
+	// silently fails to add it and this field becomes a no-op for that
+	// root. The binary this package ships (see this repo's Dockerfile)
+	// sets GODEBUG=x509negativeserial=1 to accommodate this; anything
+	// embedding this package directly must set the same.
 	AdditionalTrustedRoots []string `json:"additional_trusted_roots,omitempty" yaml:"additional_trusted_roots,omitempty"`
 }
 

--- a/pkg/registry/static/whitelist_test.go
+++ b/pkg/registry/static/whitelist_test.go
@@ -2653,6 +2653,40 @@ func TestWhitelistRegistry_TrustX509ViaSystemCA(t *testing.T) {
 		}
 	})
 
+	t.Run("additional_trusted_root_with_negative_serial_number", func(t *testing.T) {
+		// Go's x509 parser rejects certificates with a negative serial
+		// number by default since Go 1.23 (RFC 5280 recommends non-negative
+		// but doesn't forbid it, and x509.CreateCertificate itself refuses
+		// to mint one - this is a real-world-artifact test, not a synthetic
+		// one, for that reason). Real-world CA tooling still produces such
+		// certs: this is verifier.multipaz.org's actual self-generated
+		// reader-CA root (fetched from its /verifier/readerRootCert
+		// endpoint), which openssl - and every other major TLS stack -
+		// accepts without complaint, but a stock Go binary silently fails
+		// to even parse via AppendCertsFromPEM, denying every certificate
+		// it issues regardless of whitelist membership. See this package's
+		// Dockerfile's GODEBUG=x509negativeserial=1 setting, which callers
+		// embedding this package (rather than running the packaged binary)
+		// must also set for AdditionalTrustedRoots to work with such roots.
+		t.Setenv("GODEBUG", "x509negativeserial=1")
+
+		reg := NewWhitelistRegistry(WithWhitelistConfig(WhitelistConfig{
+			Lists:                  map[string][]string{"verifiers": {"x509_san_dns:verifier.multipaz.org"}},
+			Actions:                map[string]string{"credential-verifier": "verifiers"},
+			TrustX509ViaSystemCA:   true,
+			AdditionalTrustedRoots: []string{multipazReaderCAPEMWithNegativeSerial},
+		}))
+		_ = reg.Refresh(context.Background())
+
+		pool, err := reg.loadSystemCertPool()
+		if err != nil {
+			t.Fatalf("expected the negative-serial root to load successfully with GODEBUG=x509negativeserial=1, got: %v", err)
+		}
+		if pool == nil {
+			t.Fatal("expected a non-nil cert pool")
+		}
+	})
+
 	t.Run("malformed_additional_trusted_root_denies_with_pool_error", func(t *testing.T) {
 		reg := NewWhitelistRegistry(WithWhitelistConfig(WhitelistConfig{
 			Lists:                  map[string][]string{"verifiers": {"x509_san_dns:verifier.example.com"}},
@@ -2807,6 +2841,28 @@ func generateCASignedLeafCert(t *testing.T) (leaf *x509.Certificate, ca *x509.Ce
 
 	return leafCert, caCert
 }
+
+// multipazReaderCAPEMWithNegativeSerial is verifier.multipaz.org's actual
+// self-generated OpenID4VP request-signing reader-CA root, fetched from its
+// /verifier/readerRootCert endpoint on 2026-08-13. Its serial number is
+// negative (openssl explicitly flags this: "Serial Number: (Negative)
+// 48:ca:d0:...") - x509.CreateCertificate refuses to mint a certificate
+// like this at all, so this real-world artifact is embedded verbatim rather
+// than synthesized, for additional_trusted_root_with_negative_serial_number.
+const multipazReaderCAPEMWithNegativeSerial = `-----BEGIN CERTIFICATE-----
+MIICaTCCAe+gAwIBAgIQtzUvFDCKLUBWQAZ4UnCw5zAKBggqhkjOPQQDAzA3MQswCQYDVQQGDAJV
+UzEoMCYGA1UEAwwfdmVyaWZpZXIubXVsdGlwYXoub3JnIFJlYWRlciBDQTAeFw0yNTA2MTkyMjE2
+MzJaFw0zMDA2MTkyMjE2MzJaMDcxCzAJBgNVBAYMAlVTMSgwJgYDVQQDDB92ZXJpZmllci5tdWx0
+aXBhei5vcmcgUmVhZGVyIENBMHYwEAYHKoZIzj0CAQYFK4EEACIDYgAEa6oCzC8rfHfwVOmQf83W
+yHEQFE8HrLK+NxsufJDrSFgMXjhRvPt3fIjlMyRAaf94Y25Ux9tXg+28EzzB/xG7q8P/FQ9nOSJk
+w4cQJVdD/ufN599uVdfp1URdG95Vncuoo4G/MIG8MA4GA1UdDwEB/wQEAwIBBjASBgNVHRMBAf8E
+CDAGAQH/AgEAMFYGA1UdHwRPME0wS6BJoEeGRWh0dHBzOi8vZ2l0aHViLmNvbS9vcGVud2FsbGV0
+LWZvdW5kYXRpb24tbGFicy9pZGVudGl0eS1jcmVkZW50aWFsL2NybDAdBgNVHQ4EFgQUsYQ5hS9K
+buq/6mKtvFHQgfdIhykwHwYDVR0jBBgwFoAUsYQ5hS9Kbuq/6mKtvFHQgfdIhykwCgYIKoZIzj0E
+AwMDaAAwZQIwKh87sK/cMbzuc9PFvyiSRedr2RoP0fuFK0X8ddOpi6hEMOapHL/Gs/QByROCpDpk
+AjEA2yLSJDZEu1GI8uChAsDBZwJPtv5KHUjq1Vpok69SNn+zzb1mNpqmiey+tchPBjZm
+-----END CERTIFICATE-----
+`
 
 // generateCASignedLeafCertWithIntermediate builds a 3-tier root CA ->
 // intermediate CA -> leaf chain, for testing evaluateViaSystemCA's


### PR DESCRIPTION
## Summary
- Sets `GODEBUG=x509negativeserial=1` in the shipped Docker image, so Go's x509 parser accepts certificates with a negative serial number (rejected by default since Go 1.23; RFC 5280 recommends non-negative but doesn't forbid it, and real-world CA tooling - openssl included - still produces/accepts them).
- Adds this gotcha to `AdditionalTrustedRoots`'s doc comment for anyone embedding this package directly rather than running the shipped binary.
- Adds a regression test using verifier.multipaz.org's actual self-generated reader-CA root as a fixture (its serial number is negative; `x509.CreateCertificate` itself refuses to mint a synthetic one, so a real-world artifact is embedded instead).

## Why
Live debugging tonight (go-trust#124's new deny-reason logging) traced "verifier not trusted" for verifier.multipaz.org all the way down to this: `AppendCertsFromPEM` was silently failing to add their reader-CA root to the trust pool because of its negative serial number, making `AdditionalTrustedRoots` (go-trust#123) a no-op for exactly the verifier it was built to support. Confirmed via direct reproduction: `openssl verify` accepts the chain; Go's stdlib `x509.ParseCertificate` panics with `x509: negative serial number` by default, and succeeds once `GODEBUG=x509negativeserial=1` is set.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...` (full suite)
- [x] Manually reproduced against the real multipaz root+leaf cert pair (captured live via its `dcBegin` endpoint) - `openssl verify` succeeds; Go parsing/verification fails without the GODEBUG override and succeeds with it