### PR TITLE
Wire AdditionalTrustedRoots through YAML config loading

### DIFF
--- a/cmd/gt/main.go
+++ b/cmd/gt/main.go
@@ -461,13 +461,14 @@ func configureRegistriesFromConfig(cfg *config.Config, registryMgr *registry.Reg
 				static.WithWhitelistName(name),
 				static.WithWhitelistDescription(desc),
 				static.WithWhitelistConfig(static.WhitelistConfig{
-					Lists:                wlCfg.Lists,
-					Actions:              wlCfg.Actions,
-					Issuers:              wlCfg.Issuers,
-					Verifiers:            wlCfg.Verifiers,
-					TrustedSubjects:      wlCfg.TrustedSubjects,
-					AllowHTTP:            wlCfg.AllowHTTP,
-					TrustX509ViaSystemCA: wlCfg.TrustX509ViaSystemCA,
+					Lists:                  wlCfg.Lists,
+					Actions:                wlCfg.Actions,
+					Issuers:                wlCfg.Issuers,
+					Verifiers:              wlCfg.Verifiers,
+					TrustedSubjects:        wlCfg.TrustedSubjects,
+					AllowHTTP:              wlCfg.AllowHTTP,
+					TrustX509ViaSystemCA:   wlCfg.TrustX509ViaSystemCA,
+					AdditionalTrustedRoots: wlCfg.AdditionalTrustedRoots,
 				}),
 			)
 		}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -90,6 +90,10 @@ type WhitelistRegistryConfig struct {
 	// client_id_scheme verifiers) - see
 	// pkg/registry/static.WhitelistConfig.TrustX509ViaSystemCA.
 	TrustX509ViaSystemCA bool `yaml:"trust_x509_via_system_ca,omitempty"`
+	// AdditionalTrustedRoots is a list of PEM-encoded CA certificates merged
+	// into TrustX509ViaSystemCA's chain-validation pool - see
+	// pkg/registry/static.WhitelistConfig.AdditionalTrustedRoots.
+	AdditionalTrustedRoots []string `yaml:"additional_trusted_roots,omitempty"`
 }
 
 // StaticRegistryConfig contains static (always/never trusted) registry configuration.

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -3,6 +3,7 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -105,6 +106,65 @@ security:
 	}
 	if len(cfg.Security.AllowedOrigins) != 2 {
 		t.Errorf("Allowed origins count = %v, want %v", len(cfg.Security.AllowedOrigins), 2)
+	}
+}
+
+func TestLoadConfigWhitelistAdditionalTrustedRoots(t *testing.T) {
+	// Regression test: pkg/registry/static.WhitelistConfig.AdditionalTrustedRoots
+	// (go-trust#123) was never mirrored onto this package's YAML-facing
+	// WhitelistRegistryConfig struct, so the field was silently dropped for
+	// every YAML-config-based deployment - unit tests never caught this
+	// because they construct static.WhitelistConfig directly in Go,
+	// bypassing YAML entirely. Confirmed live: verifier.multipaz.org's
+	// trusted root was never actually reaching the whitelist registry
+	// despite correct-looking config.
+	tmpDir := t.TempDir()
+	configPath := filepath.Join(tmpDir, "config.yaml")
+
+	configContent := `
+server:
+  host: "0.0.0.0"
+  port: "8080"
+
+registries:
+  whitelist:
+    enabled: true
+    name: test
+    lists:
+      verifiers:
+        - x509_san_dns:verifier.example.com
+    actions:
+      credential-verifier: verifiers
+    trust_x509_via_system_ca: true
+    additional_trusted_roots:
+      - |
+        -----BEGIN CERTIFICATE-----
+        MIIBXXXXfakeXXXXXXcertXXXX
+        -----END CERTIFICATE-----
+`
+
+	if err := os.WriteFile(configPath, []byte(configContent), 0644); err != nil {
+		t.Fatalf("Failed to write config file: %v", err)
+	}
+
+	cfg, err := LoadConfig(configPath)
+	if err != nil {
+		t.Fatalf("LoadConfig() error = %v", err)
+	}
+
+	if cfg.Registries.Whitelist == nil {
+		t.Fatal("expected whitelist registry config to be present")
+	}
+	if !cfg.Registries.Whitelist.TrustX509ViaSystemCA {
+		t.Error("expected TrustX509ViaSystemCA to be true")
+	}
+	if len(cfg.Registries.Whitelist.AdditionalTrustedRoots) != 1 {
+		t.Fatalf("AdditionalTrustedRoots count = %d, want 1 - the field was dropped during YAML parsing",
+			len(cfg.Registries.Whitelist.AdditionalTrustedRoots))
+	}
+	if !strings.Contains(cfg.Registries.Whitelist.AdditionalTrustedRoots[0], "BEGIN CERTIFICATE") {
+		t.Errorf("AdditionalTrustedRoots[0] doesn't look like a PEM cert: %q",
+			cfg.Registries.Whitelist.AdditionalTrustedRoots[0])
 	}
 }
 


### PR DESCRIPTION
## Summary
- `pkg/registry/static.WhitelistConfig.AdditionalTrustedRoots` (#123) was never mirrored onto `pkg/config.WhitelistRegistryConfig` (the YAML-facing struct), so the field was silently dropped for every YAML-config-based deployment.
- `cmd/gt/main.go` now passes `wlCfg.AdditionalTrustedRoots` through when building the inline whitelist registry.
- Adds a regression test proving the field actually survives YAML parsing.

## Why
While debugging "verifier not trusted" for verifier.multipaz.org tonight (after #124's deny-reason logging and #126's negative-serial GODEBUG fix were both already deployed), captured its actual live signed request directly from its `dcBegin` endpoint and fed the real leaf certificate straight to a locally-built `gt` binary. Confirmed via a temporary debug print that `AdditionalTrustedRoots` was **empty** at runtime despite being present and correctly indented in the deployed YAML config - the whole feature has been a no-op via YAML config since #123 merged. Existing unit tests never caught this because they construct `static.WhitelistConfig` directly in Go, bypassing the YAML layer entirely.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `go test ./...`, `golangci-lint run` (all clean)
- [x] New regression test (`TestLoadConfigWhitelistAdditionalTrustedRoots`) proves the YAML field reaches the parsed struct
- [x] Manually verified end-to-end against the real captured verifier.multipaz.org leaf cert: denied before this fix, `decision=true`/`trust_path=system_ca` after (with #126's GODEBUG fix also applied)