### PR TITLE
Add generated configuration reference doc + CI drift check

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -163,3 +163,24 @@ jobs:
         version: v2.12.2
         args: --timeout=5m --tests=false
         verify: false
+
+  config-docs:
+    name: Config Docs
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v7
+
+    - name: Set up Go
+      uses: actions/setup-go@v7
+      with:
+        go-version-file: 'go.mod'
+        cache: true
+
+    - name: Check docs/CONFIGURATION.md is up to date
+      run: |
+        make gen-config-docs
+        if ! git diff --exit-code docs/CONFIGURATION.md; then
+          echo "::error::docs/CONFIGURATION.md is out of date. Run 'make gen-config-docs' and commit the result."
+          exit 1
+        fi

--- a/Makefile
+++ b/Makefile
@@ -69,6 +69,10 @@ swagger: install-swag ## Generate OpenAPI/Swagger documentation
 install-swag: ## Install swag tool for generating Swagger docs
 	@which swag > /dev/null || (echo "Installing swag..." && go install github.com/swaggo/swag/cmd/swag@latest)
 
+.PHONY: gen-config-docs
+gen-config-docs: ## Generate docs/CONFIGURATION.md from the config structs
+	go run developer_tools/scripts/gen_config_docs/main.go
+
 .PHONY: clean
 clean: ## remove temporary files
 	go clean

--- a/developer_tools/scripts/gen_config_docs/main.go
+++ b/developer_tools/scripts/gen_config_docs/main.go
@@ -1,0 +1,527 @@
+// Package main generates docs/CONFIGURATION.md from the Go-Trust config structs.
+//
+// Unlike vc/go-wallet-backend, go-trust's config has no `envconfig`-style
+// struct tags — environment variable overrides are hand-written in
+// pkg/config/config.go's applyEnvOverrides(), and only cover a subset of
+// fields (Server/Logging/Security; Registries/Policies have no env
+// override support at all). So this tool parses applyEnvOverrides itself
+// to build the real GT_* mapping, instead of mechanically constructing an
+// env var name for every field — fabricating one for a field that isn't
+// actually overridable would be documenting something false.
+//
+// It parses config struct files using go/ast and extracts YAML keys,
+// types, and comments (both doc comments and inline comments) to produce
+// a Markdown configuration reference.
+//
+// Usage:
+//
+//	go run developer_tools/scripts/gen_config_docs/main.go [-root /path/to/project] [-out docs/CONFIGURATION.md]
+package main
+
+import (
+	"flag"
+	"fmt"
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// FieldDoc represents one documented config field.
+type FieldDoc struct {
+	YAMLPath    string
+	EnvVar      string // "" if this field has no real environment variable override
+	GoType      string
+	Description string
+}
+
+// SectionDoc represents a top-level config section (one rendered table).
+type SectionDoc struct {
+	Title       string
+	Description string
+	Fields      []FieldDoc
+}
+
+// StructInfo holds parsed struct metadata.
+type StructInfo struct {
+	Name   string
+	Doc    string
+	Fields []FieldInfo
+}
+
+// FieldInfo holds parsed field metadata.
+type FieldInfo struct {
+	GoName    string
+	GoType    string
+	YAMLTag   string
+	Doc       string
+	InlineDoc string
+	TypeName  string // resolved struct type name, if this field references another struct
+}
+
+// Registry of all parsed struct types, keyed by simple type name (single package in scope).
+type Registry struct {
+	types map[string]*StructInfo
+	fset  *token.FileSet
+}
+
+func NewRegistry() *Registry {
+	return &Registry{types: make(map[string]*StructInfo), fset: token.NewFileSet()}
+}
+
+func (r *Registry) ParseDir(dir string) error {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return fmt.Errorf("reading %s: %w", dir, err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") || strings.HasSuffix(entry.Name(), "_test.go") {
+			continue
+		}
+		path := filepath.Join(dir, entry.Name())
+		file, err := parser.ParseFile(r.fset, path, nil, parser.ParseComments)
+		if err != nil {
+			return fmt.Errorf("parsing %s: %w", path, err)
+		}
+		r.extractStructs(file)
+	}
+	return nil
+}
+
+func (r *Registry) extractStructs(file *ast.File) {
+	for _, decl := range file.Decls {
+		gd, ok := decl.(*ast.GenDecl)
+		if !ok || gd.Tok != token.TYPE {
+			continue
+		}
+		for _, spec := range gd.Specs {
+			ts, ok := spec.(*ast.TypeSpec)
+			if !ok {
+				continue
+			}
+			st, ok := ts.Type.(*ast.StructType)
+			if !ok {
+				continue
+			}
+			info := &StructInfo{Name: ts.Name.Name, Doc: cleanDoc(gd.Doc)}
+			if info.Doc == "" {
+				info.Doc = cleanDoc(ts.Doc)
+			}
+			for _, field := range st.Fields.List {
+				if len(field.Names) == 0 {
+					continue // skip embedded
+				}
+				fi := FieldInfo{
+					GoName:    field.Names[0].Name,
+					GoType:    typeString(field.Type),
+					Doc:       cleanDoc(field.Doc),
+					InlineDoc: cleanInlineComment(field.Comment),
+					TypeName:  resolveTypeName(field.Type),
+				}
+				if field.Tag != nil {
+					tag := strings.Trim(field.Tag.Value, "`")
+					fi.YAMLTag = strings.Split(extractTag(tag, "yaml"), ",")[0]
+				}
+				if fi.YAMLTag == "-" || !ast.IsExported(fi.GoName) {
+					continue
+				}
+				info.Fields = append(info.Fields, fi)
+			}
+			r.types[info.Name] = info
+		}
+	}
+}
+
+// resolveTypeName returns the referenced struct type name for fields that
+// point at another struct (directly or via a pointer), so the caller can
+// decide whether to recurse. Slices/maps are deliberately not unwrapped
+// here (see flattenStruct) — go-trust has no nested slice-of-struct field
+// that needs per-element expansion in the generated doc.
+func resolveTypeName(expr ast.Expr) string {
+	switch t := expr.(type) {
+	case *ast.Ident:
+		if ast.IsExported(t.Name) {
+			return t.Name
+		}
+	case *ast.StarExpr:
+		return resolveTypeName(t.X)
+	}
+	return ""
+}
+
+func typeString(expr ast.Expr) string {
+	switch t := expr.(type) {
+	case *ast.Ident:
+		return t.Name
+	case *ast.SelectorExpr:
+		if x, ok := t.X.(*ast.Ident); ok {
+			return x.Name + "." + t.Sel.Name
+		}
+		return t.Sel.Name
+	case *ast.StarExpr:
+		return "*" + typeString(t.X)
+	case *ast.ArrayType:
+		return "[]" + typeString(t.Elt)
+	case *ast.MapType:
+		return "map[" + typeString(t.Key) + "]" + typeString(t.Value)
+	default:
+		return "unknown"
+	}
+}
+
+func extractTag(tag, key string) string {
+	search := key + `:"`
+	idx := strings.Index(tag, search)
+	if idx < 0 {
+		return ""
+	}
+	rest := tag[idx+len(search):]
+	end := strings.Index(rest, `"`)
+	if end < 0 {
+		return ""
+	}
+	return rest[:end]
+}
+
+func cleanDoc(cg *ast.CommentGroup) string {
+	if cg == nil {
+		return ""
+	}
+	var lines []string
+	for _, c := range cg.List {
+		text := strings.TrimPrefix(c.Text, "//")
+		text = strings.TrimPrefix(text, " ")
+		lines = append(lines, text)
+	}
+	return strings.TrimSpace(strings.Join(lines, " "))
+}
+
+func cleanInlineComment(cg *ast.CommentGroup) string {
+	if cg == nil {
+		return ""
+	}
+	var parts []string
+	for _, c := range cg.List {
+		text := strings.TrimSpace(strings.TrimPrefix(c.Text, "//"))
+		if text != "" {
+			parts = append(parts, text)
+		}
+	}
+	return strings.Join(parts, " ")
+}
+
+func (r *Registry) Lookup(name string) *StructInfo {
+	if name == "" {
+		return nil
+	}
+	return r.types[name]
+}
+
+// extractEnvMappings parses pkg/config/config.go's applyEnvOverrides function
+// and returns a map from Go field path (e.g. "Server.TLS.Enabled", dot-joined,
+// no leading "cfg.") to the real GT_* environment variable that overrides it.
+// Fields absent from this map have no environment variable override at all —
+// the caller must not invent one.
+func extractEnvMappings(fset *token.FileSet, path string) (map[string]string, error) {
+	file, err := parser.ParseFile(fset, path, nil, 0)
+	if err != nil {
+		return nil, fmt.Errorf("parsing %s: %w", path, err)
+	}
+	mapping := make(map[string]string)
+	for _, decl := range file.Decls {
+		fn, ok := decl.(*ast.FuncDecl)
+		if !ok || fn.Name.Name != "applyEnvOverrides" || fn.Body == nil {
+			continue
+		}
+		for _, stmt := range fn.Body.List {
+			ifStmt, ok := stmt.(*ast.IfStmt)
+			if !ok || ifStmt.Init == nil {
+				continue
+			}
+			envVar, ok := getenvArg(ifStmt.Init)
+			if !ok {
+				continue
+			}
+			if path := firstCfgAssignPath(ifStmt.Body); path != "" {
+				mapping[path] = envVar
+			}
+		}
+	}
+	return mapping, nil
+}
+
+// getenvArg matches `v := os.Getenv("GT_X")` and returns "GT_X".
+func getenvArg(init ast.Stmt) (string, bool) {
+	assign, ok := init.(*ast.AssignStmt)
+	if !ok || len(assign.Rhs) != 1 {
+		return "", false
+	}
+	call, ok := assign.Rhs[0].(*ast.CallExpr)
+	if !ok || len(call.Args) != 1 {
+		return "", false
+	}
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		return "", false
+	}
+	xIdent, ok := sel.X.(*ast.Ident)
+	if !ok || xIdent.Name != "os" || sel.Sel.Name != "Getenv" {
+		return "", false
+	}
+	lit, ok := call.Args[0].(*ast.BasicLit)
+	if !ok || lit.Kind != token.STRING {
+		return "", false
+	}
+	return strings.Trim(lit.Value, `"`), true
+}
+
+// firstCfgAssignPath finds the first `cfg.X.Y = ...` assignment anywhere in
+// block (including inside nested ifs, for the ParseDuration/Atoi-guarded
+// cases) and returns "X.Y".
+func firstCfgAssignPath(block *ast.BlockStmt) string {
+	var path string
+	ast.Inspect(block, func(n ast.Node) bool {
+		if path != "" {
+			return false
+		}
+		assign, ok := n.(*ast.AssignStmt)
+		if !ok || len(assign.Lhs) == 0 {
+			return true
+		}
+		if p := cfgSelectorPath(assign.Lhs[0]); p != "" {
+			path = p
+			return false
+		}
+		return true
+	})
+	return path
+}
+
+// cfgSelectorPath turns `cfg.Server.TLS.Enabled` into "Server.TLS.Enabled",
+// or "" if expr isn't a selector chain rooted at the identifier "cfg".
+func cfgSelectorPath(expr ast.Expr) string {
+	var parts []string
+	cur := expr
+	for {
+		sel, ok := cur.(*ast.SelectorExpr)
+		if !ok {
+			break
+		}
+		parts = append([]string{sel.Sel.Name}, parts...)
+		cur = sel.X
+	}
+	if id, ok := cur.(*ast.Ident); ok && id.Name == "cfg" && len(parts) > 0 {
+		return strings.Join(parts, ".")
+	}
+	return ""
+}
+
+// buildSections expands each direct field of the named root struct into its
+// own section (or, for scalar root fields, a single "general" section).
+func buildSections(reg *Registry, rootName string, envMap map[string]string) []SectionDoc {
+	root := reg.Lookup(rootName)
+	if root == nil {
+		log.Fatalf("root struct %q not found in parsed types", rootName)
+	}
+
+	var sections []SectionDoc
+	var rootFields []FieldDoc
+
+	for _, field := range root.Fields {
+		yamlKey := field.YAMLTag
+		if yamlKey == "" {
+			yamlKey = strings.ToLower(field.GoName)
+		}
+		if sub := reg.Lookup(field.TypeName); sub != nil {
+			sections = append(sections, SectionDoc{
+				Title:       yamlKey,
+				Description: fieldDescription(field),
+				Fields:      flattenStruct(reg, sub, yamlKey, field.GoName, envMap, 0),
+			})
+		} else {
+			rootFields = append(rootFields, FieldDoc{
+				YAMLPath:    yamlKey,
+				EnvVar:      envMap[field.GoName],
+				GoType:      friendlyType(field.GoType),
+				Description: fieldDescription(field),
+			})
+		}
+	}
+
+	if len(rootFields) > 0 {
+		sections = append([]SectionDoc{{Title: "general", Fields: rootFields}}, sections...)
+	}
+	return sections
+}
+
+func flattenStruct(reg *Registry, info *StructInfo, yamlPrefix, goPrefix string, envMap map[string]string, depth int) []FieldDoc {
+	if depth > 5 {
+		return nil // guard against cycles
+	}
+	var docs []FieldDoc
+	for _, f := range info.Fields {
+		yamlKey := f.YAMLTag
+		if yamlKey == "" {
+			yamlKey = strings.ToLower(f.GoName)
+		}
+		fullYAML := yamlPrefix + "." + yamlKey
+		fullGo := goPrefix + "." + f.GoName
+
+		if sub := reg.Lookup(f.TypeName); sub != nil {
+			docs = append(docs, flattenStruct(reg, sub, fullYAML, fullGo, envMap, depth+1)...)
+		} else {
+			docs = append(docs, FieldDoc{
+				YAMLPath:    fullYAML,
+				EnvVar:      envMap[fullGo],
+				GoType:      friendlyType(f.GoType),
+				Description: fieldDescription(f),
+			})
+		}
+	}
+	return docs
+}
+
+func fieldDescription(f FieldInfo) string {
+	if f.Doc != "" {
+		return f.Doc
+	}
+	return f.InlineDoc
+}
+
+func friendlyType(goType string) string {
+	switch goType {
+	case "time.Duration":
+		return "duration"
+	case "int", "int64":
+		return "integer"
+	case "bool":
+		return "boolean"
+	case "string":
+		return "string"
+	case "[]string":
+		return "string list"
+	default:
+		if strings.HasPrefix(goType, "map[") {
+			return goType + " (object)"
+		}
+		if strings.HasPrefix(goType, "[]") {
+			return goType[2:] + " list"
+		}
+		if strings.HasPrefix(goType, "*") {
+			return friendlyType(goType[1:])
+		}
+		return goType
+	}
+}
+
+func renderMarkdown(sections []SectionDoc) string {
+	var b strings.Builder
+	b.WriteString("<!-- Regenerate with: go run developer_tools/scripts/gen_config_docs/main.go -->\n\n")
+	b.WriteString("# Configuration Reference\n\n")
+	b.WriteString("This document describes all configuration options for go-trust (`gt`).\n")
+	b.WriteString("Configuration is loaded from a YAML file, then a handful of settings can be overridden by `GT_*` environment variables — most fields (all registries and policies) are YAML-only.\n\n")
+	b.WriteString("A few `server` settings can also be set via CLI flag (`gt -host`, `-port`, `-external-url`, `-log-level`, `-log-format`) — see `gt -h`.\n\n")
+	b.WriteString("## Table of Contents\n\n")
+
+	for _, sec := range sections {
+		if sec.Title == "general" {
+			continue
+		}
+		anchor := strings.ToLower(sec.Title)
+		anchor = strings.ReplaceAll(anchor, ".", "")
+		anchor = strings.ReplaceAll(anchor, " ", "-")
+		fmt.Fprintf(&b, "- [%s](#%s)\n", sec.Title, anchor)
+	}
+	b.WriteString("\n---\n\n")
+
+	for _, sec := range sections {
+		if sec.Title == "general" {
+			b.WriteString("## General\n\n")
+		} else {
+			b.WriteString("## " + sec.Title + "\n\n")
+		}
+		if sec.Description != "" {
+			b.WriteString(sec.Description + "\n\n")
+		}
+		if len(sec.Fields) > 0 {
+			b.WriteString("| YAML Key | Env Variable | Type | Description |\n")
+			b.WriteString("|----------|-------------|------|-------------|\n")
+			for _, f := range sec.Fields {
+				desc := strings.ReplaceAll(f.Description, "|", "\\|")
+				desc = strings.ReplaceAll(desc, "\n", " ")
+				envVar := f.EnvVar
+				if envVar == "" {
+					envVar = "—"
+				} else {
+					envVar = "`" + envVar + "`"
+				}
+				fmt.Fprintf(&b, "| `%s` | %s | %s | %s |\n", f.YAMLPath, envVar, f.GoType, desc)
+			}
+		}
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+func main() {
+	rootFlag := flag.String("root", "", "workspace root (auto-detected from cwd if empty)")
+	outFlag := flag.String("out", "docs/CONFIGURATION.md", "output path relative to root")
+	flag.Parse()
+
+	root := *rootFlag
+	if root == "" {
+		wd, err := os.Getwd()
+		if err != nil {
+			log.Fatalf("cannot get working directory: %v", err)
+		}
+		root = wd
+	}
+
+	reg := NewRegistry()
+	pkgDir := filepath.Join(root, "pkg/config")
+	if err := reg.ParseDir(pkgDir); err != nil {
+		log.Fatalf("error parsing %s: %v", pkgDir, err)
+	}
+
+	envMap, err := extractEnvMappings(reg.fset, filepath.Join(pkgDir, "config.go"))
+	if err != nil {
+		log.Fatalf("error parsing env overrides: %v", err)
+	}
+
+	rootSections := buildSections(reg, "Config", envMap)
+
+	// "registries" is one struct field on Config but really 11 independent
+	// registry types — expand it as its own set of sections (one per
+	// registry) instead of one giant merged table.
+	var sections []SectionDoc
+	for _, s := range rootSections {
+		if s.Title == "registries" {
+			continue
+		}
+		sections = append(sections, s)
+	}
+	registrySections := buildSections(reg, "RegistriesConfig", envMap)
+	for i := range registrySections {
+		registrySections[i].Title = "registries." + registrySections[i].Title
+	}
+	sections = append(sections, registrySections...)
+
+	markdown := renderMarkdown(sections)
+
+	outPath := filepath.Join(root, *outFlag)
+	if err := os.MkdirAll(filepath.Dir(outPath), 0o755); err != nil {
+		log.Fatalf("creating output dir: %v", err)
+	}
+	if err := os.WriteFile(outPath, []byte(markdown), 0o644); err != nil {
+		log.Fatalf("writing %s: %v", outPath, err)
+	}
+
+	totalFields := 0
+	for _, sec := range sections {
+		totalFields += len(sec.Fields)
+	}
+	fmt.Printf("Generated %s (%d sections, %d fields, %d env overrides found)\n", outPath, len(sections), totalFields, len(envMap))
+}

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -1,0 +1,216 @@
+<!-- Regenerate with: go run developer_tools/scripts/gen_config_docs/main.go -->
+
+# Configuration Reference
+
+This document describes all configuration options for go-trust (`gt`).
+Configuration is loaded from a YAML file, then a handful of settings can be overridden by `GT_*` environment variables — most fields (all registries and policies) are YAML-only.
+
+A few `server` settings can also be set via CLI flag (`gt -host`, `-port`, `-external-url`, `-log-level`, `-log-format`) — see `gt -h`.
+
+## Table of Contents
+
+- [server](#server)
+- [logging](#logging)
+- [security](#security)
+- [policies](#policies)
+- [registries.etsi](#registriesetsi)
+- [registries.whitelist](#registrieswhitelist)
+- [registries.oidfed](#registriesoidfed)
+- [registries.didweb](#registriesdidweb)
+- [registries.didwebvh](#registriesdidwebvh)
+- [registries.didjwks](#registriesdidjwks)
+- [registries.lote](#registrieslote)
+- [registries.mdociaca](#registriesmdociaca)
+- [registries.fidomds3](#registriesfidomds3)
+- [registries.always_trusted](#registriesalways_trusted)
+- [registries.never_trusted](#registriesnever_trusted)
+
+---
+
+## server
+
+| YAML Key | Env Variable | Type | Description |
+|----------|-------------|------|-------------|
+| `server.host` | `GT_HOST` | string |  |
+| `server.port` | `GT_PORT` | string |  |
+| `server.frequency` | `GT_FREQUENCY` | duration |  |
+| `server.external_url` | `GT_EXTERNAL_URL` | string | External URL for PDP discovery (e.g., https://pdp.example.com) |
+| `server.tls.enabled` | `GT_TLS_ENABLED` | boolean | Enable TLS/HTTPS |
+| `server.tls.cert_file` | `GT_TLS_CERT_FILE` | string | Path to TLS certificate file |
+| `server.tls.key_file` | `GT_TLS_KEY_FILE` | string | Path to TLS private key file |
+
+## logging
+
+| YAML Key | Env Variable | Type | Description |
+|----------|-------------|------|-------------|
+| `logging.level` | `GT_LOG_LEVEL` | string |  |
+| `logging.format` | `GT_LOG_FORMAT` | string |  |
+| `logging.output` | `GT_LOG_OUTPUT` | string |  |
+
+## security
+
+| YAML Key | Env Variable | Type | Description |
+|----------|-------------|------|-------------|
+| `security.rate_limit_rps` | `GT_RATE_LIMIT_RPS` | integer |  |
+| `security.enable_cors` | `GT_ENABLE_CORS` | boolean |  |
+| `security.allowed_origins` | `GT_ALLOWED_ORIGINS` | string list |  |
+| `security.max_response_body_bytes` | `GT_MAX_RESPONSE_BODY_BYTES` | integer | Max HTTP response body size in bytes (default: 10MB) |
+
+## policies
+
+| YAML Key | Env Variable | Type | Description |
+|----------|-------------|------|-------------|
+| `policies.default_policy` | — | string | DefaultPolicy is the name of the policy to use when action.name is not specified |
+| `policies.policies` | — | map[string]*PolicyConfig (object) | Policies is a map of policy name to policy configuration |
+
+## registries.etsi
+
+| YAML Key | Env Variable | Type | Description |
+|----------|-------------|------|-------------|
+| `etsi.enabled` | — | boolean |  |
+| `etsi.name` | — | string |  |
+| `etsi.description` | — | string |  |
+| `etsi.cert_bundle` | — | string |  |
+| `etsi.tsl_files` | — | string list |  |
+| `etsi.tsl_urls` | — | string list |  |
+| `etsi.follow_refs` | — | boolean |  |
+| `etsi.max_ref_depth` | — | integer |  |
+| `etsi.allow_network_access` | — | boolean |  |
+| `etsi.fetch_timeout` | — | string |  |
+| `etsi.user_agent` | — | string |  |
+| `etsi.lotl_signer_bundle` | — | string | LOTLSignerBundle is the path to a PEM file containing trusted LOTL signer certificates. These certificates are used to validate signatures on the List of Trusted Lists (LOTL). |
+| `etsi.require_signature` | — | boolean | RequireSignature controls whether TSLs must have valid signatures. When true, LOTLSignerBundle must also be configured. |
+| `etsi.follow_pivots` | — | boolean | FollowPivots enables ETSI TS 119 615 pivot LOTL processing for signer certificate rollover. When true, the registry will fetch pivot LOTLs to discover new signer certificates. |
+
+## registries.whitelist
+
+| YAML Key | Env Variable | Type | Description |
+|----------|-------------|------|-------------|
+| `whitelist.enabled` | — | boolean |  |
+| `whitelist.name` | — | string |  |
+| `whitelist.description` | — | string |  |
+| `whitelist.config_file` | — | string |  |
+| `whitelist.watch_file` | — | boolean |  |
+| `whitelist.lists` | — | map[string][]string (object) | Named lists (new format) |
+| `whitelist.actions` | — | map[string]string (object) |  |
+| `whitelist.issuers` | — | string list | Legacy fields (backward compatible) |
+| `whitelist.verifiers` | — | string list |  |
+| `whitelist.trusted_subjects` | — | string list |  |
+| `whitelist.allow_http` | — | boolean | AllowHTTP permits JWKS auto-discovery over plain HTTP instead of requiring HTTPS. Testing only - see pkg/registry/static.WhitelistConfig. |
+| `whitelist.trust_x509_via_system_ca` | — | boolean | TrustX509ViaSystemCA enables the system-CA-pool fallback for whitelisted entities with no JWKS endpoint (e.g. OpenID4VP x509_san_dns or x509_hash client_id_scheme verifiers) - see pkg/registry/static.WhitelistConfig.TrustX509ViaSystemCA. |
+| `whitelist.additional_trusted_roots` | — | string list | AdditionalTrustedRoots is a list of PEM-encoded CA certificates merged into TrustX509ViaSystemCA's chain-validation pool - see pkg/registry/static.WhitelistConfig.AdditionalTrustedRoots. |
+
+## registries.oidfed
+
+OpenID Federation registry
+
+| YAML Key | Env Variable | Type | Description |
+|----------|-------------|------|-------------|
+| `oidfed.enabled` | — | boolean |  |
+| `oidfed.name` | — | string |  |
+| `oidfed.description` | — | string |  |
+| `oidfed.trust_anchors` | — | OIDFedTrustAnchorConfig list |  |
+| `oidfed.required_trust_marks` | — | string list |  |
+| `oidfed.entity_types` | — | string list |  |
+| `oidfed.cache_ttl` | — | string |  |
+| `oidfed.max_cache_size` | — | integer |  |
+| `oidfed.max_chain_depth` | — | integer |  |
+
+## registries.didweb
+
+DID method registries
+
+| YAML Key | Env Variable | Type | Description |
+|----------|-------------|------|-------------|
+| `didweb.enabled` | — | boolean |  |
+| `didweb.name` | — | string |  |
+| `didweb.description` | — | string |  |
+| `didweb.timeout` | — | string |  |
+| `didweb.insecure_skip_verify` | — | boolean |  |
+| `didweb.allow_http` | — | boolean |  |
+
+## registries.didwebvh
+
+| YAML Key | Env Variable | Type | Description |
+|----------|-------------|------|-------------|
+| `didwebvh.enabled` | — | boolean |  |
+| `didwebvh.name` | — | string |  |
+| `didwebvh.description` | — | string |  |
+| `didwebvh.timeout` | — | string |  |
+| `didwebvh.insecure_skip_verify` | — | boolean |  |
+| `didwebvh.allow_http` | — | boolean |  |
+
+## registries.didjwks
+
+| YAML Key | Env Variable | Type | Description |
+|----------|-------------|------|-------------|
+| `didjwks.enabled` | — | boolean |  |
+| `didjwks.name` | — | string |  |
+| `didjwks.description` | — | string |  |
+| `didjwks.timeout` | — | string |  |
+| `didjwks.insecure_skip_verify` | — | boolean |  |
+| `didjwks.allow_http` | — | boolean |  |
+| `didjwks.disable_oidc_discovery` | — | boolean |  |
+
+## registries.lote
+
+ETSI TS 119 602 LoTE registry
+
+| YAML Key | Env Variable | Type | Description |
+|----------|-------------|------|-------------|
+| `lote.enabled` | — | boolean |  |
+| `lote.name` | — | string |  |
+| `lote.description` | — | string |  |
+| `lote.sources` | — | string list |  |
+| `lote.lotl_sources` | — | string list |  |
+| `lote.max_dereference_depth` | — | integer |  |
+| `lote.verify_jws` | — | boolean |  |
+| `lote.fetch_timeout` | — | string |  |
+| `lote.refresh_interval` | — | string |  |
+
+## registries.mdociaca
+
+mDOC IACA registry
+
+| YAML Key | Env Variable | Type | Description |
+|----------|-------------|------|-------------|
+| `mdociaca.enabled` | — | boolean |  |
+| `mdociaca.name` | — | string |  |
+| `mdociaca.description` | — | string |  |
+| `mdociaca.issuer_allowlist` | — | string list |  |
+| `mdociaca.cache_ttl` | — | string |  |
+| `mdociaca.http_timeout` | — | string |  |
+
+## registries.fidomds3
+
+FIDO Alliance MDS3 registry (FIDO2/CTAP2 hardware-key attestation trust)
+
+| YAML Key | Env Variable | Type | Description |
+|----------|-------------|------|-------------|
+| `fidomds3.enabled` | — | boolean |  |
+| `fidomds3.name` | — | string |  |
+| `fidomds3.description` | — | string |  |
+| `fidomds3.url` | — | string |  |
+| `fidomds3.fetch_timeout` | — | string |  |
+| `fidomds3.refresh_interval` | — | string |  |
+| `fidomds3.root_certificate_pem` | — | string |  |
+| `fidomds3.cache_path` | — | string | CachePath persists the raw MDS3 blob to disk so a restart doesn't have to block on (or fail because of) a live fetch - see fidomds3.Config.CachePath's doc for the load/refresh semantics. |
+
+## registries.always_trusted
+
+Static test registries
+
+| YAML Key | Env Variable | Type | Description |
+|----------|-------------|------|-------------|
+| `always_trusted.enabled` | — | boolean |  |
+| `always_trusted.name` | — | string |  |
+| `always_trusted.description` | — | string |  |
+
+## registries.never_trusted
+
+| YAML Key | Env Variable | Type | Description |
+|----------|-------------|------|-------------|
+| `never_trusted.enabled` | — | boolean |  |
+| `never_trusted.name` | — | string |  |
+| `never_trusted.description` | — | string |  |
+

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -7,11 +7,14 @@ sonar.organization=sirosfoundation
 # cannot be meaningfully unit-tested without the external systems they front.
 # Also excludes oidfed_registry.go which contains trust chain crypto verification
 # that requires real ECDSA-signed entity statements (tested by go-oidfed/lib and
-# integration tests rather than unit tests).
+# integration tests rather than unit tests). developer_tools/** is dev tooling
+# (e.g. the config-docs generator), not runtime logic — same exclusion as
+# go-wallet-backend's sonar-project.properties.
 sonar.coverage.exclusions=\
   **/register_stub.go,\
   **/*_stub.go,\
-  pkg/registry/oidfed/oidfed_registry.go
+  pkg/registry/oidfed/oidfed_registry.go,\
+  developer_tools/**
 
 # Exclude generated and test-support files from the overall analysis.
 sonar.exclusions=\


### PR DESCRIPTION
## Summary
- go-trust had no `docs/CONFIGURATION.md`, unlike its sibling repos (vc, go-wallet-backend), which both generate one from their config structs and check it in CI.
- Adds `developer_tools/scripts/gen_config_docs/main.go`, a small `go/ast`-based tool (same architecture as the sibling repos') that parses `pkg/config/config.go` and renders `docs/CONFIGURATION.md`.
- Adds `make gen-config-docs` and a new `config-docs` CI job in `go.yml` (regenerate, fail on `git diff`), matching the pattern already in vc/go-wallet-backend.

## A real difference from the sibling generators
vc and go-wallet-backend both use `envconfig` struct tags, so every field mechanically has a known environment variable name their generators can just print. go-trust has no such tags — `GT_*` overrides are hand-written in `applyEnvOverrides()` and only cover `Server`/`Logging`/`Security` (14 fields total). `Registries` and `Policies` have **no** environment variable override support at all.

Mechanically inventing something like `GT_REGISTRIES_ETSI_ENABLED` for a field that isn't actually overridable would be documenting something false. So this generator parses `applyEnvOverrides()`'s AST directly (matching each `os.Getenv("GT_X")` call to the `cfg.Y.Z = ...` assignment inside its guard) to build the real mapping, and renders `—` for every field that genuinely has no override — verified: exactly 14 env vars found, matching the 14 real `os.Getenv` calls.

Also: `registries` is one struct field on `Config` but really 11 independent registry types (ETSI, Whitelist, OIDFed, DID methods, LoTE, MDOC IACA, FIDO MDS3, static test registries) — expanded into its own per-registry section instead of one giant merged table.

## Test plan
- [x] `make gen-config-docs` — generates cleanly (15 sections, 100 fields, 14 env overrides found)
- [x] Confirmed output is deterministic (ran twice, byte-identical)
- [x] Spot-checked: real env vars (`GT_HOST`, `GT_TLS_ENABLED`, `GT_RATE_LIMIT_RPS`, ...) appear correctly against their fields; every Registries/Policies field correctly shows `—` (no fabricated env vars)
- [x] `go build ./...`, `gofmt -l`, `go vet` all clean; local golangci-lint pre-commit hook passed

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>