### PR TITLE
Wire brainpool curve support into the server binary's registry setup

### DIFF
--- a/cmd/gt/main.go
+++ b/cmd/gt/main.go
@@ -12,6 +12,8 @@ import (
 	"github.com/gin-gonic/gin"
 	oidfedjwx "github.com/go-oidfed/lib/jwx"
 	"github.com/sirosfoundation/g119612/pkg/logging"
+	gocryptoutil "github.com/sirosfoundation/go-cryptoutil"
+	"github.com/sirosfoundation/go-cryptoutil/brainpool"
 	_ "github.com/sirosfoundation/go-trust/docs/swagger" // Import generated docs
 	"github.com/sirosfoundation/go-trust/pkg/api"
 	"github.com/sirosfoundation/go-trust/pkg/config"
@@ -395,6 +397,15 @@ func main() {
 
 // configureRegistriesFromConfig configures registries from the loaded config file.
 func configureRegistriesFromConfig(cfg *config.Config, registryMgr *registry.RegistryManager, logger logging.Logger) {
+	// cryptoExt extends certificate parsing/signature verification beyond
+	// what crypto/x509 supports natively - currently brainpool curves, used
+	// by real-world root CAs (e.g. the Geneva 2026 interop event's RICAL/
+	// VICAL root) that stdlib's x509.ParseCertificate rejects outright with
+	// "unsupported elliptic curve". Shared across every registry below that
+	// accepts a CryptoExt field.
+	cryptoExt := gocryptoutil.New()
+	brainpool.Register(cryptoExt)
+
 	// Configure ETSI TSL registry from config
 	if cfg.Registries.ETSI != nil && cfg.Registries.ETSI.Enabled {
 		logger.Info("Configuring ETSI TSL registry from config file")
@@ -403,6 +414,7 @@ func configureRegistriesFromConfig(cfg *config.Config, registryMgr *registry.Reg
 		tslConfig := etsi.TSLConfig{
 			Name:             etsiCfg.Name,
 			Description:      etsiCfg.Description,
+			CryptoExt:        cryptoExt,
 			CertBundle:       etsiCfg.CertBundle,
 			TSLFiles:         etsiCfg.TSLFiles,
 			LOTLSignerBundle: etsiCfg.LOTLSignerBundle,
@@ -541,6 +553,7 @@ func configureRegistriesFromConfig(cfg *config.Config, registryMgr *registry.Reg
 			Description:        oidfedCfg.Description,
 			MaxCacheSize:       oidfedCfg.MaxCacheSize,
 			MaxChainDepth:      oidfedCfg.MaxChainDepth,
+			CryptoExt:          cryptoExt,
 		}
 
 		// Parse CacheTTL if provided
@@ -675,6 +688,7 @@ func configureRegistriesFromConfig(cfg *config.Config, registryMgr *registry.Reg
 			MaxDereferenceDepth: loteCfg.MaxDereferenceDepth,
 			VerifyJWS:           loteCfg.VerifyJWS,
 			Logger:              slog.Default(),
+			CryptoExt:           cryptoExt,
 		}
 
 		if loteCfg.FetchTimeout != "" {
@@ -722,6 +736,7 @@ func configureRegistriesFromConfig(cfg *config.Config, registryMgr *registry.Reg
 			Name:            mdocCfg.Name,
 			Description:     mdocCfg.Description,
 			IssuerAllowlist: mdocCfg.IssuerAllowlist,
+			CryptoExt:       cryptoExt,
 		}
 
 		// Parse CacheTTL if provided
@@ -767,6 +782,7 @@ func configureRegistriesFromConfig(cfg *config.Config, registryMgr *registry.Reg
 			Description:             ricalCfg.Description,
 			RicalProviderURL:        ricalCfg.RicalProviderURL,
 			RicalRootCertificatePEM: ricalCfg.RicalRootCertificatePEM,
+			CryptoExt:               cryptoExt,
 		}
 
 		if ricalCfg.CacheTTL != "" {
@@ -810,6 +826,7 @@ func configureRegistriesFromConfig(cfg *config.Config, registryMgr *registry.Reg
 			Description:             vicalCfg.Description,
 			VicalProviderURL:        vicalCfg.VicalProviderURL,
 			VicalRootCertificatePEM: vicalCfg.VicalRootCertificatePEM,
+			CryptoExt:               cryptoExt,
 		}
 
 		if vicalCfg.CacheTTL != "" {

--- a/go.mod
+++ b/go.mod
@@ -49,6 +49,7 @@ require (
 	github.com/decred/dcrd/dcrec/secp256k1/v4 v4.4.1 // indirect
 	github.com/fatih/structs v1.1.0 // indirect
 	github.com/gabriel-vasile/mimetype v1.4.13 // indirect
+	github.com/gematik/zero-lab/go/brainpool v0.0.0-20260309133150-5b2b80ad6517 // indirect
 	github.com/gin-contrib/sse v1.1.1 // indirect
 	github.com/go-jose/go-jose/v4 v4.1.4 // indirect
 	github.com/go-json-experiment/json v0.0.0-20260601182631-00ed12fed2a6 // indirect
@@ -115,6 +116,7 @@ require (
 	github.com/scylladb/go-set v1.0.3-0.20200225121959-cc7b2070d91e // indirect
 	github.com/segmentio/asm v1.2.1 // indirect
 	github.com/shopspring/decimal v1.4.0 // indirect
+	github.com/sirosfoundation/go-cryptoutil/brainpool v0.2.0 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/skip2/go-qrcode v0.0.0-20200617195104-da1b6568686e // indirect
 	github.com/twitchyliquid64/golang-asm v0.15.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -84,6 +84,8 @@ github.com/fxamacker/cbor/v2 v2.9.2 h1:X4Ksno9+x3cz0TZv69ec1hxP/+tymuR8PXQJyDwfh
 github.com/fxamacker/cbor/v2 v2.9.2/go.mod h1:vM4b+DJCtHn+zz7h3FFp/hDAI9WNWCsZj23V5ytsSxQ=
 github.com/gabriel-vasile/mimetype v1.4.13 h1:46nXokslUBsAJE/wMsp5gtO500a4F3Nkz9Ufpk2AcUM=
 github.com/gabriel-vasile/mimetype v1.4.13/go.mod h1:d+9Oxyo1wTzWdyVUPMmXFvp4F9tea18J8ufA774AB3s=
+github.com/gematik/zero-lab/go/brainpool v0.0.0-20260309133150-5b2b80ad6517 h1:3SRQAONsFs3YkkmSenc3t37Hxt030LXEhY1xDU6hZT0=
+github.com/gematik/zero-lab/go/brainpool v0.0.0-20260309133150-5b2b80ad6517/go.mod h1:TaeFLI1a/MDVsD8s9QcvIBigMUB6TrwjTW07mjrfhek=
 github.com/gin-contrib/gzip v1.2.6 h1:OtN8DplD5DNZCSLAnQ5HxRkD2qZ5VU+JhOrcfJrcRvg=
 github.com/gin-contrib/gzip v1.2.6/go.mod h1:BQy8/+JApnRjAVUplSGZiVtD2k8GmIE2e9rYu/hLzzU=
 github.com/gin-contrib/sse v1.1.1 h1:uGYpNwTacv5R68bSGMapo62iLTRa9l5zxGCps4hK6ko=
@@ -329,6 +331,8 @@ github.com/sirosfoundation/g119612 v0.5.0 h1:A7P7NWhmHfS/7yewPQqI/x/7qen/raj+u78
 github.com/sirosfoundation/g119612 v0.5.0/go.mod h1:jdXmmDpNoh19SLKuNXC1STHKU9f5BPUoCYCnZ1w+DOo=
 github.com/sirosfoundation/go-cryptoutil v0.5.0 h1:ByKuNjHSdlvkOzGeElh0QAku36iuymqLVvBLMY4x5as=
 github.com/sirosfoundation/go-cryptoutil v0.5.0/go.mod h1:OZi673Xmf5o2LzF/QMceptIpiB2GKYAYBfEa75ocBss=
+github.com/sirosfoundation/go-cryptoutil/brainpool v0.2.0 h1:tLBZFdBAloNDwP2j87MRW0W/ujrj+EbVylrkWAIHON4=
+github.com/sirosfoundation/go-cryptoutil/brainpool v0.2.0/go.mod h1:h5sFbD8z/TLv+MziA97+UOXwDEN3drSYheRM5X9yaBE=
 github.com/sirosfoundation/signedxml v1.4.0-siros1 h1:+d+j6AQxu9CNylGkmPbUAUdEYny6gvXZxFnuvrPViHk=
 github.com/sirosfoundation/signedxml v1.4.0-siros1/go.mod h1:qXhLkLQ7B8fg9YSTqBmWSynY9tkkEx2QsIBjMeJTGcM=
 github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=


### PR DESCRIPTION
## Summary
- `cmd/gt/main.go` never constructed or passed a `CryptoExt` to any registry, despite `mdociaca`/`mdocrical`/`vical`/`lote`/`etsi`/`oidfed` all accepting one for exactly this purpose (real-world CAs using non-NIST curves like brainpool, which `crypto/x509` rejects outright with `x509: unsupported elliptic curve`).
- Found live: the Geneva 2026 interop event's real RICAL/VICAL root certificate uses `brainpoolP256r1` and crash-looped the PDP on boot (`logger.Fatal` in `mdocrical.New()`/`vical.New()`) once wired up against it in the gdc test environment.
- Constructs one shared `gocryptoutil.Extensions` with `brainpool.Register()` at the top of `configureRegistriesFromConfig` and threads it into all six registries' `Config.CryptoExt`.

## Test plan
- [x] `go build ./...`, `go vet ./...`, `gofmt -l` all clean
- [x] Full `go test ./...` passes
- [x] Standalone repro: `x509.ParseCertificate` fails on the real Geneva root cert with `unsupported elliptic curve`; `gocryptoutil.New()` + `brainpool.Register()` parses it successfully (subject: `Trusted Lists Root CA Certificate Geneva 2026`)
- [x] Live-verified against gdc Fly environment after this fix: PDP boots cleanly with the real RICAL/VICAL registries configured against `geneva2026.mdoc.online`'s trust lists

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01J9zyFYobKY92mLBKMMrYsQ