### PR TITLE
Opt in to AI-generated release notes

### DIFF
--- a/.github/workflows/release-notes.yml
+++ b/.github/workflows/release-notes.yml
@@ -1,0 +1,53 @@
+# Opt a repo into AI-generated release notes.
+#
+# Copy to .github/workflows/release-notes.yml in the repo, and make sure the
+# siros-release-notes-bot GitHub App is installed on it.
+#
+# Carries no secrets: the OIDC token is minted per-run by GitHub, and every
+# real credential lives on the service.
+name: Release Notes
+
+on:
+  push:
+    tags: ['v[0-9]+.[0-9]+.[0-9]+*']
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to (re)generate. Required for mode=single, ignored for mode=all.'
+        required: false
+      mode:
+        description: 'single = one tag; all = bootstrap the whole file (refuses if it already exists)'
+        type: choice
+        options: [single, all]
+        default: single
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  request:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Request release notes
+        env:
+          TAG: ${{ inputs.tag || github.ref_name }}
+          MODE: ${{ inputs.mode || 'single' }}
+        run: |
+          set -euo pipefail
+
+          OIDC_TOKEN=$(curl -sS \
+            -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=release-notes-bot" \
+            | jq -r '.value')
+
+          curl -sS --fail-with-body -X POST \
+            https://release-notes-bot.fly.dev/generate \
+            -H "Authorization: Bearer $OIDC_TOKEN" \
+            -H 'Content-Type: application/json' \
+            -d "$(jq -nc \
+                  --arg repo "$GITHUB_REPOSITORY" \
+                  --arg tag "$TAG" \
+                  --arg mode "$MODE" \
+                  '{repo: $repo, tag: $tag, mode: $mode}')" \
+            | tee /dev/stderr | jq -r '.pull_request // .detail // .'


### PR DESCRIPTION
## Summary
Adds the wrapper workflow for [sirosfoundation/release-notes-bot](https://github.com/sirosfoundation/release-notes-bot) (private repo). On a semver tag push (or manual `workflow_dispatch`), it mints a GitHub Actions OIDC token and POSTs to the service — the service does everything else: gathers PR/commit context for the release, calls an LLM to write the notes, and opens a PR that appends (or, if explicitly re-run for that tag, replaces) just that tag's section in `RELEASE_NOTES.md`. Every other tag's section — including any hand edits — is left byte-for-byte untouched.

No secrets live in this repo. The OIDC token is what proves the request comes from this repo's own CI; the service verifies it against GitHub's own signing keys and checks the token's `repository` claim matches.

The `siros-release-notes-bot` GitHub App is already installed on this repo (Contents: write, Pull requests: write only).

## Next step after merge
Manually dispatch this workflow once with `mode: all` to bootstrap `RELEASE_NOTES.md` from the ~25 existing tags — that PR will need a careful review before merging since it's the one case that writes the whole file.

## Test plan
- [x] Service deployed and health-checked (`https://release-notes-bot.fly.dev/health`)
- [x] Confirmed unauthenticated and garbage-token requests are rejected (422/403) against the live service
- [x] Confirmed the GitHub App is installed on this repo

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>