### PR TITLE
fix: read organizationIdentifier from 2.5.4.97, not serialNumber

### DIFF
--- a/pkg/registry/rpcert/wrpac.go
+++ b/pkg/registry/rpcert/wrpac.go
@@ -181,14 +181,23 @@ func (p *WRPACProfile) ExtractIdentity(credential interface{}) (map[string]inter
 	// Start with the shared base identity (org, CN, country, SANs, policy_oids, validity, etc.)
 	identity := ExtractBaseCertIdentity(cert)
 
-	// WRPAC-specific: rename serial_number to organization_identifier
-	if cert.Subject.SerialNumber != "" {
-		identity["organization_identifier"] = cert.Subject.SerialNumber
+	// WRPAC-specific: surface the organisation identifier.
+	//
+	// EN 319 412-3 clause 4.2.1 puts it in organizationIdentifier
+	// (2.5.4.97), which Go does not model on pkix.Name - it only appears in
+	// Subject.Names, so it has to be read out by OID. Fall back to
+	// serialNumber (2.5.4.5), which earlier certificates and test fixtures
+	// used, so both continue to resolve.
+	if orgID := SubjectOrganizationIdentifier(cert); orgID != "" {
+		identity["organization_identifier"] = orgID
 		delete(identity, "serial_number")
 	}
 
-	// Determine subject type (natural vs legal person)
-	if len(cert.Subject.Organization) > 0 && cert.Subject.SerialNumber != "" {
+	// Determine subject type (natural vs legal person). Keyed off the same
+	// organisation identifier as above - reading Subject.SerialNumber
+	// directly classified a conformant legal-person certificate, which
+	// carries the value in 2.5.4.97, as a natural person.
+	if len(cert.Subject.Organization) > 0 && SubjectOrganizationIdentifier(cert) != "" {
 		identity["subject_type"] = "legal_person"
 	} else {
 		identity["subject_type"] = "natural_person"
@@ -294,4 +303,33 @@ func (p *WRPACProfile) ValidateCredential(credential interface{}) error {
 	}
 
 	return nil
+}
+
+// oidOrganizationIdentifier is organizationIdentifier per EN 319 412-1
+// clause 5.1.4, the attribute EN 319 412-3 clause 4.2.1 requires in the
+// subject DN of a legal-person certificate.
+var oidOrganizationIdentifier = asn1.ObjectIdentifier{2, 5, 4, 97}
+
+// SubjectOrganizationIdentifier returns the certificate's
+// organizationIdentifier (2.5.4.97), falling back to serialNumber (2.5.4.5)
+// when the former is absent.
+//
+// Go's pkix.Name has no field for organizationIdentifier, so a certificate
+// that carries it correctly exposes it only through Subject.Names. Reading
+// Subject.SerialNumber alone therefore reports nothing for a conformant
+// WRPAC while appearing to work against fixtures that put the value in
+// serialNumber instead - which is why the fallback stays.
+func SubjectOrganizationIdentifier(cert *x509.Certificate) string {
+	if cert == nil {
+		return ""
+	}
+	for _, atv := range cert.Subject.Names {
+		if !atv.Type.Equal(oidOrganizationIdentifier) {
+			continue
+		}
+		if v, ok := atv.Value.(string); ok && v != "" {
+			return v
+		}
+	}
+	return cert.Subject.SerialNumber
 }

--- a/pkg/registry/rpcert/wrpac.go
+++ b/pkg/registry/rpcert/wrpac.go
@@ -188,7 +188,8 @@ func (p *WRPACProfile) ExtractIdentity(credential interface{}) (map[string]inter
 	// Subject.Names, so it has to be read out by OID. Fall back to
 	// serialNumber (2.5.4.5), which earlier certificates and test fixtures
 	// used, so both continue to resolve.
-	if orgID := SubjectOrganizationIdentifier(cert); orgID != "" {
+	orgID := SubjectOrganizationIdentifier(cert)
+	if orgID != "" {
 		identity["organization_identifier"] = orgID
 		delete(identity, "serial_number")
 	}
@@ -196,8 +197,9 @@ func (p *WRPACProfile) ExtractIdentity(credential interface{}) (map[string]inter
 	// Determine subject type (natural vs legal person). Keyed off the same
 	// organisation identifier as above - reading Subject.SerialNumber
 	// directly classified a conformant legal-person certificate, which
-	// carries the value in 2.5.4.97, as a natural person.
-	if len(cert.Subject.Organization) > 0 && SubjectOrganizationIdentifier(cert) != "" {
+	// carries the value in 2.5.4.97, as a natural person. Reusing the one
+	// value keeps the two decisions from ever disagreeing.
+	if len(cert.Subject.Organization) > 0 && orgID != "" {
 		identity["subject_type"] = "legal_person"
 	} else {
 		identity["subject_type"] = "natural_person"

--- a/pkg/registry/rpcert/wrpac_orgid_test.go
+++ b/pkg/registry/rpcert/wrpac_orgid_test.go
@@ -1,0 +1,116 @@
+package rpcert
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/asn1"
+	"math/big"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// newSubjectCert mints a certificate whose subject DN carries exactly the
+// attributes given, so each test controls which of the two the value lives in.
+func newSubjectCert(t *testing.T, serialNumber string, extra []pkix.AttributeTypeAndValue) *x509.Certificate {
+	t.Helper()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	require.NoError(t, err)
+
+	tmpl := &x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject: pkix.Name{
+			CommonName:   "rp.example.com",
+			Organization: []string{"Example RP"},
+			SerialNumber: serialNumber,
+			ExtraNames:   extra,
+		},
+		NotBefore: time.Now().Add(-time.Hour),
+		NotAfter:  time.Now().Add(time.Hour),
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	require.NoError(t, err)
+	cert, err := x509.ParseCertificate(der)
+	require.NoError(t, err)
+	return cert
+}
+
+func orgIDAttr(v string) []pkix.AttributeTypeAndValue {
+	return []pkix.AttributeTypeAndValue{{
+		Type:  asn1.ObjectIdentifier{2, 5, 4, 97},
+		Value: v,
+	}}
+}
+
+// TestSubjectOrganizationIdentifier covers where the value may live.
+//
+// EN 319 412-3 clause 4.2.1 requires organizationIdentifier (2.5.4.97) for a
+// legal person. Go's pkix.Name has no field for it, so it surfaces only in
+// Subject.Names — reading Subject.SerialNumber instead returns nothing for a
+// conformant certificate while still appearing to work against fixtures that
+// put the value in serialNumber.
+func TestSubjectOrganizationIdentifier(t *testing.T) {
+	t.Run("reads organizationIdentifier 2.5.4.97", func(t *testing.T) {
+		cert := newSubjectCert(t, "", orgIDAttr("VATSE-5560000000"))
+		assert.Equal(t, "VATSE-5560000000", SubjectOrganizationIdentifier(cert))
+	})
+
+	t.Run("falls back to serialNumber when 2.5.4.97 is absent", func(t *testing.T) {
+		cert := newSubjectCert(t, "NTRSE-1234567890", nil)
+		assert.Equal(t, "NTRSE-1234567890", SubjectOrganizationIdentifier(cert))
+	})
+
+	t.Run("prefers organizationIdentifier when both are present", func(t *testing.T) {
+		// siros-wrpac-tool currently writes both so the two readings agree.
+		// Once this ships, the conformant attribute is authoritative and that
+		// dual write can be dropped.
+		cert := newSubjectCert(t, "serial-value", orgIDAttr("orgid-value"))
+		assert.Equal(t, "orgid-value", SubjectOrganizationIdentifier(cert))
+	})
+
+	t.Run("neither present", func(t *testing.T) {
+		assert.Empty(t, SubjectOrganizationIdentifier(newSubjectCert(t, "", nil)))
+	})
+
+	t.Run("nil certificate", func(t *testing.T) {
+		assert.Empty(t, SubjectOrganizationIdentifier(nil))
+	})
+}
+
+// TestExtractIdentity_OrganizationIdentifier is the regression that matters:
+// a conformant WRPAC must yield an organization_identifier, because the
+// WRPAC-to-WRPRC binding check (ARF RPRC_16) compares against it. Reading the
+// wrong attribute made a valid certificate look like one carrying no
+// identifier at all.
+func TestExtractIdentity_OrganizationIdentifier(t *testing.T) {
+	profile := NewWRPACProfile()
+
+	t.Run("conformant certificate yields the identifier", func(t *testing.T) {
+		cert := newSubjectCert(t, "", orgIDAttr("VATSE-5560000000"))
+		identity, err := profile.ExtractIdentity(cert)
+		require.NoError(t, err)
+		assert.Equal(t, "VATSE-5560000000", identity["organization_identifier"])
+		assert.NotContains(t, identity, "serial_number",
+			"the identifier is reported once, under its own name")
+	})
+
+	t.Run("legacy serialNumber-only certificate still resolves", func(t *testing.T) {
+		cert := newSubjectCert(t, "NTRSE-1234567890", nil)
+		identity, err := profile.ExtractIdentity(cert)
+		require.NoError(t, err)
+		assert.Equal(t, "NTRSE-1234567890", identity["organization_identifier"])
+	})
+
+	t.Run("subject_type is legal_person when an organisation is present", func(t *testing.T) {
+		cert := newSubjectCert(t, "", orgIDAttr("VATSE-5560000000"))
+		identity, err := profile.ExtractIdentity(cert)
+		require.NoError(t, err)
+		assert.Equal(t, "legal_person", identity["subject_type"])
+	})
+}


### PR DESCRIPTION
First piece of track A1, split out because it is small, independent, and blocks correctness elsewhere.

## The bug

EN 319 412-3 clause 4.2.1 requires **organizationIdentifier (2.5.4.97)** in the subject DN of a legal-person certificate. `WRPACProfile.ExtractIdentity` read **`Subject.SerialNumber` (2.5.4.5)** and reported it as `organization_identifier`. Before this change, `2.5.4.97` appeared **nowhere in the package**.

Go's `pkix.Name` has no field for organizationIdentifier, so a conformant certificate exposes it only via `Subject.Names`. That is why this stayed invisible: fixtures that put the value in `serialNumber` worked fine, and only a real certificate would expose the gap.

## Why it matters

Two consequences, both silent:

- **ARF RPRC_16 binding.** The WRPAC↔WRPRC check compares against this identifier, so a valid certificate read as one carrying *none*. In SUNET/vc#614 that surfaces as "cannot enforce the access-certificate binding because the access certificate carries no organisation identifier" — for a certificate that has one.
- **`subject_type` misclassification.** It keyed off the same field, so a conformant **legal person** was classified **natural person**. That feeds the NCP-l versus NCP-n policy distinction. This one was caught by writing the test against a properly-formed certificate rather than a fixture.

## The change

`SubjectOrganizationIdentifier(cert)` reads 2.5.4.97 from `Subject.Names`, falling back to `serialNumber`. Both readings resolve, so nothing that works today stops working — this is additive in effect as well as in API.

It follows the `Subject.Names` traversal pattern #110 introduced for the service-identifier OID.

## Tests

Cover each place the value may live: 2.5.4.97 only, serialNumber only, both present (2.5.4.97 wins), neither, and nil. Plus `ExtractIdentity` against a conformant certificate, a legacy one, and the `subject_type` classification.

## Note for siros-wrpac-tool

The tool currently writes the value to **both** attributes so the two readings agree. That workaround can be dropped once this ships — the conformant attribute is now authoritative.