### PR TITLE
feat(rpcert): surface revocation references and own the decision

### DIFF
--- a/pkg/registry/rpcert/doc.go
+++ b/pkg/registry/rpcert/doc.go
@@ -89,12 +89,21 @@
 //
 // # What is not here
 //
-// No signature verification, no network access, and no revocation fetching.
-// Revocation of these certificates is real and currently unimplemented
-// everywhere in the stack - a WRPAC is revoked through a CRL or OCSP, a
-// WRPRC through the Token Status List referenced by
-// RPEntitlements.StatusListURI and StatusListIndex. This package surfaces
-// those references so a caller can act on them; it does not fetch them.
+// No signature verification and no network access.
+//
+// Revocation follows the same split. A WRPAC is revoked through a CRL or
+// OCSP; a WRPRC through the Token Status List named in its own status
+// claim. This package says where to look - CRLDistributionPoints,
+// OCSPResponders, RPEntitlements.StatusReference - and decides what an
+// answer means, through RevocationMode.Evaluate. It does not fetch: the
+// caller supplies a StatusListChecker or CertRevocationChecker, the same
+// way key resolvers are injected elsewhere here.
+//
+// The distinction that matters in that decision is between "revoked" and
+// "could not determine". An unreachable list is not evidence that a
+// certificate is valid, and collapsing the two is how a fetch failure
+// quietly becomes a pass - so RevocationUndetermined is its own state, and
+// RevocationWarn reports it while still proceeding.
 //
 // # References
 //

--- a/pkg/registry/rpcert/revocation.go
+++ b/pkg/registry/rpcert/revocation.go
@@ -1,0 +1,222 @@
+// Revocation references and the decision that acts on them.
+//
+// Three unrelated things are called "revocation" in this ecosystem, and
+// conflating them is the easiest way to build the wrong one:
+//
+//   - An access certificate (WRPAC) is revoked through an X.509 CRL or OCSP.
+//   - A registration certificate (WRPRC) is revoked through the IETF Token
+//     Status List referenced by its own status claim.
+//   - An issued credential is revoked through its own status list, which has
+//     nothing to do with either of the above.
+//
+// This file covers the first two. It surfaces where to look and decides what
+// an answer means; it does not fetch anything. go-trust performs no I/O, so
+// the caller supplies a checker - the same shape as the injected key
+// resolvers used elsewhere in this repository.
+
+package rpcert
+
+import (
+	"context"
+	"crypto/x509"
+	"fmt"
+	"net/url"
+)
+
+// RevocationState is what a checker found out about a certificate.
+//
+// Undetermined is a distinct outcome rather than a flavour of Good on
+// purpose. An unreachable CRL is not evidence that a certificate is valid,
+// and collapsing the two is precisely how a fetch failure quietly becomes a
+// pass.
+type RevocationState string
+
+const (
+	// RevocationGood means the responder was reached and did not list the
+	// certificate as revoked.
+	RevocationGood RevocationState = "good"
+
+	// RevocationRevoked means the responder listed the certificate as
+	// revoked.
+	RevocationRevoked RevocationState = "revoked"
+
+	// RevocationUndetermined means no answer was obtained - the list was
+	// unreachable, malformed, untrusted, or the certificate carried no
+	// revocation reference at all.
+	RevocationUndetermined RevocationState = "undetermined"
+)
+
+// RevocationMode is how a deployment wants an outcome treated.
+type RevocationMode string
+
+const (
+	// RevocationOff performs no check. Every state is allowed.
+	RevocationOff RevocationMode = "off"
+
+	// RevocationWarn allows every state but reports a reason for anything
+	// other than Good. This is the appropriate default: a Registrar outage
+	// should not become our outage.
+	RevocationWarn RevocationMode = "warn"
+
+	// RevocationFail rejects both Revoked and Undetermined. Undetermined is
+	// rejected because a deployment choosing this mode has said it would
+	// rather stop than proceed without an answer.
+	RevocationFail RevocationMode = "fail"
+)
+
+// Valid reports whether m is a recognised mode.
+func (m RevocationMode) Valid() bool {
+	switch m {
+	case RevocationOff, RevocationWarn, RevocationFail:
+		return true
+	}
+	return false
+}
+
+// RevocationDecision is the outcome of applying a mode to a state.
+//
+// Allowed and Reason are separate because "allowed, but you should know
+// about this" is a real and common outcome under RevocationWarn. A caller
+// that only reads Allowed silently discards the warning, so Reason is
+// populated whenever there is anything to say.
+type RevocationDecision struct {
+	// State is the state the decision was made about.
+	State RevocationState
+	// Allowed reports whether the certificate may be used.
+	Allowed bool
+	// Reason is a human-readable explanation, empty only when the state was
+	// Good or the mode was Off.
+	Reason string
+}
+
+// Evaluate applies the mode to a checker's finding.
+//
+// An unknown mode is treated as RevocationWarn rather than silently allowing
+// everything: a typo in configuration should not disable a check without
+// saying so.
+func (m RevocationMode) Evaluate(state RevocationState, subject string) RevocationDecision {
+	if subject == "" {
+		subject = "certificate"
+	}
+	if m == RevocationOff {
+		return RevocationDecision{State: state, Allowed: true}
+	}
+	strict := m == RevocationFail
+
+	switch state {
+	case RevocationGood:
+		return RevocationDecision{State: state, Allowed: true}
+	case RevocationRevoked:
+		return RevocationDecision{
+			State:   state,
+			Allowed: !strict,
+			Reason:  fmt.Sprintf("%s has been revoked", subject),
+		}
+	default:
+		return RevocationDecision{
+			State:   RevocationUndetermined,
+			Allowed: !strict,
+			Reason: fmt.Sprintf("could not determine whether %s has been revoked; "+
+				"this is not evidence that it is valid", subject),
+		}
+	}
+}
+
+// StatusReference locates one entry in an IETF Token Status List - the
+// mechanism a WRPRC is revoked through (TS 119 475 Table 7, `status`).
+type StatusReference struct {
+	// URI is where the status list is published.
+	URI string
+	// Index is this certificate's position within that list.
+	Index int
+}
+
+// StatusReference returns the WRPRC's Token Status List entry, and whether
+// the certificate carried one.
+//
+// A WRPRC without a status reference is not revocable at all, which callers
+// should treat as Undetermined rather than Good - see RevocationMode.
+func (e *RPEntitlements) StatusReference() (StatusReference, bool) {
+	if e == nil || e.StatusListURI == "" {
+		return StatusReference{}, false
+	}
+	return StatusReference{URI: e.StatusListURI, Index: e.StatusListIndex}, true
+}
+
+// StatusListChecker resolves a Token Status List entry to a state.
+//
+// go-trust defines the shape and interprets the answer; the implementation -
+// fetching, caching, verifying the status list's own signature - belongs to
+// the caller, which is the layer that owns network policy.
+type StatusListChecker interface {
+	CheckStatus(ctx context.Context, ref StatusReference) (RevocationState, error)
+}
+
+// CertRevocationChecker resolves an X.509 certificate to a state, through
+// whichever of CRL or OCSP the caller implements.
+type CertRevocationChecker interface {
+	CheckCertificate(ctx context.Context, cert *x509.Certificate) (RevocationState, error)
+}
+
+// CRLDistributionPoints returns the HTTP(S) CRL distribution point URLs from
+// a certificate, in order and without duplicates.
+//
+// Only http and https are returned. A CRL published over ldap or through a
+// directoryName general name is not something a caller here can fetch, and
+// returning one would produce an Undetermined result that looks like a
+// fetch failure rather than an unsupported scheme.
+//
+// An empty result means the certificate cannot be checked this way, which is
+// Undetermined - not Good.
+func CRLDistributionPoints(cert *x509.Certificate) []string {
+	if cert == nil {
+		return nil
+	}
+	seen := make(map[string]bool, len(cert.CRLDistributionPoints))
+	var out []string
+	for _, dp := range cert.CRLDistributionPoints {
+		if seen[dp] {
+			continue
+		}
+		u, err := url.Parse(dp)
+		if err != nil {
+			continue
+		}
+		switch u.Scheme {
+		case "http", "https":
+		default:
+			continue
+		}
+		seen[dp] = true
+		out = append(out, dp)
+	}
+	return out
+}
+
+// OCSPResponders returns the OCSP responder URLs from a certificate, in
+// order and without duplicates. Same scheme restriction as
+// CRLDistributionPoints.
+func OCSPResponders(cert *x509.Certificate) []string {
+	if cert == nil {
+		return nil
+	}
+	seen := make(map[string]bool, len(cert.OCSPServer))
+	var out []string
+	for _, s := range cert.OCSPServer {
+		if seen[s] {
+			continue
+		}
+		u, err := url.Parse(s)
+		if err != nil {
+			continue
+		}
+		switch u.Scheme {
+		case "http", "https":
+		default:
+			continue
+		}
+		seen[s] = true
+		out = append(out, s)
+	}
+	return out
+}

--- a/pkg/registry/rpcert/revocation_test.go
+++ b/pkg/registry/rpcert/revocation_test.go
@@ -1,0 +1,192 @@
+package rpcert
+
+import (
+	"crypto/x509"
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestRevocationMode_Evaluate is the table that matters most here: the
+// difference between "revoked" and "could not determine", and the fact that
+// warn allows both while still reporting them.
+func TestRevocationMode_Evaluate(t *testing.T) {
+	tests := []struct {
+		name        string
+		mode        RevocationMode
+		state       RevocationState
+		wantAllowed bool
+		wantReason  bool
+	}{
+		{"off ignores revoked", RevocationOff, RevocationRevoked, true, false},
+		{"off ignores undetermined", RevocationOff, RevocationUndetermined, true, false},
+		{"off allows good", RevocationOff, RevocationGood, true, false},
+
+		{"warn allows good silently", RevocationWarn, RevocationGood, true, false},
+		{"warn allows revoked but reports", RevocationWarn, RevocationRevoked, true, true},
+		{"warn allows undetermined but reports", RevocationWarn, RevocationUndetermined, true, true},
+
+		{"fail allows good", RevocationFail, RevocationGood, true, false},
+		{"fail rejects revoked", RevocationFail, RevocationRevoked, false, true},
+		{"fail rejects undetermined", RevocationFail, RevocationUndetermined, false, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			d := tt.mode.Evaluate(tt.state, "the access certificate")
+			assert.Equal(t, tt.wantAllowed, d.Allowed)
+			assert.Equal(t, tt.wantReason, d.Reason != "", "reason presence")
+			if tt.mode != RevocationOff {
+				assert.Equal(t, tt.state, d.State)
+			}
+		})
+	}
+}
+
+// TestRevocationMode_UndeterminedIsNotAPass pins the distinction the whole
+// type exists for: an unreachable list must never read as valid.
+func TestRevocationMode_UndeterminedIsNotAPass(t *testing.T) {
+	d := RevocationWarn.Evaluate(RevocationUndetermined, "the registration certificate")
+	assert.True(t, d.Allowed, "warn mode proceeds")
+	assert.Contains(t, d.Reason, "not evidence that it is valid")
+	assert.NotEqual(t, RevocationGood, d.State)
+}
+
+// TestRevocationMode_UnknownModeIsNotOff covers a configuration typo: it
+// must not silently disable the check.
+func TestRevocationMode_UnknownModeIsNotOff(t *testing.T) {
+	d := RevocationMode("warnn").Evaluate(RevocationRevoked, "cert")
+	assert.NotEmpty(t, d.Reason, "an unrecognised mode must still report")
+	assert.False(t, RevocationMode("warnn").Valid())
+
+	for _, m := range []RevocationMode{RevocationOff, RevocationWarn, RevocationFail} {
+		assert.True(t, m.Valid(), string(m))
+	}
+}
+
+func TestRevocationMode_EvaluateDefaultSubject(t *testing.T) {
+	d := RevocationFail.Evaluate(RevocationRevoked, "")
+	assert.Contains(t, d.Reason, "certificate has been revoked")
+}
+
+// ---------------------------------------------------------------------------
+// Status references
+// ---------------------------------------------------------------------------
+
+func TestRPEntitlements_StatusReference(t *testing.T) {
+	t.Run("present", func(t *testing.T) {
+		ent := &RPEntitlements{StatusListURI: "https://registrar.example/status", StatusListIndex: 42}
+		ref, ok := ent.StatusReference()
+		require.True(t, ok)
+		assert.Equal(t, "https://registrar.example/status", ref.URI)
+		assert.Equal(t, 42, ref.Index)
+	})
+
+	t.Run("absent", func(t *testing.T) {
+		_, ok := (&RPEntitlements{}).StatusReference()
+		assert.False(t, ok)
+	})
+
+	t.Run("index zero is a real index", func(t *testing.T) {
+		ent := &RPEntitlements{StatusListURI: "https://registrar.example/status", StatusListIndex: 0}
+		ref, ok := ent.StatusReference()
+		require.True(t, ok, "index 0 is the first slot, not a missing reference")
+		assert.Equal(t, 0, ref.Index)
+	})
+
+	t.Run("nil receiver", func(t *testing.T) {
+		var ent *RPEntitlements
+		_, ok := ent.StatusReference()
+		assert.False(t, ok)
+	})
+}
+
+// TestStatusReference_FromSandboxCertificate wires the parser to the
+// revocation reference, against the real Registrar-issued fixture.
+func TestStatusReference_FromSandboxCertificate(t *testing.T) {
+	token, err := os.ReadFile("testdata/german-sandbox-wrprc.jwt")
+	require.NoError(t, err)
+	payload, err := ParseWRPRCJWTPayload(string(token))
+	require.NoError(t, err)
+	ent, err := ParseWRPRCClaims(payload)
+	require.NoError(t, err)
+
+	ref, ok := ent.StatusReference()
+	require.True(t, ok)
+	assert.Equal(t, "https://sandbox.eudi-wallet.org/api/status-management/status-list", ref.URI)
+	assert.Equal(t, 9940, ref.Index)
+}
+
+// ---------------------------------------------------------------------------
+// Certificate revocation endpoints
+// ---------------------------------------------------------------------------
+
+func TestCRLDistributionPoints(t *testing.T) {
+	tests := []struct {
+		name string
+		in   []string
+		want []string
+	}{
+		{
+			name: "https and http are returned in order",
+			in:   []string{"https://ca.example/crl", "http://ca.example/other.crl"},
+			want: []string{"https://ca.example/crl", "http://ca.example/other.crl"},
+		},
+		{
+			name: "duplicates collapse",
+			in:   []string{"https://ca.example/crl", "https://ca.example/crl"},
+			want: []string{"https://ca.example/crl"},
+		},
+		{
+			name: "ldap is dropped as unfetchable",
+			in:   []string{"ldap://ca.example/cn=crl", "https://ca.example/crl"},
+			want: []string{"https://ca.example/crl"},
+		},
+		{
+			name: "only unfetchable schemes yields nothing",
+			in:   []string{"ldap://ca.example/cn=crl"},
+			want: nil,
+		},
+		{
+			name: "no distribution points",
+			in:   nil,
+			want: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cert := &x509.Certificate{CRLDistributionPoints: tt.in}
+			assert.Equal(t, tt.want, CRLDistributionPoints(cert))
+		})
+	}
+
+	t.Run("nil certificate", func(t *testing.T) {
+		assert.Nil(t, CRLDistributionPoints(nil))
+	})
+}
+
+func TestOCSPResponders(t *testing.T) {
+	cert := &x509.Certificate{OCSPServer: []string{
+		"http://ocsp.example", "http://ocsp.example", "ldap://ocsp.example",
+	}}
+	assert.Equal(t, []string{"http://ocsp.example"}, OCSPResponders(cert))
+	assert.Nil(t, OCSPResponders(nil))
+	assert.Nil(t, OCSPResponders(&x509.Certificate{}))
+}
+
+// TestNoRevocationEndpointsIsUndetermined records the intended reading of an
+// empty result, which is the whole reason these helpers return a list rather
+// than a bool.
+func TestNoRevocationEndpointsIsUndetermined(t *testing.T) {
+	cert := &x509.Certificate{}
+	require.Empty(t, CRLDistributionPoints(cert))
+	require.Empty(t, OCSPResponders(cert))
+
+	// A certificate that cannot be checked is undetermined, not good - and
+	// under fail mode that is a rejection.
+	assert.False(t, RevocationFail.Evaluate(RevocationUndetermined, "the access certificate").Allowed)
+	assert.True(t, RevocationWarn.Evaluate(RevocationUndetermined, "the access certificate").Allowed)
+}


### PR DESCRIPTION
Stacked on #139 — review that first; this PR shows only the delta and will retarget to `main` automatically when #139 merges.

## Why

A WRPAC is revoked through an X.509 CRL or OCSP. A WRPRC is revoked through the IETF Token Status List named in its own `status` claim. Issued credentials use a status list too, and are unrelated to both — conflating the three is the easiest way to build the wrong one.

Nothing in the stack checks either certificate today, so **a revoked certificate is indistinguishable from a valid one on every surface.**

This adds the half that belongs in go-trust, and stops there:

| Question | Answer here |
|---|---|
| Where do I look? | `CRLDistributionPoints`, `OCSPResponders`, `RPEntitlements.StatusReference()` |
| What does the answer mean? | `RevocationMode.Evaluate(state, subject) RevocationDecision` |
| How do I fetch it? | **Not here.** `StatusListChecker` / `CertRevocationChecker`, supplied by the caller |

Fetching stays with the caller, matching how key resolvers are already injected in this repo. go-trust gains no I/O.

## The distinction the types exist for

`RevocationUndetermined` is a separate state from `RevocationGood`, not a flavour of it. **An unreachable CRL is not evidence that a certificate is valid**, and collapsing the two is precisely how a fetch failure quietly becomes a pass.

So:

- `warn` (the sensible default) allows every state but populates `Reason` for anything other than good — a Registrar outage should not become our outage.
- `fail` rejects revoked **and** undetermined, because a deployment choosing that mode has said it would rather stop than proceed without an answer.
- `Allowed` and `Reason` are separate fields because "allowed, but you should know about this" is the common outcome under `warn`, and a caller reading only a bool would discard it.

## Two smaller decisions

- **An unrecognised mode is treated as `warn`, not `off`.** A configuration typo must not silently disable a security check.
- **Non-http(s) distribution points are dropped.** Returning an `ldap://` URL a caller cannot fetch only yields an undetermined result that reads as a fetch failure rather than an unsupported scheme.

A certificate with no fetchable distribution point therefore yields an empty list, which is undetermined — which is why these helpers return a list rather than a bool.

## Verification

- Full `go test ./...` green; `pkg/registry/rpcert` at **94.9%** coverage; lint 0 issues.
- `TestStatusReference_FromSandboxCertificate` runs the parser against the real German sandbox fixture and recovers `idx 9940` at the Registrar's live status-list URI.
- `TestNoRevocationEndpointsIsUndetermined` and `TestRevocationMode_UndeterminedIsNotAPass` pin the fetch-failure-is-not-a-pass property.

## Now exercisable end to end

`siros-wrpac-tool` has since gained `revoke` / `publish` / `serve`, and moves both mechanisms together — the WRPAC serial goes on the CRL *and* the WRPRC's status bit is set, since revoking one alone leaves the party usable through the other. So the checks a caller builds on this can be tested against material we control, not only against the sandbox.