### PR TITLE
fix: make the goxmldsig replace directive actually apply

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.26.5
 
 replace github.com/moov-io/signedxml v1.2.3 => github.com/sirosfoundation/signedxml v1.4.0-siros1
 
-replace github.com/russellhaering/goxmldsig v1.5.0 => github.com/sirosfoundation/goxmldsig v1.6.0-siros1
+replace github.com/russellhaering/goxmldsig => github.com/sirosfoundation/goxmldsig v1.6.1-siros1
 
 require (
 	github.com/SUNET/vc v0.7.0

--- a/go.sum
+++ b/go.sum
@@ -313,8 +313,6 @@ github.com/redis/go-redis/v9 v9.21.0 h1:FPBE4hhbAke+TLmcY3WkpbDffJEomdqPn3HYiqAt
 github.com/redis/go-redis/v9 v9.21.0/go.mod h1:v/M13XI1PVCDcm01VtPFOADfZtHf8YW3baQf57KlIkA=
 github.com/rogpeppe/go-internal v1.14.1 h1:UQB4HGPB6osV0SQTLymcB4TgvyWu6ZyliaW0tI/otEQ=
 github.com/rogpeppe/go-internal v1.14.1/go.mod h1:MaRKkUm5W0goXpeCfT7UZI6fk/L7L7so1lCWt35ZSgc=
-github.com/russellhaering/goxmldsig v1.6.0 h1:8fdWXEPh2k/NZNQBPFNoVfS3JmzS4ZprY/sAOpKQLks=
-github.com/russellhaering/goxmldsig v1.6.0/go.mod h1:TrnaquDcYxWXfJrOjeMBTX4mLBeYAqaHEyUeWPxZlBM=
 github.com/scylladb/go-set v1.0.3-0.20200225121959-cc7b2070d91e h1:7q6NSFZDeGfvvtIRwBrU/aegEYJYmvev0cHAwo17zZQ=
 github.com/scylladb/go-set v1.0.3-0.20200225121959-cc7b2070d91e/go.mod h1:DkpGd78rljTxKAnTDPFqXSGxvETQnJyuSOQwsHycqfs=
 github.com/segmentio/asm v1.2.1 h1:DTNbBqs57ioxAD4PrArqftgypG4/qNpXoJx8TVXxPR0=
@@ -332,6 +330,8 @@ github.com/sirosfoundation/go-cryptoutil/brainpool v0.2.0 h1:tLBZFdBAloNDwP2j87M
 github.com/sirosfoundation/go-cryptoutil/brainpool v0.2.0/go.mod h1:h5sFbD8z/TLv+MziA97+UOXwDEN3drSYheRM5X9yaBE=
 github.com/sirosfoundation/go-spocp v0.1.0 h1:fH/jrSHS8vc+KfAzJmq3fE9OH69ShRgL7G1ihb9FCPs=
 github.com/sirosfoundation/go-spocp v0.1.0/go.mod h1:a6WtxG5hnsUzcqUt5iHmSMvyX4PLUPMDFK7FLoDMSMs=
+github.com/sirosfoundation/goxmldsig v1.6.1-siros1 h1:iQadRZy/iwj0E/hXlfKrEDqA94Ey1ozIdLtATKGpGH8=
+github.com/sirosfoundation/goxmldsig v1.6.1-siros1/go.mod h1:tGmeKRnyDp6EcdMP5U6hJotJ++bdpwFNuExwyJGUUM4=
 github.com/sirosfoundation/signedxml v1.4.0-siros1 h1:+d+j6AQxu9CNylGkmPbUAUdEYny6gvXZxFnuvrPViHk=
 github.com/sirosfoundation/signedxml v1.4.0-siros1/go.mod h1:qXhLkLQ7B8fg9YSTqBmWSynY9tkkEx2QsIBjMeJTGcM=
 github.com/sirupsen/logrus v1.9.4 h1:TsZE7l11zFCLZnZ+teH4Umoq5BhEIfIzfRDZ1Uzql2w=


### PR DESCRIPTION
The `replace` for goxmldsig has been silently inert. We have been building against plain upstream, not the fork.

## The bug

```
replace github.com/russellhaering/goxmldsig v1.5.0 => github.com/sirosfoundation/goxmldsig v1.6.0-siros1
```

The left side pins **v1.5.0**, but the module graph selects **v1.6.0** — go-trust requires it directly, and only `moov-io/signedxml` still wants v1.5.0. A version-specific `replace` fires only when the *selected* version matches, so this one never applied:

```
$ go list -m ... github.com/russellhaering/goxmldsig
github.com/russellhaering/goxmldsig v1.6.0        # no "=>" — not replaced
```

The sibling `replace` for `moov-io/signedxml` **does** apply (its selected version does match the pin), so this was the only broken one.

## What we were silently giving up

Three commits the fork carries and upstream v1.6.0/v1.6.1 do not:

| | in upstream? |
|---|---|
| ECDSA **P1363 → DER** conversion for verification | no |
| `CryptoExtensions` for non-standard algorithms (brainpool et al.) | no |
| generic signer suitable for HSMs | no |

The first two are **reachable**: `pkg/registry/etsi/pivot.go` checks `tsl.Signed` / `tsl.Signer`, which routes through g119612's `pkg/dsig` into goxmldsig. So an ETSI trust list signed with ECDSA in P1363 encoding, or with a non-standard curve, would fail to verify.

**Fail-closed, not a bypass** — a bad signature was never accepted; a good one could be rejected. Worth stating precisely.

The pin also named `v1.6.0-siros1`, which is only the *first* of those three commits, so even had it applied it would have delivered a third of the intent.

## The fix

Drop the version from the left side so it applies to whichever version is selected:

```
replace github.com/russellhaering/goxmldsig => github.com/sirosfoundation/goxmldsig v1.6.1-siros1
```

The fork previously branched from v1.6.0, so pointing at it would have traded upstream's v1.6.1 for our patches. It is now **rebased onto v1.6.1** and tagged [`v1.6.1-siros1`](https://github.com/sirosfoundation/goxmldsig/releases/tag/v1.6.1-siros1) — all four siros commits replayed, only `go.mod`/`go.sum` conflicted, the code applied clean. Fork tests pass, `TestValidateECDSA_P1363` included.

`go 1.26` in the fork comes from `go-cryptoutil`, which `CryptoExtensions` requires; go-trust and vc are both already on 1.26.5.

## Not a vulnerability fix

To head off the obvious question: **GO-2026-4753** (loop-variable signature bypass in goxmldsig) was fixed in upstream **v1.6.0**, and go-trust was already on v1.6.0. We were never exposed. This is about the fork's *added* functionality, not the CVE.

## Verification

- `go list -m` now shows the `=>`, confirming the replace applies.
- `go build ./...` and the **full** `go test ./...` pass.
- Diff is `go.mod`/`go.sum` only.

## Follow-up

vc has **no `replace` at all** and is on upstream v1.6.1, so it is missing the same three patches. Repointing it is a separate PR against SUNET/vc, and needs `go mod vendor` since vc vendors.

The fork's `main` still sits on the old v1.6.0 base; the rebased history is on branch `siros-on-v1.6.1`. Old tags `v1.6.0-siros1..3` still resolve, so nothing existing breaks — but `main` is worth repointing so the next person does not redo this.