### PR TITLE
fix(rpcert): compare the WRPRC typ header exactly

### DIFF
--- a/pkg/registry/rpcert/jwt_validator.go
+++ b/pkg/registry/rpcert/jwt_validator.go
@@ -95,8 +95,12 @@ func (v *JWTRegistrationCertValidator) Validate(_ context.Context, certData []by
 		return nil, fmt.Errorf("wrprc: parsing JWT header: %w", err)
 	}
 
-	// Validate typ = "rc-wrp+jwt" (GEN-5.2.2-01)
-	if !strings.EqualFold(header.Typ, WRPRCTyp) {
+	// Validate typ = "rc-wrp+jwt" (GEN-5.2.2-01), compared exactly.
+	//
+	// A JWT typ is nominally a media type and so case-insensitive, but
+	// Registrars emit the lowercase form and callers compare it exactly, so
+	// the latitude buys nothing and costs a second rule.
+	if header.Typ != WRPRCTyp {
 		return nil, fmt.Errorf("wrprc: unexpected JWT typ %q, want %q", header.Typ, WRPRCTyp)
 	}
 

--- a/pkg/registry/rpcert/jwt_validator_test.go
+++ b/pkg/registry/rpcert/jwt_validator_test.go
@@ -472,3 +472,28 @@ func TestWRPRCPayload_LegalNameFieldIsCanonical(t *testing.T) {
 	assert.Empty(t, subTypo.LegalName, "spec typo 'leagal_name' is not parsed — use canonical 'legal_name'")
 	_ = fmt.Sprintf("TODO: file a corrigendum to TS 119 475 v1.1.1 Annex C: 'leagal_name' should be 'legal_name'")
 }
+
+// TestJWTValidator_TypIsComparedExactly pins the strict reading. A JWT typ
+// is nominally a media type and so case-insensitive, which makes this the
+// kind of check that gets softened back by a well-meaning edit.
+func TestJWTValidator_TypIsComparedExactly(t *testing.T) {
+	cert, key, pool := generateWRPRCProviderCert(t)
+	token := buildWRPRCJWT(t, annexCPayload(), cert, key)
+
+	// Re-encode the header with a case variant of the media type.
+	parts := strings.Split(token, ".")
+	require.Len(t, parts, 3)
+	headerBytes, err := base64.RawURLEncoding.DecodeString(parts[0])
+	require.NoError(t, err)
+	var header map[string]any
+	require.NoError(t, json.Unmarshal(headerBytes, &header))
+	header["typ"] = strings.ToUpper(WRPRCTyp)
+	reencoded, err := json.Marshal(header)
+	require.NoError(t, err)
+	parts[0] = base64.RawURLEncoding.EncodeToString(reencoded)
+
+	v := NewJWTRegistrationCertValidator(pool)
+	_, err = v.Validate(context.Background(), []byte(strings.Join(parts, ".")))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unexpected JWT typ")
+}


### PR DESCRIPTION
Aligns `typ` comparison with how callers do it.

## Why

`JWTRegistrationCertValidator` compares the media type with `strings.EqualFold`. A JWT `typ` is nominally a media type, and media type names are case-insensitive per RFC 2045 §5.1 — so the lenient form is defensible in isolation.

It stops being defensible once you look at the callers. SUNET/vc compares `typ` exactly in `pkg/trust/wallet_attestation.go`, and its registration-certificate loader now does too ([vc#614](https://github.com/SUNET/vc/pull/614)). Registrars emit the lowercase form, so the latitude admits nothing real while costing a second rule for reviewers to track.

## Scope

Only the `typ` comparison. `pkg/registry/clientid.go:101` also uses `EqualFold`, and correctly — it compares a **hex digest**, where case-insensitivity is the point, not a media type. Left alone.

## Verification

- `go build ./...` clean; `pkg/registry/rpcert` green; lint 0 issues.
- `TestJWTValidator_TypIsComparedExactly` re-encodes a valid token's header with an uppercase media type and expects rejection.
- I checked the test **fails** against the previous `EqualFold` behaviour (`An error is expected but got nil`) rather than passing for an unrelated reason. The `typ` check runs before chain handling, so the assertion is reached on its own merits.

## Note

`JWTRegistrationCertValidator` is deprecated as of v0.20.0 and returns `StatusUnknown`, so this is consistency housekeeping rather than a fix to a load-bearing path — worth doing so the deprecated validator isn't the one place with a different rule.