### PR TITLE
Wire CryptoExt into WhitelistRegistry for brainpool-curve support

### DIFF
--- a/cmd/gt/main.go
+++ b/cmd/gt/main.go
@@ -295,9 +295,12 @@ func main() {
 			logger.Info("Configuring whitelist registry from file",
 				logging.F("path", *whitelistFile),
 				logging.F("watch", *whitelistWatch))
+			cryptoExt := gocryptoutil.New()
+			brainpool.Register(cryptoExt)
 			whitelistReg, err := static.NewWhitelistRegistryFromFile(*whitelistFile, *whitelistWatch,
 				static.WithWhitelistName("whitelist"),
-				static.WithWhitelistDescription("URL whitelist from "+*whitelistFile))
+				static.WithWhitelistDescription("URL whitelist from "+*whitelistFile),
+				static.WithWhitelistCryptoExt(cryptoExt))
 			if err != nil {
 				logger.Fatal("Failed to create whitelist registry",
 					logging.F("error", err.Error()))
@@ -463,6 +466,7 @@ func configureRegistriesFromConfig(cfg *config.Config, registryMgr *registry.Reg
 				wlCfg.WatchFile,
 				static.WithWhitelistName(name),
 				static.WithWhitelistDescription(desc),
+				static.WithWhitelistCryptoExt(cryptoExt),
 			)
 			if err != nil {
 				logger.Fatal("Failed to create whitelist registry from config file",
@@ -474,6 +478,7 @@ func configureRegistriesFromConfig(cfg *config.Config, registryMgr *registry.Reg
 			whitelistReg = static.NewWhitelistRegistry(
 				static.WithWhitelistName(name),
 				static.WithWhitelistDescription(desc),
+				static.WithWhitelistCryptoExt(cryptoExt),
 				static.WithWhitelistConfig(static.WhitelistConfig{
 					Lists:                  wlCfg.Lists,
 					Actions:                wlCfg.Actions,

--- a/pkg/registry/static/whitelist.go
+++ b/pkg/registry/static/whitelist.go
@@ -20,6 +20,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/sirosfoundation/g119612/pkg/utils/x509util"
+	gocryptoutil "github.com/sirosfoundation/go-cryptoutil"
 	"github.com/sirosfoundation/go-trust/pkg/authzen"
 	"github.com/sirosfoundation/go-trust/pkg/registry"
 	"github.com/sirosfoundation/go-trust/pkg/resilience"
@@ -85,6 +86,13 @@ type WhitelistRegistry struct {
 	systemCertPoolOnce sync.Once
 	systemCertPool     *x509.CertPool
 	systemCertPoolErr  error
+
+	// cryptoExt provides curve support beyond Go's stdlib crypto/x509 (e.g.
+	// brainpool, used by several real-world ISO 18013-5 reader-CA roots) for
+	// parsing AdditionalTrustedRoots. Nil falls back to stdlib parsing only,
+	// same as every other registry's use of this type (see
+	// pkg/registry/cryptoext.go's ParseCertificatesPEM).
+	cryptoExt *gocryptoutil.Extensions
 }
 
 // WhitelistConfig holds the whitelist configuration.
@@ -252,6 +260,18 @@ func WithHTTPClient(client *http.Client) WhitelistOption {
 func WithRefreshInterval(interval time.Duration) WhitelistOption {
 	return func(r *WhitelistRegistry) {
 		r.refreshInterval = interval
+	}
+}
+
+// WithWhitelistCryptoExt sets curve support beyond stdlib crypto/x509 (e.g.
+// brainpool) for parsing AdditionalTrustedRoots PEMs. Without this, a root
+// using a curve stdlib doesn't recognize (confirmed live for a real ISO
+// 18013-5 reader-CA root using brainpoolP256r1) fails the whole registry's
+// CA pool construction, denying every whitelisted entity, not just the one
+// with the unsupported root.
+func WithWhitelistCryptoExt(ext *gocryptoutil.Extensions) WhitelistOption {
+	return func(r *WhitelistRegistry) {
+		r.cryptoExt = ext
 	}
 }
 
@@ -681,9 +701,20 @@ func (r *WhitelistRegistry) loadSystemCertPool() (*x509.CertPool, error) {
 		}
 		if r.systemCertPoolErr == nil {
 			for i, pemCert := range r.config.AdditionalTrustedRoots {
-				if !r.systemCertPool.AppendCertsFromPEM([]byte(pemCert)) {
+				// Uses registry.ParseCertificatesPEM (r.cryptoExt-aware,
+				// same helper mdocrical/vical/etc. use) rather than
+				// x509.CertPool.AppendCertsFromPEM directly - the stdlib
+				// method can't parse curves it doesn't recognize (e.g.
+				// brainpool, a real ISO 18013-5 reader-CA root curve) and
+				// silently drops the whole PEM rather than reporting which
+				// certificate failed.
+				certs, err := registry.ParseCertificatesPEM([]byte(pemCert), r.cryptoExt)
+				if err != nil || len(certs) == 0 {
 					r.systemCertPoolErr = fmt.Errorf("additional_trusted_roots[%d]: failed to parse PEM certificate", i)
 					return
+				}
+				for _, cert := range certs {
+					r.systemCertPool.AddCert(cert)
 				}
 			}
 		}

--- a/pkg/registry/static/whitelist_test.go
+++ b/pkg/registry/static/whitelist_test.go
@@ -24,6 +24,8 @@ import (
 	"testing"
 	"time"
 
+	gocryptoutil "github.com/sirosfoundation/go-cryptoutil"
+	"github.com/sirosfoundation/go-cryptoutil/brainpool"
 	"github.com/sirosfoundation/go-trust/pkg/authzen"
 )
 
@@ -2687,6 +2689,55 @@ func TestWhitelistRegistry_TrustX509ViaSystemCA(t *testing.T) {
 		}
 	})
 
+	t.Run("additional_trusted_root_with_brainpool_curve_fails_without_cryptoext", func(t *testing.T) {
+		// Real-world artifact, not synthesized: the Geneva 2026 interop
+		// event's actual reader-CA root for its reference OpenID4VP
+		// verifier (geneva2026.mdoc.online), which uses brainpoolP256r1 -
+		// a real ISO 18013-5/eIDAS-ecosystem curve stdlib crypto/x509
+		// doesn't parse. Confirmed live 2026-08-31: adding this root
+		// without CryptoExt wired up denied every other whitelisted
+		// verifier too (verifier.multipaz.org included), not just Geneva -
+		// AppendCertsFromPEM fails the whole pool on one bad cert.
+		reg := NewWhitelistRegistry(WithWhitelistConfig(WhitelistConfig{
+			Lists:                  map[string][]string{"verifiers": {"x509_san_dns:geneva2026.mdoc.online"}},
+			Actions:                map[string]string{"credential-verifier": "verifiers"},
+			TrustX509ViaSystemCA:   true,
+			AdditionalTrustedRoots: []string{geneva2026VerifierReaderCABrainpoolPEM},
+		}))
+		_ = reg.Refresh(context.Background())
+
+		_, err := reg.loadSystemCertPool()
+		if err == nil {
+			t.Fatal("expected loadSystemCertPool to fail without CryptoExt: stdlib crypto/x509 cannot parse a brainpoolP256r1 cert")
+		}
+		if !strings.Contains(err.Error(), "additional_trusted_roots") {
+			t.Errorf("expected error to name additional_trusted_roots as the cause, got: %v", err)
+		}
+	})
+
+	t.Run("additional_trusted_root_with_brainpool_curve_succeeds_with_cryptoext", func(t *testing.T) {
+		cryptoExt := gocryptoutil.New()
+		brainpool.Register(cryptoExt)
+		reg := NewWhitelistRegistry(
+			WithWhitelistConfig(WhitelistConfig{
+				Lists:                  map[string][]string{"verifiers": {"x509_san_dns:geneva2026.mdoc.online"}},
+				Actions:                map[string]string{"credential-verifier": "verifiers"},
+				TrustX509ViaSystemCA:   true,
+				AdditionalTrustedRoots: []string{geneva2026VerifierReaderCABrainpoolPEM},
+			}),
+			WithWhitelistCryptoExt(cryptoExt),
+		)
+		_ = reg.Refresh(context.Background())
+
+		pool, err := reg.loadSystemCertPool()
+		if err != nil {
+			t.Fatalf("expected the brainpool root to load successfully with CryptoExt wired up, got: %v", err)
+		}
+		if pool == nil {
+			t.Fatal("expected a non-nil cert pool")
+		}
+	})
+
 	t.Run("malformed_additional_trusted_root_denies_with_pool_error", func(t *testing.T) {
 		reg := NewWhitelistRegistry(WithWhitelistConfig(WhitelistConfig{
 			Lists:                  map[string][]string{"verifiers": {"x509_san_dns:verifier.example.com"}},
@@ -2861,6 +2912,33 @@ LWZvdW5kYXRpb24tbGFicy9pZGVudGl0eS1jcmVkZW50aWFsL2NybDAdBgNVHQ4EFgQUsYQ5hS9K
 buq/6mKtvFHQgfdIhykwHwYDVR0jBBgwFoAUsYQ5hS9Kbuq/6mKtvFHQgfdIhykwCgYIKoZIzj0E
 AwMDaAAwZQIwKh87sK/cMbzuc9PFvyiSRedr2RoP0fuFK0X8ddOpi6hEMOapHL/Gs/QByROCpDpk
 AjEA2yLSJDZEu1GI8uChAsDBZwJPtv5KHUjq1Vpok69SNn+zzb1mNpqmiey+tchPBjZm
+-----END CERTIFICATE-----
+`
+
+// geneva2026VerifierReaderCABrainpoolPEM is the Geneva 2026 interop event's
+// actual reader-CA root for its reference OpenID4VP verifier
+// (geneva2026.mdoc.online), extracted 2026-08-31 from the event's own
+// distributed certificate bundle ("Reader CA Certificate Default Relying
+// Party Geneva 2026.cer"). Self-signed, subjectAltName URI
+// https://geneva2026.mdoc.online, using the brainpoolP256r1 curve - see
+// additional_trusted_root_with_brainpool_curve_fails_without_cryptoext.
+const geneva2026VerifierReaderCABrainpoolPEM = `-----BEGIN CERTIFICATE-----
+MIIC+DCCAp+gAwIBAgIQD+aaWtJUM91mcNCqtGQIbjAKBggqhkjOPQQDAjCBgjFA
+MD4GA1UEAxM3UmVhZGVyIENBIENlcnRpZmljYXRlIERlZmF1bHQgUmVseWluZyBQ
+YXJ0eSBHZW5ldmEgMjAyNjELMAkGA1UEBhMCQ0gxETAPBgNVBAoTCEFwdGl0dWRl
+MR4wHAYDVQQLExVDZXJ0aWZpY2F0ZSBBdXRob3JpdHkwHhcNMjYwNjExMDgzODEz
+WhcNNDYwNjExMDgzODEzWjCBgjFAMD4GA1UEAxM3UmVhZGVyIENBIENlcnRpZmlj
+YXRlIERlZmF1bHQgUmVseWluZyBQYXJ0eSBHZW5ldmEgMjAyNjELMAkGA1UEBhMC
+Q0gxETAPBgNVBAoTCEFwdGl0dWRlMR4wHAYDVQQLExVDZXJ0aWZpY2F0ZSBBdXRo
+b3JpdHkwWjAUBgcqhkjOPQIBBgkrJAMDAggBAQcDQgAEaDG8yWWWSdNMJWwOOcQG
+VSaIC1HQHMqUVkMwchxawqxqwgEi3uIXv9cKNj3EAVyxyBwzJ9Vy0G4iEHeYhp2c
+ZqOB8zCB8DAdBgNVHQ4EFgQUl2gUHoVJ5fazwTypwN5pdXqepdUwDgYDVR0PAQH/
+BAQDAgEGMFYGA1UdEgRPME2GH2h0dHBzOi8vZ2VuZXZhMjAyNi5tZG9jLm9ubGlu
+ZS+BKnJlYWRlcmNhY2VydGlmaWNhdGVAZ2VuZXZhMjAyNi5tZG9jLm9ubGluZTAP
+BgNVHRMBAf8EBTADAQH/MFYGA1UdHwRPME0wS6BJoEeGRWh0dHBzOi8vZ2VuZXZh
+MjAyNi5tZG9jLm9ubGluZS9DZXJ0aWZpY2F0ZXMvMS9SZWFkZXJDYUNlcnRpZmlj
+YXRlLmNybDAKBggqhkjOPQQDAgNHADBEAiA8kN16YtTtyKmrDXV/18cVWg6vdNGA
+wmo13EG6SYju2wIgIsh0Ca9Tm7FsnKmi9QpX84L8TE3rLbyhPXJilIEYV8Y=
 -----END CERTIFICATE-----
 `
 


### PR DESCRIPTION
## Summary
- `additional_trusted_roots` was parsed via `x509.CertPool.AppendCertsFromPEM` directly, which can't handle curves stdlib `crypto/x509` doesn't recognize (e.g. brainpoolP256r1, used by real ISO 18013-5/eIDAS reader-CA roots) — confirmed live against the Geneva 2026 interop event's OpenID4VP verifier root.
- Worse, one such root failed the *entire* registry's CA pool construction, denying every other whitelisted verifier too, not just the one with the unsupported root.
- `WhitelistRegistry` now accepts a `CryptoExt` (`WithWhitelistCryptoExt`), using the same `registry.ParseCertificatesPEM` helper `mdocrical`/`vical`/etc. already use, and both CLI construction paths in `cmd/gt/main.go` wire it up.

## Test plan
- [x] `go test ./pkg/registry/static/...` — full suite green, including new regression tests using the real Geneva root, both with and without `CryptoExt` wired
- [x] `go build ./...` / `go vet ./...` clean
- [x] Confirmed live: this exact root previously produced `system CA pool unavailable: additional_trusted_roots[N]: failed to parse PEM certificate` and denied trust for `verifier.multipaz.org` too

🤖 Generated with [Claude Code](https://claude.com/claude-code)