### PR TITLE
Carry every configured ETSI field into the TSL registry

### DIFF
--- a/cmd/gt/main.go
+++ b/cmd/gt/main.go
@@ -414,23 +414,7 @@ func configureRegistriesFromConfig(cfg *config.Config, registryMgr *registry.Reg
 		logger.Info("Configuring ETSI TSL registry from config file")
 		etsiCfg := cfg.Registries.ETSI
 
-		tslConfig := etsi.TSLConfig{
-			Name:             etsiCfg.Name,
-			Description:      etsiCfg.Description,
-			CryptoExt:        cryptoExt,
-			CertBundle:       etsiCfg.CertBundle,
-			TSLFiles:         etsiCfg.TSLFiles,
-			LOTLSignerBundle: etsiCfg.LOTLSignerBundle,
-			RequireSignature: etsiCfg.RequireSignature,
-			FollowPivots:     etsiCfg.FollowPivots,
-		}
-
-		if tslConfig.Name == "" {
-			tslConfig.Name = "ETSI-TSL"
-		}
-		if tslConfig.Description == "" {
-			tslConfig.Description = "ETSI TS 119612 Trust Status List Registry"
-		}
+		tslConfig := etsiTSLConfig(etsiCfg, cryptoExt, logger)
 
 		tslRegistry, err := etsi.NewTSLRegistry(tslConfig)
 		if err != nil {
@@ -1054,4 +1038,49 @@ func trimSpace(s string) string {
 
 func isSpace(r rune) bool {
 	return r == ' ' || r == '\t' || r == '\n' || r == '\r'
+}
+
+// etsiTSLConfig maps the ETSI registry's configuration onto the registry's own
+// config struct.
+//
+// Extracted so the mapping can be tested. Every field here was once dropped on
+// the floor: TSLURLs, FollowRefs, MaxRefDepth, UserAgent, AllowNetworkAccess
+// and FetchTimeout were all absent, so configuring an ETSI registry from a file
+// with tsl_urls left it with nothing to load and the process exited with
+// "no trust data loaded" - a message that points at the configuration rather
+// than at the code that ignored it.
+func etsiTSLConfig(etsiCfg *config.ETSIRegistryConfig, cryptoExt *gocryptoutil.Extensions, logger logging.Logger) etsi.TSLConfig {
+	tslConfig := etsi.TSLConfig{
+		Name:               etsiCfg.Name,
+		Description:        etsiCfg.Description,
+		CryptoExt:          cryptoExt,
+		CertBundle:         etsiCfg.CertBundle,
+		TSLFiles:           etsiCfg.TSLFiles,
+		TSLURLs:            etsiCfg.TSLURLs,
+		FollowRefs:         etsiCfg.FollowRefs,
+		MaxRefDepth:        etsiCfg.MaxRefDepth,
+		UserAgent:          etsiCfg.UserAgent,
+		AllowNetworkAccess: etsiCfg.AllowNetworkAccess,
+		LOTLSignerBundle:   etsiCfg.LOTLSignerBundle,
+		RequireSignature:   etsiCfg.RequireSignature,
+		FollowPivots:       etsiCfg.FollowPivots,
+	}
+
+	if etsiCfg.FetchTimeout != "" {
+		if timeout, err := time.ParseDuration(etsiCfg.FetchTimeout); err == nil {
+			tslConfig.FetchTimeout = timeout
+		} else if logger != nil {
+			logger.Warn("Invalid fetch_timeout for etsi registry, using default",
+				logging.F("value", etsiCfg.FetchTimeout),
+				logging.F("error", err.Error()))
+		}
+	}
+
+	if tslConfig.Name == "" {
+		tslConfig.Name = "ETSI-TSL"
+	}
+	if tslConfig.Description == "" {
+		tslConfig.Description = "ETSI TS 119612 Trust Status List Registry"
+	}
+	return tslConfig
 }


### PR DESCRIPTION
## The bug

Configuring the ETSI registry **from a config file** built `etsi.TSLConfig` without copying `TSLURLs` across — nor `FollowRefs`, `MaxRefDepth`, `UserAgent`, `AllowNetworkAccess` or `FetchTimeout`.

A config file with `tsl_urls` therefore produced a registry with nothing to load, and the process exited with:

```
no trust data loaded - configure CertBundle, TSLFiles, or TSLURLs
```

...while the operator was looking at a file that plainly configures `TSLURLs`. The message points at the configuration rather than at the code that ignored it, so the natural reaction is to doubt the key name or the URL. The `lote` registry's config path has no such gap, which makes the ETSI one look like the operator's mistake.

Only `tsl_files` worked, and only by accident of being one of the fields that *was* mapped.

## Why nothing caught it

A dropped field does not produce a wrong value, it produces the **zero** value — an empty slice, a false bool, a zero duration. Every one of those is a plausible default, so nothing downstream looks wrong until the registry has no trust data at all.

The mapping is now its own function so it can be tested, and the test asserts **every** field individually rather than the one that happened to be noticed. Reverting the fix fails it on all five:

```
TSLURLs = [], want [https://registrar.example.org/tsl.xml]
FollowRefs was not carried across
MaxRefDepth = 0, want 4
AllowNetworkAccess was not carried across
UserAgent = "", want "test-agent/1.0"
```

`FetchTimeout` follows the LoTE registry's existing pattern: parse the duration, warn and leave the default on a bad value. A test pins that an unparseable value leaves the zero so the registry applies *its* default, rather than propagating "no timeout".

## Verified against a real deployment

An ETSI registry configured with `tsl_urls` now fetches and parses over HTTP, where before it refused to start:

```
Configuring ETSI TSL registry from config file
g119612: Parsed TSL from http://wrpac-registrar:8080/tsl.xml with 2 trust service providers
ETSI TSL registry registered from config
```

The list is one published by `siros-wrpac-tool`. `go test ./cmd/... ./pkg/config/... ./pkg/registry/etsi/...` and `golangci-lint` are clean.

Found while wiring sirosid-dev to a TSL; that stack currently works around this with `tsl_files` and a bind mount, which can go once this is released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DWj5aAxqWjEm5ESCX4P1hk